### PR TITLE
Fixed some spelling errors, iOS firing arcs, and Borg Cube maneuvers card

### DIFF
--- a/Utopia-Master/src/css/common/utopia-card.css
+++ b/Utopia-Master/src/css/common/utopia-card.css
@@ -40,6 +40,10 @@
 	height: 4em;
 }
 
+.card-image-large {
+	height: 2em;
+}
+
 .card-corner-top-left {
 	background: #a8b6bf;
 	height: 1.6em;
@@ -804,6 +808,13 @@
 	margin-top: 0.2em;
 }
 
+.card-border-right-tall {
+	background: #a8b6bf;
+	width: 0.8em;
+	height: 8.35em;
+	margin-top: 0.2em;
+}
+
 .card-faction-federation {
 	background-image: url("../img/faction-federation.png");
 }
@@ -967,6 +978,14 @@
 	background: #a8b6bf;
 	width: 0.8em;
 	height: 4.11em;
+	margin-top: 0.2em;
+	clear: left;
+}
+
+.card-border-left-tall {
+	background: #a8b6bf;
+	width: 0.8em;
+	height: 8.31em;
 	margin-top: 0.2em;
 	clear: left;
 }
@@ -1306,6 +1325,15 @@
 	color: white;
 	margin: 0.2em 1em 0em 1em;
 	height: 7em;
+	position: relative;
+	top: -0.35em;
+	padding: 0 0.3em;
+}
+
+.card-class-maneuvers-tall {
+	color: white;
+	margin: 0.2em 1em 0em 1em;
+	height: 9em;
 	position: relative;
 	top: -0.35em;
 	padding: 0 0.3em;

--- a/Utopia-Master/src/css/common/utopia-class-arcs.css
+++ b/Utopia-Master/src/css/common/utopia-class-arcs.css
@@ -1,16 +1,31 @@
+/**
+ * Style definitions of the ship tile and firing arcs.
+ */
+
+/**
+ * Parent division style. A square that holds the other tile elements.
+ */
 .card-shipclass-arcs {
+	display: inline-block;
+	box-sizing: border-box;
 	position: absolute;
 	width: 4.5em;
 	height: 5em;
 	border: 1px solid #333;
 	transform: rotate(-15deg);
+	-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0% 100%);
+	clip-path: polygon(0 0, 100% 0, 100% 100%, 0% 100%);
 	left: 6em;
-	z-index: 1000;
+	z-index: 100;
 	overflow: hidden;
 	background: #111;
 	box-shadow: 0 0 0.4em #333;
 }
 
+/**
+ * 90 deg forward firing arc. A filled in square that is rotated 45 degrees to
+ * provide a triangle that is then clipped to within the parent box.
+ */
 .arc-fore-90 {
 	position: absolute;
 	top: -3.8em;
@@ -20,8 +35,28 @@
 	border: 0.1em solid #aaa;
 	background: #777;
 	transform: rotate(45deg);
+	clip: inherit;
 }
 
+/**
+ * 90 deg rear firing arc. An empty square that has a dashed border and is
+ * rotated 45 degrees to provide a triangle that is then clipped to within the
+ * parent box.
+ */
+.arc-rear-90 {
+	position: absolute;
+	top: 3.7em;
+	left: -0.275em;
+	width: 5em;
+	height: 5em;
+	border: 0.1em dashed #aaa;
+	transform: rotate(45deg);
+}
+
+/**
+ * 180 deg forward firing arc. A filled square that is rotated 45 degrees to
+ * provide a triangle that is then clipped to within the parent box.
+ */
 .arc-fore-180 {
 	position: absolute;
 	top: 0;
@@ -32,28 +67,9 @@
 	border-bottom: 0.1em solid #aaa;
 }
 
-.arc-second-45 {
-	display: block;
-	-webkit-box-sizing: content-box;
-	-moz-box-sizing: content-box;
-	box-sizing: content-box;
-	float: none;
-	z-index: auto;
-	width: 5em;
-	height: 5em;
-	position: absolute;
-	cursor: default;
-	opacity: 1;
-	top: -3.8em;
-	left: -0.275em;
-	overflow: visible;
-	border: 0.1em dashed rgb(170,170,170);
-	-webkit-transform: rotateZ(67.5deg)   skewX(45deg);
-	transform: rotateZ(67.5deg)   skewX(45deg);
-	-webkit-transform-origin: 99% 9% 0;
-	transform-origin: 99% 9% 0;
-}
-
+/**
+ * Hole in the center of the tile.
+ */
 .arc-hole {
 	position: absolute;
 	left: 1.5em;
@@ -65,16 +81,9 @@
 	border: 1px solid #333;
 }
 
