### PR TITLE
Single shield-generator value + ship-art upload for SSD designer

### DIFF
--- a/starforce-commander-ship-designer/README.md
+++ b/starforce-commander-ship-designer/README.md
@@ -1,0 +1,23 @@
+# Starforce Commander SSD Designer
+
+A static prototype for designing **Starforce Commander SSD-style ship cards** inspired by Yorktown-style layout blocks.
+
+## Run locally
+
+```bash
+cd starforce-commander-ship-designer
+python3 -m http.server 4173
+```
+
+Open: `http://localhost:4173`
+
+## Features
+
+- Left-side stat editor with right-side live SSD template preview
+- Template sections for engineering, shields, weapons, systems, and structure footer
+- Single shield-generator value that renders black generator boxes + matching green boxes on each facing
+- Multi-line text blocks for functions/power/maneuvering
+- Structure strip with repairable (gray) and permanent (red) box counts
+- Custom ship art upload rendered in the shield center
+- Save and restore drafts with `localStorage`
+- Export current SSD build as JSON

--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -1,0 +1,284 @@
+const form = document.getElementById('ssdForm');
+const draftsEl = document.getElementById('drafts');
+const jsonPreview = document.getElementById('jsonPreview');
+const liveBadge = document.getElementById('liveBadge');
+const STORAGE_KEY = 'sfCommanderSsdDrafts';
+let shipArtDataUrl = '';
+
+function parseWeapons(raw) {
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [name, ...ranges] = line.split('|').map((part) => part.trim());
+      return { name, ranges };
+    });
+}
+
+function parseSystems(raw) {
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [key, value] = line.split(':').map((part) => part.trim());
+      return { key, value: value ?? '' };
+    });
+}
+
+function num(name) {
+  return Number(form.elements[name].value || 0);
+}
+
+function getBuild() {
+  return {
+    identity: {
+      name: form.elements.name.value,
+      classType: form.elements.classType.value,
+      faction: form.elements.faction.value,
+      era: form.elements.era.value
+    },
+    engineering: {
+      move: num('move'),
+      vector: num('vector'),
+      turn: num('turn'),
+      special: num('special')
+    },
+    shields: {
+      forward: num('shieldFwd'),
+      aft: num('shieldAft'),
+      port: num('shieldPort'),
+      starboard: num('shieldStbd')
+    },
+    shieldGen: num('shieldGen'),
+    textBlocks: {
+      functions: form.elements.functions.value,
+      powerSystem: form.elements.powerSystem.value,
+      maneuvering: form.elements.maneuvering.value
+    },
+    structure: {
+      repairable: num('structureBlack'),
+      permanent: num('structureRed')
+    },
+    shipArtDataUrl,
+    weapons: parseWeapons(form.elements.weapons.value),
+    systems: parseSystems(form.elements.systems.value)
+  };
+}
+
+function renderBoxes(containerId, count, className) {
+  const container = document.getElementById(containerId);
+  container.innerHTML = '';
+  for (let i = 0; i < count; i += 1) {
+    const box = document.createElement('span');
+    box.className = className;
+    container.appendChild(box);
+  }
+}
+
+function weaponSlot(id, weapon) {
+  const title = document.getElementById(`pvWpn${id}Title`);
+  const body = document.getElementById(`pvWpn${id}Body`);
+  if (!weapon) {
+    title.textContent = 'WPN NAME TYP';
+    body.textContent = '';
+    return;
+  }
+  title.textContent = weapon.name || 'WPN NAME TYP';
+  body.textContent = weapon.ranges.join('  •  ');
+}
+
+function renderStructure(build) {
+  const row = document.getElementById('pvStructureBoxes');
+  row.innerHTML = '';
+  for (let i = 0; i < build.structure.repairable; i += 1) {
+    const box = document.createElement('span');
+    box.className = 'structure-box';
+    row.appendChild(box);
+  }
+  for (let i = 0; i < build.structure.permanent; i += 1) {
+    const box = document.createElement('span');
+    box.className = 'structure-box permanent';
+    row.appendChild(box);
+  }
+}
+
+function renderPreview(build) {
+  document.getElementById('pvName').textContent = build.identity.name || 'SHIP NAME / ID';
+  document.getElementById('pvClass').textContent = build.identity.classType || 'CLASSNAME ID-class Weight Class';
+  document.getElementById('pvFaction').textContent = build.identity.faction || 'COMMON';
+  document.getElementById('pvEra').textContent = build.identity.era || 'ERA';
+
+  document.getElementById('pvMove').textContent = build.engineering.move;
+  document.getElementById('pvVector').textContent = build.engineering.vector;
+  document.getElementById('pvTurn').textContent = build.engineering.turn;
+  document.getElementById('pvSpecial').textContent = build.engineering.special;
+
+  document.getElementById('pvShieldFwd').textContent = String(build.shields.forward).padStart(2, '0');
+  document.getElementById('pvShieldAft').textContent = String(build.shields.aft).padStart(2, '0');
+  document.getElementById('pvShieldPort').textContent = String(build.shields.port).padStart(2, '0');
+  document.getElementById('pvShieldStbd').textContent = String(build.shields.starboard).padStart(2, '0');
+
+  const blackGenRow = document.getElementById('pvShieldGenBlackBoxes');
+  blackGenRow.innerHTML = '';
+  for (let i = 0; i < build.shieldGen; i += 1) {
+    const box = document.createElement('span');
+    box.className = 'shield-gen-black';
+    blackGenRow.appendChild(box);
+  }
+
+  renderBoxes('pvFwdShieldBoxes', build.shields.forward, 'shield-box');
+  renderBoxes('pvAftShieldBoxes', build.shields.aft, 'shield-box');
+  renderBoxes('pvPortShieldBoxes', build.shields.port, 'shield-box');
+  renderBoxes('pvStbdShieldBoxes', build.shields.starboard, 'shield-box');
+
+  renderBoxes('pvFwdGenBoxes', build.shieldGen, 'shield-gen');
+  renderBoxes('pvAftGenBoxes', build.shieldGen, 'shield-gen');
+  renderBoxes('pvPortGenBoxes', build.shieldGen, 'shield-gen');
+  renderBoxes('pvStbdGenBoxes', build.shieldGen, 'shield-gen');
+
+  const artEl = document.getElementById('pvShipArt');
+  const silhouetteEl = document.getElementById('pvShipSilhouette');
+  if (build.shipArtDataUrl) {
+    artEl.src = build.shipArtDataUrl;
+    artEl.style.display = 'block';
+    silhouetteEl.style.display = 'none';
+  } else {
+    artEl.removeAttribute('src');
+    artEl.style.display = 'none';
+    silhouetteEl.style.display = 'block';
+  }
+
+  document.getElementById('pvFunctions').textContent = build.textBlocks.functions;
+  document.getElementById('pvPowerSystem').textContent = build.textBlocks.powerSystem;
+  document.getElementById('pvManeuvering').textContent = build.textBlocks.maneuvering;
+
+  weaponSlot(1, build.weapons[0]);
+  weaponSlot(2, build.weapons[1]);
+  weaponSlot(3, build.weapons[2]);
+  weaponSlot(4, build.weapons[3]);
+
+  const systemsText = build.systems.map((entry) => `${entry.key} ${entry.value}`.trim()).join('\n');
+  document.getElementById('pvSystems').textContent = systemsText;
+  renderStructure(build);
+}
+
+function pulseLiveBadge() {
+  liveBadge.style.opacity = '0.35';
+  setTimeout(() => {
+    liveBadge.style.opacity = '1';
+  }, 110);
+}
+
+function render() {
+  const build = getBuild();
+  renderPreview(build);
+  jsonPreview.textContent = JSON.stringify(build, null, 2);
+  pulseLiveBadge();
+}
+
+function loadDrafts() {
+  return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+}
+
+function renderDrafts() {
+  draftsEl.innerHTML = '';
+  const drafts = loadDrafts();
+  if (!drafts.length) {
+    draftsEl.innerHTML = '<li>No drafts saved yet.</li>';
+    return;
+  }
+  drafts.slice().reverse().forEach((entry) => {
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = `${entry.draft.identity.name || 'Unnamed Ship'} (${new Date(entry.savedAt).toLocaleString()})`;
+    btn.addEventListener('click', () => restoreDraft(entry.draft));
+    li.appendChild(btn);
+    draftsEl.appendChild(li);
+  });
+}
+
+function restoreDraft(draft) {
+  form.elements.name.value = draft.identity?.name ?? '';
+  form.elements.classType.value = draft.identity?.classType ?? '';
+  form.elements.faction.value = draft.identity?.faction ?? '';
+  form.elements.era.value = draft.identity?.era ?? '';
+
+  form.elements.move.value = draft.engineering?.move ?? 0;
+  form.elements.vector.value = draft.engineering?.vector ?? 0;
+  form.elements.turn.value = draft.engineering?.turn ?? 0;
+  form.elements.special.value = draft.engineering?.special ?? 0;
+
+  form.elements.shieldFwd.value = draft.shields?.forward ?? 0;
+  form.elements.shieldAft.value = draft.shields?.aft ?? 0;
+  form.elements.shieldPort.value = draft.shields?.port ?? 0;
+  form.elements.shieldStbd.value = draft.shields?.starboard ?? 0;
+
+  form.elements.shieldGen.value = draft.shieldGen ?? 0;
+
+  form.elements.functions.value = draft.textBlocks?.functions ?? '';
+  form.elements.powerSystem.value = draft.textBlocks?.powerSystem ?? '';
+  form.elements.maneuvering.value = draft.textBlocks?.maneuvering ?? '';
+  form.elements.structureBlack.value = draft.structure?.repairable ?? 0;
+  form.elements.structureRed.value = draft.structure?.permanent ?? 0;
+
+  shipArtDataUrl = draft.shipArtDataUrl ?? '';
+  form.elements.weapons.value = (draft.weapons ?? []).map((item) => [item.name, ...(item.ranges ?? [])].join('|')).join('\n');
+  form.elements.systems.value = (draft.systems ?? []).map((item) => `${item.key}:${item.value ?? ''}`).join('\n');
+
+  render();
+}
+
+function saveDraft() {
+  const drafts = loadDrafts();
+  drafts.push({ id: crypto.randomUUID(), savedAt: new Date().toISOString(), draft: getBuild() });
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(drafts));
+  renderDrafts();
+}
+
+function clearDrafts() {
+  localStorage.removeItem(STORAGE_KEY);
+  renderDrafts();
+}
+
+function exportCurrent() {
+  const name = form.elements.name.value || 'starforce-ssd';
+  const blob = new Blob([JSON.stringify(getBuild(), null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${name}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+form.addEventListener('input', render);
+form.addEventListener('change', render);
+document.getElementById('saveBtn').addEventListener('click', saveDraft);
+document.getElementById('clearBtn').addEventListener('click', clearDrafts);
+document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+
+const shipArtInput = document.getElementById('shipArt');
+document.getElementById('clearArtBtn').addEventListener('click', () => {
+  shipArtDataUrl = '';
+  shipArtInput.value = '';
+  render();
+});
+
+shipArtInput.addEventListener('change', (event) => {
+  const [file] = event.target.files || [];
+  if (!file) {
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = () => {
+    shipArtDataUrl = String(reader.result || '');
+    render();
+  };
+  reader.readAsDataURL(file);
+});
+
+render();
+renderDrafts();

--- a/starforce-commander-ship-designer/data.json
+++ b/starforce-commander-ship-designer/data.json
@@ -1,0 +1,21 @@
+{
+  "modules": {
+    "weapon": [
+      { "name": "None", "power": 0 },
+      { "name": "Pulse Cannons", "power": 2 },
+      { "name": "Plasma Lance", "power": 4 },
+      { "name": "Rail Battery", "power": 5 }
+    ],
+    "engine": [
+      { "name": "None", "power": 0 },
+      { "name": "Vector Thrusters", "power": 2 },
+      { "name": "Warp Burst Drive", "power": 4 }
+    ],
+    "utility": [
+      { "name": "None", "power": 0 },
+      { "name": "Shield Matrix", "power": 2 },
+      { "name": "Sensor Suite", "power": 1 },
+      { "name": "Drone Bay", "power": 3 }
+    ]
+  }
+}

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Starforce Commander SSD Designer</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="layout">
+    <section class="panel controls">
+      <h1>Starforce Commander SSD Designer</h1>
+      <p class="muted">This version mirrors your blank SSD template: left-side editing, right-side live layout preview.</p>
+
+      <form id="ssdForm" class="stack">
+        <h2>Identity</h2>
+        <label>Ship Name / ID <input name="name" value="SHIP NAME / ID" /></label>
+        <label>Class Label <input name="classType" value="CLASSNAME ID-class Weight Class" /></label>
+        <div class="grid2">
+          <label>Faction <input name="faction" value="COMMON" /></label>
+          <label>Era <input name="era" value="ERA" /></label>
+        </div>
+
+        <h2>Engineering</h2>
+        <div class="grid2">
+          <label>Move <input name="move" type="number" min="0" value="0" /></label>
+          <label>Vector <input name="vector" type="number" min="0" value="0" /></label>
+          <label>Turn <input name="turn" type="number" min="0" value="0" /></label>
+          <label>Special <input name="special" type="number" min="0" value="0" /></label>
+        </div>
+
+        <h2>Shields</h2>
+        <div class="grid2">
+          <label>Forward <input name="shieldFwd" type="number" min="0" value="0" /></label>
+          <label>Aft <input name="shieldAft" type="number" min="0" value="0" /></label>
+          <label>Port <input name="shieldPort" type="number" min="0" value="0" /></label>
+          <label>Starboard <input name="shieldStbd" type="number" min="0" value="0" /></label>
+        </div>
+        <label>Shield Generators (single value for all facings) <input name="shieldGen" type="number" min="0" value="0" /></label>
+        <label>Ship Art (for shield center)
+          <input name="shipArt" id="shipArt" type="file" accept="image/*" />
+        </label>
+        <button type="button" id="clearArtBtn" class="ghost">Clear Ship Art</button>
+
+        <h2>Weapons (up to 4 lines)</h2>
+        <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
+
+        <h2>Functions / Power / Maneuvering</h2>
+        <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
+        <label>Power System <textarea name="powerSystem" rows="3" placeholder="L MAIN, R MAIN, BATTERY..."></textarea></label>
+        <label>Sublight Drive & Maneuvering <textarea name="maneuvering" rows="3" placeholder="MAX ACC/PHS, DMG, SPD, TURN..."></textarea></label>
+
+        <h2>Systems (one per line)</h2>
+        <label><textarea name="systems" rows="4" placeholder="SCNC:0"></textarea></label>
+
+        <h2>Structure</h2>
+        <div class="grid2">
+          <label>Repairable Structure Boxes <input name="structureBlack" type="number" min="0" value="20" /></label>
+          <label>Permanent Structure Boxes <input name="structureRed" type="number" min="0" value="4" /></label>
+        </div>
+
+        <div class="row">
+          <button type="button" id="saveBtn">Save Draft</button>
+          <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="panel preview-wrap">
+      <div class="preview-head">
+        <h2>SSD Preview</h2>
+        <span id="liveBadge" class="live-badge">LIVE</span>
+      </div>
+
+      <article class="ssd-template" id="ssdCard">
+        <header class="template-top">
+          <div class="template-ship" id="pvName">SHIP NAME / ID</div>
+          <div class="template-class" id="pvClass">CLASSNAME ID-class Weight Class</div>
+        </header>
+
+        <div class="template-columns">
+          <section class="col left-col">
+            <h3>ENGINEERING</h3>
+            <div class="eng-stats">
+              <span>🚀 <b id="pvMove">0</b></span>
+              <span>🟢 <b id="pvVector">0</b></span>
+              <span>↪ <b id="pvTurn">0</b></span>
+              <span>🔧 <b id="pvSpecial">0</b></span>
+            </div>
+            <div class="green-block">
+              <h4>FUNCTIONS / POWER LEVEL</h4>
+              <pre id="pvFunctions"></pre>
+            </div>
+            <div class="green-block">
+              <h4>POWER SYSTEM</h4>
+              <pre id="pvPowerSystem"></pre>
+            </div>
+            <div class="green-block">
+              <h4>SUBLIGHT DRIVE AND MANEUVERING</h4>
+              <pre id="pvManeuvering"></pre>
+            </div>
+          </section>
+
+          <section class="col middle-col">
+            <h3>SHIELDS</h3>
+            <div class="shield-top">FWD SHIELD <b id="pvShieldFwd">00</b></div>
+            <div class="shield-box-row" id="pvFwdShieldBoxes"></div>
+            <div class="shield-gen-row" id="pvFwdGenBoxes"></div>
+            <div class="shield-gen-label">SHIELD GEN <span id="pvShieldGenBlackBoxes" class="shield-gen-black-row"></span></div>
+            <div class="shield-body">
+              <div class="side side-port">
+                <span class="side-label">PORT SHIELD <b id="pvShieldPort">00</b></span>
+                <div class="shield-box-col" id="pvPortShieldBoxes"></div>
+                <div class="shield-gen-col" id="pvPortGenBoxes"></div>
+              </div>
+              <div class="ship-art-wrap">
+                <img id="pvShipArt" class="ship-art" alt="Ship art" />
+                <div class="ship-silhouette" id="pvShipSilhouette"></div>
+              </div>
+              <div class="side side-stbd">
+                <span class="side-label">STBD SHIELD <b id="pvShieldStbd">00</b></span>
+                <div class="shield-box-col" id="pvStbdShieldBoxes"></div>
+                <div class="shield-gen-col" id="pvStbdGenBoxes"></div>
+              </div>
+            </div>
+            <div class="shield-bottom">AFT SHIELD <b id="pvShieldAft">00</b></div>
+            <div class="shield-box-row" id="pvAftShieldBoxes"></div>
+            <div class="shield-gen-row" id="pvAftGenBoxes"></div>
+            <div class="systems-box">
+              <h3>SYSTEMS</h3>
+              <pre id="pvSystems"></pre>
+            </div>
+          </section>
+
+          <section class="col right-col">
+            <h3>WEAPONS</h3>
+            <div class="weapon-slot"><div class="slot-title" id="pvWpn1Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn1Body"></div></div>
+            <div class="weapon-slot"><div class="slot-title" id="pvWpn2Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn2Body"></div></div>
+            <div class="weapon-slot"><div class="slot-title" id="pvWpn3Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn3Body"></div></div>
+            <div class="weapon-slot"><div class="slot-title" id="pvWpn4Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn4Body"></div></div>
+          </section>
+        </div>
+
+        <footer class="template-bottom">
+          <span class="structure">STRUCTURE</span>
+          <span class="structure-row" id="pvStructureBoxes"></span>
+          <span class="structure-bands" id="pvStructureBands">5🔧 4🔧 3🔧 2🔧 1🔧</span>
+          <span id="pvFaction">COMMON</span>
+          <span id="pvEra">ERA</span>
+        </footer>
+      </article>
+
+      <h3>Saved Drafts</h3>
+      <ul id="drafts"></ul>
+      <h3>Current JSON</h3>
+      <pre id="jsonPreview"></pre>
+    </section>
+  </main>
+
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -1,0 +1,139 @@
+:root { color-scheme: dark; font-family: Inter, Segoe UI, Roboto, sans-serif; }
+body { margin: 0; background: #0d1222; color: #eaf0ff; }
+.layout { display: grid; grid-template-columns: minmax(340px, 430px) 1fr; gap: 1rem; padding: 1rem; }
+.panel { background: #151d35; border: 1px solid #25315c; border-radius: 10px; padding: 1rem; }
+.controls { max-height: calc(100vh - 2rem); overflow: auto; }
+.preview-wrap { position: sticky; top: 1rem; align-self: start; }
+.stack label { display: block; margin: 0.5rem 0; }
+textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; border-radius: 8px; border: 1px solid #32427a; background: #0f1731; color: #eaf0ff; }
+.grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.65rem; }
+.row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0.5rem; margin-top: 0.75rem; }
+button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
+button.ghost { background: #273055; }
+.muted { color: #a7b4da; }
+.preview-head { display: flex; justify-content: space-between; align-items: center; }
+.live-badge { background: #11b96b; color: #072b19; font-size: 0.76rem; font-weight: 800; border-radius: 999px; padding: 0.12rem 0.5rem; }
+
+.ssd-template { border: 3px solid #0d78c5; background: #dedede; color: #001a34; border-radius: 8px; overflow: hidden; }
+.template-top { display: grid; grid-template-columns: 1fr 1.4fr; border-bottom: 3px solid #0d78c5; }
+.template-ship, .template-class { padding: 0.45rem 0.6rem; font-weight: 800; font-size: 1.1rem; border-right: 3px solid #0d78c5; background: #edf4fa; }
+.template-class { border-right: 0; text-align: center; }
+.template-columns { display: grid; grid-template-columns: 1.12fr 1fr 0.82fr; gap: 0.28rem; padding: 0.25rem; }
+.col h3 { margin: 0 0 0.2rem; background: #4a5a68; color: #fff; text-align: center; padding: 0.25rem 0.4rem; border: 2px solid #1d2d3a; }
+
+.eng-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.2rem; margin-bottom: 0.22rem; }
+.eng-stats span { background: #4a5a68; color: #fff; text-align: center; padding: 0.3rem 0.15rem; border: 2px solid #1d2d3a; font-size: 0.9rem; }
+.green-block { border: 2px solid #00a750; background: #f0f0f0; margin-bottom: 0.2rem; }
+.green-block h4 { margin: 0; background: #00b050; color: #fff; padding: 0.18rem 0.28rem; font-size: 0.8rem; }
+.green-block pre { min-height: 56px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; }
+
+.middle-col { border: 2px solid #09a6de; background: #f8f8f8; }
+.shield-top, .shield-bottom { background: #16a7dd; color: #fff; text-align: center; font-weight: 800; padding: 0.25rem; }
+.shield-box-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.25rem 0.35rem; min-height: 22px; justify-content: center; }
+.shield-gen-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0 0.35rem 0.25rem; min-height: 22px; justify-content: center; }
+.shield-gen-label { text-align: center; font-weight: 800; color: #123; margin-bottom: 0.15rem; display: flex; justify-content: center; align-items: center; gap: 6px; }
+.shield-gen-black-row { display: flex; gap: 4px; flex-wrap: wrap; }
+.shield-box {
+  width: 12px;
+  height: 12px;
+  border: 2px solid #08a8df;
+  box-sizing: border-box;
+}
+.shield-gen {
+  width: 12px;
+  height: 12px;
+  border: 2px solid #00b050;
+  box-sizing: border-box;
+}
+.shield-gen-black {
+  width: 12px;
+  height: 12px;
+  border: 2px solid #1f1f1f;
+  box-sizing: border-box;
+  background: #555;
+}
+
+.shield-body { position: relative; min-height: 285px; background: #e2e2e2; display: flex; align-items: center; justify-content: center; }
+.ship-art-wrap { width: 34%; height: 58%; display: flex; align-items: center; justify-content: center; }
+.ship-art { max-width: 100%; max-height: 100%; object-fit: contain; display: none; }
+.ship-silhouette { width: 100%; height: 100%; background: linear-gradient(180deg,#31b5ea,#0095d9); border-radius: 52% 52% 35% 35% / 60% 60% 40% 40%; }
+.side {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.side-port { left: 8px; }
+.side-stbd { right: 8px; flex-direction: row-reverse; }
+.side-label {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  color: #fff;
+  background: #16a7dd;
+  padding: 0.35rem 0.2rem;
+  font-weight: 800;
+}
+.shield-box-col, .shield-gen-col {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 112px;
+  justify-content: center;
+}
+.systems-box { border-top: 2px solid #f0b500; margin-top: 0.2rem; }
+.systems-box h3 { border-color: #f0b500; }
+.systems-box pre { min-height: 92px; margin: 0; white-space: pre-wrap; color: #223; }
+
+.right-col { border: 2px solid #ff0000; background: #fafafa; }
+.weapon-slot { border-top: 2px solid #ff0000; min-height: 104px; }
+.weapon-slot:first-of-type { border-top: 0; }
+.slot-title { background: #ff0000; color: #fff; font-weight: 800; padding: 0.17rem 0.3rem; }
+.slot-body { white-space: pre-wrap; color: #233; padding: 0.35rem 0.38rem; min-height: 72px; }
+
+.template-bottom {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto;
+  align-items: center;
+  gap: 0.35rem;
+  background: #4a5a68;
+  color: #fff;
+  font-weight: 800;
+  padding: 0.28rem 0.45rem;
+  border-top: 3px solid #0d78c5;
+}
+.structure { letter-spacing: 0.03em; }
+.structure-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-height: 14px;
+}
+.structure-bands { font-size: 0.85rem; opacity: 0.95; }
+.structure-box {
+  width: 12px;
+  height: 12px;
+  border: 2px solid #d7dce0;
+  box-sizing: border-box;
+  background: #5e6e7a;
+}
+.structure-box.permanent {
+  border-color: #ff3b3b;
+  background: #7a1f1f;
+}
+
+pre { background: #0b1128; color: #d5e2ff; padding: 0.65rem; border-radius: 8px; overflow: auto; max-height: 220px; }
+#drafts { padding-left: 1rem; }
+
+@media (max-width: 1280px) {
+  .layout { grid-template-columns: 1fr; }
+  .controls { max-height: none; overflow: visible; }
+  .preview-wrap { position: static; }
+}
+@media (max-width: 980px) {
+  .template-columns { grid-template-columns: 1fr; }
+  .side-port,.side-stbd { position: static; transform: none; display: inline-flex; margin: 0.2rem; }
+  .template-bottom { grid-template-columns: 1fr; }
+  .ship-art-wrap { width: 40%; }
+}


### PR DESCRIPTION
### Motivation
- Simplify shield-generator handling by using a single generator count for the whole ship and allow custom ship art to be placed in the shield center for visual customization.

### Description
- Replace the four per-facing shield-generator inputs with one `shieldGen` input and render that value as black boxes next to the `SHIELD GEN` label and as green generator boxes on every facing (Fwd/Port/Stbd/Aft). 
- Add a file input `shipArt` and a `Clear Ship Art` button to upload a custom image, render the uploaded art in the shield center (fallback to silhouette when no art), and keep the image data URL in the exported/ saved build. 
- Persist and restore the new `shieldGen` and `shipArtDataUrl` properties in save/restore/export logic and update the live preview rendering in `app.js` accordingly. 
- Update CSS to support black generator boxes and center art sizing, and update `README.md` to document the single-generator behavior and custom ship-art feature.

### Testing
- Checked JavaScript syntax with `node --check starforce-commander-ship-designer/app.js` and it succeeded. 
- Served the prototype with `python3 -m http.server 4173 --directory starforce-commander-ship-designer` and confirmed the site responded via `curl -I http://127.0.0.1:4173/`. 
- Exercised the UI via an automated Playwright script that set shield values, uploaded a sample PNG, and captured a screenshot to validate black generator boxes, per-facing green boxes, and center ship art rendering, and the script completed successfully. 
- Verified save/restore/export include the `shieldGen` and `shipArtDataUrl` fields and the preview updates live with input changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990b0699dbc8332b16879f2469e1652)