### PR TITLE
Adjust sublight maneuver preview to six aligned columns

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -145,9 +145,13 @@ function renderManeuvering(sublight) {
   circleRun('pvRndGreen', data.greenCircles);
   circleRun('pvRndRed', data.redCircles);
 
-  document.getElementById('pvSpdVals').innerHTML = data.spd.map((value) => `<b>${value}</b>`).join('');
-  document.getElementById('pvTurnVals').innerHTML = data.turns.map((value) => `<b>${value}</b>`).join('');
-  document.getElementById('pvDmgStops').innerHTML = data.dmgStops.map((stop) => `<b>${stop ? '■' : '□'}</b>`).join('');
+  const previewColumns = 6;
+  document.getElementById('pvSpdVals').innerHTML = data.spd.slice(0, previewColumns).map((value) => `<b>${value}</b>`).join('');
+  document.getElementById('pvTurnVals').innerHTML = data.turns.slice(0, previewColumns).map((value) => `<b>${value}</b>`).join('');
+  document.getElementById('pvDmgStops').innerHTML = data.dmgStops
+    .slice(0, previewColumns)
+    .map((stop) => `<b class="dmg-stop${stop ? '' : ' is-inactive'}">■</b>`)
+    .join('');
 }
 
 function renderPreview(build) {

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -233,6 +233,7 @@ pre { background: #0b1128; color: #d5e2ff; padding: 0.65rem; border-radius: 8px;
 .rnd-circle { width: 10px; height: 10px; border-radius: 999px; border: 2px solid currentColor; box-sizing: border-box; }
 .rnd-circles.green { color: #00b050; }
 .rnd-circles.red { color: #ff1f1f; }
-.man-values { display: inline-grid; grid-template-columns: repeat(7, minmax(16px, auto)); gap: 0.45rem; }
+.man-values { display: inline-grid; grid-template-columns: repeat(6, minmax(16px, auto)); gap: 0.45rem; }
 .man-values b { font-size: 1.05rem; line-height: 1; }
 .dmg-values b { font-size: 0.95rem; }
+.dmg-stop.is-inactive { visibility: hidden; }


### PR DESCRIPTION
### Motivation
- Ensure the sublight maneuver preview's DMG, SPD, and TURN rows align visually by rendering a fixed number of columns.
- Preserve layout spacing for DMG stops even when a stop is inactive so columns remain consistent.
- Make inactive DMG stop markers visually hidden rather than removing their layout footprint.

### Description
- Limit the previewed maneuver columns to six by slicing arrays in `renderManeuvering` (`app.js`) so `SPD`, `TURN`, and `DMG` use the first six entries (`.slice(0, previewColumns)`).
- Render DMG stop markers as filled elements and add an `is-inactive` class for inactive stops (`app.js`) so they keep space but can be hidden visually.
- Update CSS in `styles.css` to change `.man-values` grid from `repeat(7, ...)` to `repeat(6, ...)` and add `.dmg-stop.is-inactive { visibility: hidden; }` to hide inactive DMG stops while preserving layout.

### Testing
- Launched a local static server with `python3 -m http.server 4173` and loaded the page for visual verification, which succeeded.
- Automated a Playwright run to open the site and capture a screenshot (`artifacts/sublight-layout.png`), which completed successfully.
- Verified diffs and committed the changes locally (`git` diff/commit), and the commit recorded the two modified files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69912e019f488332af9f99c283d4d749)