-.arc-rear-90 {
-	position: absolute;
-	top: 3.7em;
-	left: -0.275em;
-	width: 5em;
-	height: 5em;
-	border: 0.1em dashed #aaa;
-	transform: rotate(45deg);
-}
-
+/**
+ * Style for the ship name on the arc tile.
+ */
 .arc-name {
 	position: absolute;
 	left: 0;
@@ -86,6 +95,9 @@
 	text-transform: uppercase;
 }
 
+/**
+ * Style for group of the ship stats printed on the tile.
+ */
 .arc-stats {
 	position: absolute;
 	top: 0.25em;
@@ -93,6 +105,9 @@
 	height: 100%;
 }
 
+/**
+ * Style for the individual stats within the arc-stats group.
+ */
 .arc-stat {
 	border-width: .1em;
 	border-style: solid;
@@ -103,6 +118,9 @@
 	margin-top: 0.3em;
 }
 
+/**
+ * Style for the actions group printed on the tile.
+ */
 .arc-actions {
 	position: absolute;
 	top: 0.25em;
@@ -111,10 +129,16 @@
 	color: green;
 }
 
+/**
+ * Style for the individaul actions in the actions group.
+ */
 .arc-actions .fs {
 	font-size: 0.5em;
 }
 
+/**
+ * Start of colors for the arcs for individual factions.
+ */
 .arc-faction-mirror-universe .arc {
 	border-color: #bb963c;
 }

