### PR TITLE
Refine Ship Maker SSD preview to better match custom mockup

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -87,9 +87,11 @@
               <span>🟢 <b id="pvVector">0</b></span>
               <span>↪ <b id="pvTurn">0</b></span>
               <span>🔧 <b id="pvSpecial">0</b></span>
+              <span class="stat-tag">PWR</span>
+              <span class="stat-tag">BAT</span>
             </div>
             <div class="green-block">
-              <h4>FUNCTIONS / POWER LEVEL</h4>
+              <h4><span>FUNCTIONS</span><span>POWER LEVEL</span></h4>
               <pre id="pvFunctions"></pre>
             </div>
             <div class="green-block">
@@ -145,7 +147,7 @@
         <footer class="template-bottom">
           <span class="structure">STRUCTURE</span>
           <span class="structure-row" id="pvStructureBoxes"></span>
-          <span class="structure-bands" id="pvStructureBands">5🔧 4🔧 3🔧 2🔧 1🔧</span>
+          <span class="structure-bands" id="pvStructureBands">3⚙ 2⚙ 1⚙</span>
           <span id="pvFaction">COMMON</span>
           <span id="pvEra">ERA</span>
         </footer>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -14,24 +14,72 @@ button.ghost { background: #273055; }
 .preview-head { display: flex; justify-content: space-between; align-items: center; }
 .live-badge { background: #11b96b; color: #072b19; font-size: 0.76rem; font-weight: 800; border-radius: 999px; padding: 0.12rem 0.5rem; }
 
-.ssd-template { border: 3px solid #0d78c5; background: #dedede; color: #001a34; border-radius: 8px; overflow: hidden; }
-.template-top { display: grid; grid-template-columns: 1fr 1.4fr; border-bottom: 3px solid #0d78c5; }
-.template-ship, .template-class { padding: 0.45rem 0.6rem; font-weight: 800; font-size: 1.1rem; border-right: 3px solid #0d78c5; background: #edf4fa; }
-.template-class { border-right: 0; text-align: center; }
-.template-columns { display: grid; grid-template-columns: 1.12fr 1fr 0.82fr; gap: 0.28rem; padding: 0.25rem; }
-.col h3 { margin: 0 0 0.2rem; background: #4a5a68; color: #fff; text-align: center; padding: 0.25rem 0.4rem; border: 2px solid #1d2d3a; }
+.ssd-template {
+  border: 3px solid #0b71ba;
+  background: #d9d9d9;
+  color: #04111f;
+  border-radius: 0;
+  overflow: hidden;
+  font-family: Arial Black, Arial, Helvetica, sans-serif;
+}
+.template-top {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) 1.5fr;
+  gap: 0.35rem;
+  border-bottom: 3px solid #0b71ba;
+  background: #d9d9d9;
+  padding: 0.15rem;
+  position: relative;
+}
+.template-top::before,
+.template-top::after {
+  content: "";
+  width: 48px;
+  height: 44px;
+  border: 4px solid #111;
+  background: #5a6a76;
+  border-radius: 22px;
+  position: absolute;
+  top: 1px;
+}
+.template-top::before { left: -1px; }
+.template-top::after { right: -1px; }
+.template-ship,
+.template-class {
+  padding: 0.45rem 0.6rem;
+  font-weight: 900;
+  font-size: 1.05rem;
+  border: 3px solid #0e3f8c;
+  background: #c8d5e3;
+  text-transform: uppercase;
+}
+.template-ship {
+  margin-left: 3.2rem;
+  text-align: center;
+  color: #b7b7b7;
+}
+.template-class {
+  margin-right: 3.2rem;
+  border-color: transparent;
+  background: transparent;
+  color: #000;
+  text-align: right;
+}
+.template-columns { display: grid; grid-template-columns: 1.06fr 0.94fr 0.72fr; gap: 0.4rem; padding: 0.25rem 0.15rem 0.2rem; }
+.col h3 { margin: 0 0 0.2rem; background: #566674; color: #f3f3f3; text-align: center; padding: 0.1rem 0.3rem; border: 3px solid #111; font-size: 1.02rem; letter-spacing: 0.02em; }
 
-.eng-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.2rem; margin-bottom: 0.22rem; }
-.eng-stats span { background: #4a5a68; color: #fff; text-align: center; padding: 0.3rem 0.15rem; border: 2px solid #1d2d3a; font-size: 0.9rem; }
-.green-block { border: 2px solid #00a750; background: #f0f0f0; margin-bottom: 0.2rem; }
-.green-block h4 { margin: 0; background: #00b050; color: #fff; padding: 0.18rem 0.28rem; font-size: 0.8rem; }
-.green-block pre { min-height: 56px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; }
+.eng-stats { display: grid; grid-template-columns: repeat(6, 1fr); gap: 0.15rem; margin-bottom: 0.2rem; }
+.eng-stats span { background: #566674; color: #fff; text-align: center; padding: 0.25rem 0.1rem; border: 2px solid #f5f5f5; font-size: 0.9rem; font-weight: 900; }
+.stat-tag { color: #b8b8b8 !important; background: #e9eef3 !important; border-color: #10a5df !important; }
+.green-block { border: 2px solid #02a45c; background: #f0f0f0; margin-bottom: 0.2rem; }
+.green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
+.green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
 
-.middle-col { border: 2px solid #09a6de; background: #f8f8f8; }
-.shield-top, .shield-bottom { background: #16a7dd; color: #fff; text-align: center; font-weight: 800; padding: 0.25rem; }
+.middle-col { border: 3px solid #10a5df; background: #f8f8f8; }
+.shield-top, .shield-bottom { background: #17a8df; color: #fff; text-align: center; font-weight: 900; padding: 0.16rem; font-size: 0.95rem; }
 .shield-box-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.25rem 0.35rem; min-height: 22px; justify-content: center; }
 .shield-gen-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0 0.35rem 0.25rem; min-height: 22px; justify-content: center; }
-.shield-gen-label { text-align: center; font-weight: 800; color: #123; margin-bottom: 0.15rem; display: flex; justify-content: center; align-items: center; gap: 6px; }
+.shield-gen-label { text-align: center; font-weight: 900; color: #0872c2; margin: 0.15rem 0 0.25rem; display: flex; justify-content: center; align-items: center; gap: 6px; font-size: 0.92rem; }
 .shield-gen-black-row { display: flex; gap: 4px; flex-wrap: wrap; }
 .shield-box {
   width: 12px;
@@ -42,21 +90,21 @@ button.ghost { background: #273055; }
 .shield-gen {
   width: 12px;
   height: 12px;
-  border: 2px solid #00b050;
+  border: 3px solid #00b050;
   box-sizing: border-box;
 }
 .shield-gen-black {
   width: 12px;
   height: 12px;
-  border: 2px solid #1f1f1f;
+  border: 3px solid #111;
   box-sizing: border-box;
-  background: #555;
+  background: #eee;
 }
 
-.shield-body { position: relative; min-height: 285px; background: #e2e2e2; display: flex; align-items: center; justify-content: center; }
-.ship-art-wrap { width: 34%; height: 58%; display: flex; align-items: center; justify-content: center; }
-.ship-art { max-width: 100%; max-height: 100%; object-fit: contain; display: none; }
-.ship-silhouette { width: 100%; height: 100%; background: linear-gradient(180deg,#31b5ea,#0095d9); border-radius: 52% 52% 35% 35% / 60% 60% 40% 40%; }
+.shield-body { position: relative; min-height: 385px; background: #e2e2e2; display: flex; align-items: center; justify-content: center; }
+.ship-art-wrap { width: 76%; height: 82%; display: flex; align-items: center; justify-content: center; }
+.ship-art { max-width: 100%; max-height: 100%; object-fit: contain; display: none; filter: saturate(0.9) contrast(1.02); }
+.ship-silhouette { width: 58%; height: 82%; background: linear-gradient(180deg,#d8d8d8,#b5b5b5); border: 3px solid #121212; border-radius: 46% 46% 30% 30% / 58% 58% 42% 42%; }
 .side {
   position: absolute;
   top: 50%;
@@ -73,7 +121,8 @@ button.ghost { background: #273055; }
   color: #fff;
   background: #16a7dd;
   padding: 0.35rem 0.2rem;
-  font-weight: 800;
+  font-weight: 900;
+  font-size: 0.95rem;
 }
 .shield-box-col, .shield-gen-col {
   display: flex;
@@ -82,45 +131,55 @@ button.ghost { background: #273055; }
   min-height: 112px;
   justify-content: center;
 }
-.systems-box { border-top: 2px solid #f0b500; margin-top: 0.2rem; }
+.systems-box { border-top: 0; margin-top: 0.3rem; border: 2px solid #f0b500; }
 .systems-box h3 { border-color: #f0b500; }
-.systems-box pre { min-height: 92px; margin: 0; white-space: pre-wrap; color: #223; }
+.systems-box pre { min-height: 96px; margin: 0; white-space: pre-wrap; color: #223; background: transparent; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
 
-.right-col { border: 2px solid #ff0000; background: #fafafa; }
-.weapon-slot { border-top: 2px solid #ff0000; min-height: 104px; }
+.right-col { border: 3px solid #ff0000; background: #fafafa; }
+.weapon-slot { border-top: 2px solid #ff0000; min-height: 120px; }
 .weapon-slot:first-of-type { border-top: 0; }
-.slot-title { background: #ff0000; color: #fff; font-weight: 800; padding: 0.17rem 0.3rem; }
-.slot-body { white-space: pre-wrap; color: #233; padding: 0.35rem 0.38rem; min-height: 72px; }
+.slot-title { background: #ff0000; color: #fff; font-weight: 900; padding: 0.17rem 0.3rem; }
+.slot-body { white-space: pre-wrap; color: #233; padding: 0.35rem 0.38rem; min-height: 88px; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
 
 .template-bottom {
   display: grid;
-  grid-template-columns: auto 1fr auto auto auto;
+  grid-template-columns: auto 1fr auto auto;
   align-items: center;
-  gap: 0.35rem;
-  background: #4a5a68;
+  gap: 0.22rem;
+  background: #d9d9d9;
   color: #fff;
-  font-weight: 800;
-  padding: 0.28rem 0.45rem;
+  font-weight: 900;
+  padding: 0.1rem 0.15rem;
   border-top: 3px solid #0d78c5;
 }
-.structure { letter-spacing: 0.03em; }
+.structure { letter-spacing: 0.03em; background: #566674; border: 3px solid #111; padding: 0.03rem 0.6rem; }
 .structure-row {
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
   min-height: 14px;
 }
-.structure-bands { font-size: 0.85rem; opacity: 0.95; }
+.structure-bands { font-size: 2rem; opacity: 1; color: #111; letter-spacing: 0.08em; line-height: 1; font-family: "Segoe UI Symbol", Arial, sans-serif; }
 .structure-box {
   width: 12px;
   height: 12px;
-  border: 2px solid #d7dce0;
+  border: 2px solid #111;
   box-sizing: border-box;
-  background: #5e6e7a;
+  background: #e8e8e8;
 }
 .structure-box.permanent {
-  border-color: #ff3b3b;
-  background: #7a1f1f;
+  border-color: #d10000;
+  background: #ff5a5a;
+}
+
+#pvFaction,
+#pvEra {
+  background: #566674;
+  border: 3px solid #111;
+  padding: 0.02rem 0.55rem;
+  min-width: 86px;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 pre { background: #0b1128; color: #d5e2ff; padding: 0.65rem; border-radius: 8px; overflow: auto; max-height: 220px; }


### PR DESCRIPTION
### Motivation
- Bring the Ship Maker SSD preview into closer visual parity with the provided Lexington-style mockup by adjusting engineering, structure, shields, and header presentation.
- Make PWR/BAT engineering cells explicit and improve the Functions/Power visual alignment to match the mockup's label layout.
- Improve the ship-art fallback, shield-generator look, and structure track annotation for clearer, more mockup-faithful rendering.

### Description
- Updated `index.html` to add `PWR` and `BAT` stat cells, split the `FUNCTIONS / POWER LEVEL` header into two aligned labels, and change the structure-band text to `3⚙ 2⚙ 1⚙`.
- Expanded the engineering stat grid and added a `.stat-tag` class for the new PWR/BAT cells, and adjusted header/title markup for improved alignment.
- Refined `styles.css` for the SSD preview including stronger stat-cell styling, `green-block h4` set to a flex layout, shield generator border weight and color tweaks, and a desaturated ship-silhouette fallback with border.
- Tuned footer/faction/era badge styling and enlarged the structure-band glyphs and typography to match the mockup proportions.

### Testing
- Served the preview locally using `python3 -m http.server 8000` and exercised the page.
- Captured an automated visual snapshot of the populated preview using Playwright (Firefox) to validate layout and styling changes, and the screenshot run succeeded.
- Verified the rendered DOM and CSS differences via a diff inspection to confirm the intended template and style modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69911be29fd48332b6b719f7faf0e164)