### PR TITLE
Stabilize sublight maneuver alignment and restore full 0–6 range

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -145,9 +145,16 @@ function renderManeuvering(sublight) {
   circleRun('pvRndGreen', data.greenCircles);
   circleRun('pvRndRed', data.redCircles);
 
-  document.getElementById('pvSpdVals').innerHTML = data.spd.map((value) => `<b>${value}</b>`).join('');
-  document.getElementById('pvTurnVals').innerHTML = data.turns.map((value) => `<b>${value}</b>`).join('');
-  document.getElementById('pvDmgStops').innerHTML = data.dmgStops.map((stop) => `<b>${stop ? '■' : '□'}</b>`).join('');
+  const previewColumns = 7;
+  const spdValues = data.spd.slice(-previewColumns);
+  const turnValues = data.turns.slice(-previewColumns);
+  const dmgValues = data.dmgStops.slice(-previewColumns);
+
+  document.getElementById('pvSpdVals').innerHTML = spdValues.map((value) => `<b>${value}</b>`).join('');
+  document.getElementById('pvTurnVals').innerHTML = turnValues.map((value) => `<b>${value}</b>`).join('');
+  document.getElementById('pvDmgStops').innerHTML = dmgValues
+    .map((stop) => `<span class="dmg-stop${stop ? '' : ' is-inactive'}"></span>`)
+    .join('');
 }
 
 function renderPreview(build) {

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -226,13 +226,32 @@ pre { background: #0b1128; color: #d5e2ff; padding: 0.65rem; border-radius: 8px;
   .ship-art-wrap { width: 40%; }
 }
 
-.maneuver-preview { background: transparent; color: #111; font-family: Arial, Helvetica, sans-serif; font-size: 0.78rem; padding: 0.25rem 0.2rem; }
-.man-row { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.15rem; font-weight: 800; }
-.man-top { margin-bottom: 0.22rem; }
+.maneuver-preview {
+  --man-label-width: 54px;
+  --man-col-width: 24px;
+  --man-col-gap: 0.45rem;
+  background: transparent;
+  color: #111;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 0.78rem;
+  padding: 0.25rem 0.2rem;
+}
+.man-row { margin-bottom: 0.15rem; font-weight: 800; }
+.man-row:not(.man-top) { display: grid; grid-template-columns: var(--man-label-width) max-content; column-gap: 0.35rem; align-items: center; }
+.man-top { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.22rem; }
 .rnd-circles { display: inline-flex; gap: 0.2rem; min-width: 44px; }
 .rnd-circle { width: 10px; height: 10px; border-radius: 999px; border: 2px solid currentColor; box-sizing: border-box; }
 .rnd-circles.green { color: #00b050; }
 .rnd-circles.red { color: #ff1f1f; }
-.man-values { display: inline-grid; grid-template-columns: repeat(7, minmax(16px, auto)); gap: 0.45rem; }
-.man-values b { font-size: 1.05rem; line-height: 1; }
-.dmg-values b { font-size: 0.95rem; }
+.man-values { display: inline-grid; grid-template-columns: repeat(7, var(--man-col-width)); column-gap: var(--man-col-gap); justify-content: start; align-items: center; }
+.man-values b { width: var(--man-col-width); text-align: center; font-size: 1.05rem; line-height: 1; font-variant-numeric: tabular-nums; }
+.dmg-stop {
+  width: 12px;
+  height: 12px;
+  border: 2px solid #111;
+  box-sizing: border-box;
+  display: inline-block;
+  justify-self: center;
+  align-self: center;
+}
+.dmg-stop.is-inactive { visibility: hidden; }


### PR DESCRIPTION
### Motivation
- The maneuver preview dropped one column and misaligned values at some screen scales, preventing the full sublight speed range `0–6` from displaying correctly.
- The layout relied on flexible inline sizing which produced visual drift as zoom/scale changed.

### Description
- Restored the preview to render the last seven values by setting `previewColumns = 7` and slicing `spd`, `turns`, and `dmgStops` in `renderManeuvering` (`starforce-commander-ship-designer/app.js`).
- Replaced the textual DMG box characters with structured elements and classes, rendering damage markers as `<span class="dmg-stop">` and toggling inactive state with the `is-inactive` class (`app.js`).
- Reworked maneuver CSS to use fixed column widths and a dedicated label column by introducing `--man-label-width`, `--man-col-width`, and `--man-col-gap`, switching rows to a small grid for consistent alignment, and enabling tabular numerals for stable digit spacing (`starforce-commander-ship-designer/styles.css`).
- Added explicit styling for `.dmg-stop` and kept inactive boxes hidden via `visibility: hidden` so spacing is preserved while inactive markers are not visible (`styles.css`).

### Testing
- Served the app locally with `python3 -m http.server 4173` and confirmed resources loaded successfully (server run completed). (succeeded)
- Ran a Playwright script that populated representative sublight turn/damage inputs and captured a verification screenshot (`artifacts/sublight-layout-7cols.png`) to validate 7-column layout and alignment. (succeeded)
- Committed the changes to the repository with `git` after verification. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69912e019f488332af9f99c283d4d749)