--- a/Utopia-Master/src/data/admirals.js
+++ b/Utopia-Master/src/data/admirals.js
@@ -103,7 +103,7 @@ module.exports = [{
 	set: ["71526"],
 	name: "Maxwell Forrest",
 	unique: true,
-	text: "<b>FLEET ACTION:</b> Perform and additional 1 Maneuver (straight, bank or turn).",
+	text: "<b>FLEET ACTION:</b> Perform an additional 1 Maneuver (straight, bank or turn).",
 	factions: ["federation"],
 	cost: 3,
 	skill: 1,

--- a/Utopia-Master/src/data/captains.js
+++ b/Utopia-Master/src/data/captains.js
@@ -2761,7 +2761,7 @@ module.exports = [{
 	set: ["71786", "71810"],
 	name: "Benjamin Sisko",
 	unique: true,
-	text: "During the Roll Defense Dice step of the Combat Phase, if your ship is in the forward firing arc of 2 or more ships, roll 1 extra defense die against all attacks from those ships. Each time your ship receives a Damage Card (normal or critical), incrase your Captain Skill by +1 for the rest of the game (max +2). The bonus Skill remains even if the damage is later repaired.",
+	text: "During the Roll Defense Dice step of the Combat Phase, if your ship is in the forward firing arc of 2 or more ships, roll 1 extra defense die against all attacks from those ships. Each time your ship receives a Damage Card (normal or critical), increase your Captain Skill by +1 for the rest of the game (max +2). The bonus Skill remains even if the damage is later repaired.",
 	factions: ["federation"],
 	cost: 4,
 	skill: 7,

--- a/Utopia-Master/src/data/ship_classes.js
+++ b/Utopia-Master/src/data/ship_classes.js
@@ -1534,7 +1534,7 @@ module.exports = [{
 	id: "bajoran_solar_sailor",
 	name: "BAJORAN SOLAR SAILOR",
 	frontArc: "90",
-	rearArc: "0",
+	rearArc: "",
 	maneuvers: {
 		1: {
 			straight: "green",

--- a/Utopia-Master/src/data/ships.js
+++ b/Utopia-Master/src/data/ships.js
@@ -15,7 +15,7 @@ module.exports = [{
 	unique: true,
 	factions: ["dominion"],
 	squadron: false
-},{
+}, {
 	type: "ship",
 	id: "gress'sril_73031",
 	set: ["73031"],
@@ -140,7 +140,7 @@ module.exports = [{
 		fleet: {}
 	},
 	squadron: false
-},  {
+}, {
 	type: "ship",
 	id: "goss_shuttle_75003",
 	set: ["75003"],
@@ -160,7 +160,7 @@ module.exports = [{
 }, {
 	type: "ship",
 	id: "ferengi_starship_75003",
-	set: ["75003","72013"],
+	set: ["75003", "72013"],
 	name: "Ferengi Starship",
 	class: "Ferengi Shuttle",
 	actions: ["evade", "scan"],
@@ -193,7 +193,7 @@ module.exports = [{
 		ship: {},
 		fleet: {}
 	},
-	unique:true,
+	unique: true,
 	squadron: false
 }, {
 	type: "ship",
@@ -354,7 +354,7 @@ module.exports = [{
 	unique: true,
 	factions: ["dominion"],
 	squadron: false
-},{
+}, {
 	type: "ship",
 	id: "jemhadar_attack_ship_75002",
 	set: ["75002", "73032", "71271", "3rd_wing_attack_ship"],
@@ -647,7 +647,7 @@ module.exports = [{
 }, {
 	type: "ship",
 	id: "vorcha_class_2017core",
-	set: ["2017core","71120", "72241", "72280p"],
+	set: ["2017core", "71120", "72241", "72280p"],
 	name: "Klingon Starship",
 	class: "Vor'cha Class",
 	actions: ["evade", "target-lock", "cloak", "sensor-echo"],
@@ -748,7 +748,7 @@ module.exports = [{
 }, {
 	type: "ship",
 	id: "dominion_starship_dreadnought_72013wp",
-	set: ["72013wp","71212"],
+	set: ["72013wp", "71212"],
 	name: "Dominion Starship",
 	class: "Cardassian ATR-4107",
 	actions: ["evade", "target-lock", "scan"],
@@ -786,7 +786,7 @@ module.exports = [{
 }, {
 	type: "ship",
 	id: "ship_71448",
-	set: ["72012wp","71448"],
+	set: ["72012wp", "71448"],
 	name: "Klingon Starship",
 	class: "Raptor Class",
 	actions: ["evade", "target-lock", "scan"],
@@ -4477,7 +4477,7 @@ module.exports = [{
 		fleet: {}
 	},
 	squadron: false
-},  {
+}, {
 	type: "ship",
 	id: "fina_prime_71534",
 	set: ["71534"],
@@ -4813,7 +4813,7 @@ module.exports = [{
 		fleet: {}
 	},
 	squadron: false
-},  {
+}, {
 	type: "ship",
 	id: "i_k_s_pagh_71996",
 	set: ["71996"],
@@ -5712,7 +5712,7 @@ module.exports = [{
 	unique: true,
 	factions: ["federation"],
 	squadron: false
-},  {
+}, {
 	type: "ship",
 	id: "quark_s_treasure_72013",
 	set: ["72013"],

--- a/Utopia-Master/src/data/upgrades.js
+++ b/Utopia-Master/src/data/upgrades.js
@@ -1838,7 +1838,7 @@ module.exports = [{
 	cost: 5,
 	attack: 5,
 	range: "2 - 3",
-	text: "<b>ATTACK: (Target Lock)</b> Spend your target lock and place 3 Time Tokens on this card to perform this attack. You may convert 1 of your [battlestations] results into 1 [crit] result. You may fire this weapon form your forward or rear firing arcs.",
+	text: "<b>ATTACK: (Target Lock)</b> Spend your target lock and place 3 Time Tokens on this card to perform this attack. You may convert 1 of your [battlestations] results into 1 [crit] result. You may fire this weapon from your forward or rear firing arcs.",
 	unique: false,
 	factions: ["federation"]
 }, {
@@ -2499,7 +2499,7 @@ module.exports = [{
 	attack: 4,
 	range: "1",
 	text: "<b>ATTACK: </b>Disable this card to perform this attack. You may fire this weapon in any direction. This Upgrade may only be purchased for a Xindi Weapon.",
-	unique: false, 
+	unique: false,
 	factions: ["xindi"]
 }, {
 	type: "tech",
@@ -9555,7 +9555,7 @@ module.exports = [{
 	set: ["71802"],
 	name: "Ablative Hull Armor",
 	unique: true,
-	text: "When defending, during the Modify Defense Dice step, convert all of your opponent's [crit] results into [hit] results. Place all t he damage cards that your ship receives beneath this card. Once there are 3 damage cards beneath this card, discard this Upgrade and all damage cards beneath it. All excess damage affects the ship as normal. This Upgrade may only be purchased for a Prometheus Class ship.",
+	text: "When defending, during the Modify Defense Dice step, convert all of your opponent's [crit] results into [hit] results. Place all the damage cards that your ship receives beneath this card. Once there are 3 damage cards beneath this card, discard this Upgrade and all damage cards beneath it. All excess damage affects the ship as normal. This Upgrade may only be purchased for a Prometheus Class ship.",
 	factions: ["federation"],
 	cost: 7,
 	skill: 0,

--- a/Utopia-Master/src/templates/common/card-ship-class.html
+++ b/Utopia-Master/src/templates/common/card-ship-class.html
@@ -15,7 +15,8 @@
 		<div class="arc-actions"><i ng-repeat="action in ship.actions" class="fs fs-{{action}}"></i></div>
 	</div>
 
-	<div class="card-image"></div>
+	<!-- <div class="card-image" ng-class="{'card-image-large': Object.keys(shipClass.maneuvers).length > 9}"></div> -->
+	<div ng-class="(shipClass.id == 'borg_cube') ? 'card-image-large' : 'card-image'"></div>
 
 	<div class="card-corner-top-left pull-left">
 		<div class="card-corner-inner pull-right"></div>
@@ -27,11 +28,11 @@
 		<span class="card-shipclass-title" ng-class="{'card-title-long': shipClass.name.length >= 20 }">{{shipClass.name | uppercase}}</span>
 	</div>
 
-	<div class="card-border-left pull-left"></div>
+	<div ng-class="(shipClass.id == 'borg_cube') ? 'card-border-left-tall pull-left' : 'card-border-left pull-left'"></div>
 
-	<div class="card-border-right pull-right"></div>
+	<div ng-class="(shipClass.id == 'borg_cube') ? 'card-border-right-tall pull-right' : 'card-border-right pull-right'"></div>
 
-	<div class="card-class-maneuvers">
+	<div ng-class="(shipClass.id == 'borg_cube') ? 'card-class-maneuvers-tall' : 'card-class-maneuvers'">
 		<div class="card-maneuver-row" ng-repeat="speed in speeds track by $index">
 			<div class="card-maneuver-box" ng-class="{'speed-reverse': speed < 0}"><span ng-show="speed != 9">{{abs(speed)}}</span></div>
 			<div class="card-maneuver-box" ng-class="{'card-maneuver-box-highlight': shipClass.maneuvers[speed].turn || shipClass.maneuvers[speed]['90-degree-rotate']}">

--- a/Utopia-Master/src/templates/common/card-ship-class.html
+++ b/Utopia-Master/src/templates/common/card-ship-class.html
@@ -4,7 +4,6 @@
 		<div class="arc arc-fill arc-fore-90" ng-show="shipClass.frontArc == 90"></div>
 		<div class="arc arc-fill arc-fore-180" ng-show="shipClass.frontArc == 180"></div>
 		<div class="arc arc-rear-90" ng-show="shipClass.rearArc == 90"></div>
-		<div class="arc arc-second-45" ng-show="shipClass.secondArc == 45"></div>
 		<div class="arc-hole"></div>
 		<div class="arc-name">{{getBaseTileName(ship)}}</div>
 		<div class="arc-stats">
@@ -68,11 +67,11 @@
 	<div class="card-corner-bottom-left pull-left">
 		<div class="card-corner-inner"></div>
 	</div>
-	
+
 	<div class="card-corner-bottom-right pull-right">
 		<div class="card-corner-inner"></div>
 	</div>
-	
+
 	<div class="card-border-bottom"></div>
 
 	<div style="clear: both"></div>


### PR DESCRIPTION
Fixed spelling errors in Captain Sisko, Admiral Forrest, and Federation Photon Torpedos. 

Also fixed an error where the forward and rear 90 deg firing arcs displayed well outside the ship tile on iOS webkit browsers (Safari and Chrome). It had been displaying as shown in this image but the arcs now show as expected.

![utopia_bad_clipping](https://user-images.githubusercontent.com/1534397/39099700-cdd2b168-464c-11e8-8913-9c221050f6d4.jpg)

Finally, also fixed the formatting for the Borg Cube ship class maneuver card so that it no longer overruns the bottom of the card.

Was:
![screenshot from 2018-04-22 19-45-29](https://user-images.githubusercontent.com/1534397/39101305-c4c8ae6a-4665-11e8-9ce5-14f8e92b8809.png)
Is:

![screenshot from 2018-04-22 19-46-05](https://user-images.githubusercontent.com/1534397/39101310-d73370a8-4665-11e8-9459-1f597753a6e4.png)
