### PR TITLE
Add padding to vertical PORT/STBD labels and remove leading zeros from shield values

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -227,10 +227,10 @@ function renderPreview(build) {
   document.getElementById('pvTurn').textContent = build.engineering.turn;
   document.getElementById('pvSpecial').textContent = build.engineering.special;
 
-  document.getElementById('pvShieldFwd').textContent = String(build.shields.forward).padStart(2, '0');
-  document.getElementById('pvShieldAft').textContent = String(build.shields.aft).padStart(2, '0');
-  document.getElementById('pvShieldPort').textContent = String(build.shields.port).padStart(2, '0');
-  document.getElementById('pvShieldStbd').textContent = String(build.shields.starboard).padStart(2, '0');
+  document.getElementById('pvShieldFwd').textContent = String(build.shields.forward);
+  document.getElementById('pvShieldAft').textContent = String(build.shields.aft);
+  document.getElementById('pvShieldPort').textContent = String(build.shields.port);
+  document.getElementById('pvShieldStbd').textContent = String(build.shields.starboard);
 
   const blackGenRow = document.getElementById('pvShieldGenBlackBoxes');
   blackGenRow.innerHTML = '';

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -102,9 +102,9 @@ button.ghost { background: #273055; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
 
 .middle-col { border: 3px solid #10a5df; background: #14a7de; padding: 0.15rem; }
-.shield-frame { position: relative; border: 3px solid #10a5df; background: #14a7de; padding: 0.18rem 2rem 0.12rem; }
-.shield-inner { position: relative; z-index: 1; overflow: visible; background: #fff; border: 2px solid #fff; }
-.shield-top, .shield-bottom { background: #17a8df; color: #fff; text-align: center; font-weight: 900; padding: 0.12rem; font-size: 0.95rem; }
+.shield-frame { position: relative; border: 3px solid #10a5df; background: #14a7de; padding: 0.18rem 1rem 0.12rem; }
+.shield-inner { position: relative; z-index: 1; overflow: visible; background: #ececec; border: 2px solid #ececec; }
+.shield-top, .shield-bottom { background: #17a8df; color: #fff; text-align: center; font-weight: 900; padding: 0.12rem; font-size: 0.95rem; letter-spacing: 0.03em; }
 .shield-top { margin-bottom: 0.12rem; }
 .shield-bottom { margin-top: 0.12rem; }
 .shield-box-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.12rem 0.35rem; min-height: 20px; justify-content: center; }
@@ -132,7 +132,7 @@ button.ghost { background: #273055; }
   background: #eee;
 }
 
-.shield-body { position: relative; height: 385px; background: #fff; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.shield-body { position: relative; height: 385px; background: #ececec; display: flex; align-items: center; justify-content: center; overflow: hidden; }
 .ship-art-wrap { width: 76%; height: 100%; max-height: 100%; display: flex; align-items: center; justify-content: center; overflow: hidden; }
 .ship-art { width: 100%; height: 100%; object-fit: contain; display: none; filter: saturate(0.9) contrast(1.02); }
 .ship-silhouette { width: 58%; height: 82%; background: linear-gradient(180deg,#d8d8d8,#b5b5b5); border: 3px solid #121212; border-radius: 46% 46% 30% 30% / 58% 58% 42% 42%; }
@@ -159,25 +159,32 @@ button.ghost { background: #273055; }
 .side-label {
   position: absolute;
   top: 50%;
+  transform: translateY(-50%);
   color: #fff;
-  background: #16a7dd;
-  padding: 0.2rem 0.35rem;
   font-weight: 900;
-  font-size: 0.82rem;
-  white-space: nowrap;
+  font-size: 1rem;
   line-height: 1;
   z-index: 3;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  letter-spacing: 0.04em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.2rem 0.08rem;
+}
+
+.side-label b {
+  font-size: 1rem;
+  line-height: 1;
 }
 
 .side-label-port {
-  left: 0.35rem;
-  transform: translateY(-50%) rotate(-90deg);
-  transform-origin: center;
+  left: 0.08rem;
+  transform: translateY(-50%) rotate(180deg);
 }
 .side-label-stbd {
-  right: 0.35rem;
-  transform: translateY(-50%) rotate(90deg);
-  transform-origin: center;
+  right: 0.08rem;
 }
 .shield-box-col, .shield-gen-col {
   display: flex;


### PR DESCRIPTION
### Motivation
- Improve label readability by giving the vertical `PORT`/`STBD` text more breathing room and present shield numbers naturally without forced two-digit formatting.

### Description
- Modified `starforce-commander-ship-designer/styles.css` to add `padding: 0.2rem 0.08rem` and unify vertical label styling on `.side-label` so the side-facing labels sit clear of the frame edge, and updated `starforce-commander-ship-designer/app.js` to remove `.padStart(2, '0')` so `pvShieldFwd`, `pvShieldAft`, `pvShieldPort`, and `pvShieldStbd` use `String(...)` directly.

### Testing
- Executed a Playwright script that filled shield inputs and saved `artifacts/shields-area-v2.png`, which ran successfully and produced the screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d4434a6483329cbaa5df958fa680)