### PR TITLE
Render battery power points as green rings in Power System preview

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -64,7 +64,20 @@
 
         <h2>Functions / Power / Maneuvering</h2>
         <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
-        <label>Power System <textarea name="powerSystem" rows="3" placeholder="L MAIN, R MAIN, BATTERY..."></textarea></label>
+        <div class="power-system-editor">
+          <strong>Power System Tracks</strong>
+          <p class="muted">Set points per track and structure boxes per point (1-3). Tracks with 0 points are hidden.</p>
+          <div class="power-grid-head"><span>Track</span><span>Points</span><span>Boxes/Point</span></div>
+          <div class="power-grid">
+            <label>L MAIN</label><input name="powerLMainPoints" type="number" min="0" value="4" /><input name="powerLMainBoxes" type="number" min="1" max="3" value="2" />
+            <label>R MAIN</label><input name="powerRMainPoints" type="number" min="0" value="4" /><input name="powerRMainBoxes" type="number" min="1" max="3" value="2" />
+            <label>C MAIN</label><input name="powerCMainPoints" type="number" min="0" value="4" /><input name="powerCMainBoxes" type="number" min="1" max="3" value="2" />
+            <label>SL REAC</label><input name="powerSlReacPoints" type="number" min="0" value="1" /><input name="powerSlReacBoxes" type="number" min="1" max="3" value="2" />
+            <label>AUX PWR</label><input name="powerAuxPwrPoints" type="number" min="0" value="1" /><input name="powerAuxPwrBoxes" type="number" min="1" max="3" value="2" />
+            <label>BATTERY</label><input name="powerBatteryPoints" type="number" min="0" value="2" /><input name="powerBatteryBoxes" type="number" min="1" max="3" value="1" />
+            <label>FTL DRIVE</label><input name="powerFtlDrivePoints" type="number" min="0" value="1" /><input name="powerFtlDriveBoxes" type="number" min="1" max="3" value="3" />
+          </div>
+        </div>
         <div class="maneuver-editor">
           <strong>Sublight Drive & Maneuvering</strong>
           <div class="grid3">
@@ -130,7 +143,7 @@
             </div>
             <div class="green-block block-power">
               <h4>POWER SYSTEM</h4>
-              <pre id="pvPowerSystem"></pre>
+              <div id="pvPowerTracks" class="power-track-list"></div>
             </div>
             <div class="green-block block-maneuver">
               <h4>SUBLIGHT DRIVE AND MANEUVERING</h4>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -22,6 +22,13 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .maneuver-grid label { margin: 0; font-weight: 700; }
 .maneuver-grid input[type="checkbox"] { width: 20px; height: 20px; margin: 0; justify-self: start; }
 .maneuver-grid input[type="number"] { margin: 0; }
+.power-system-editor { border: 1px solid #32427a; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #0f1731; }
+.power-system-editor strong { display: block; margin-bottom: 0.2rem; }
+.power-system-editor .muted { margin: 0 0 0.5rem; font-size: 0.82rem; }
+.power-grid-head, .power-grid { display: grid; grid-template-columns: minmax(0, 1fr) 74px 96px; gap: 0.4rem; align-items: center; }
+.power-grid-head { margin: 0.2rem 0; color: #a7b4da; font-size: 0.78rem; }
+.power-grid label { margin: 0; font-weight: 700; }
+.power-grid input { margin: 0; }
 button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
 button.ghost { background: #273055; }
 .muted { color: #a7b4da; }
@@ -94,7 +101,6 @@ button.ghost { background: #273055; }
 }
 
 .block-functions pre { height: 220px; max-height: 220px; overflow: auto; }
-.block-power pre { height: 200px; max-height: 200px; overflow: auto; }
 .block-maneuver { display: flex; flex-direction: column; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
@@ -105,6 +111,14 @@ button.ghost { background: #273055; }
 .green-block { border: 2px solid #02a45c; background: #f0f0f0; margin-bottom: 0.2rem; }
 .green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
+.power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.18rem; font-size: 0.72rem; font-weight: 700; }
+.power-track-name { text-transform: uppercase; white-space: nowrap; }
+.power-track-units { display: flex; flex-wrap: wrap; gap: 0.34rem; }
+.power-unit { display: inline-flex; align-items: center; gap: 0.15rem; }
+.power-dot { width: 10px; height: 10px; border: 2px solid #09a84f; border-radius: 50%; background: #09a84f; box-sizing: border-box; }
+.power-dot.is-ring { background: transparent; }
+.power-box { width: 10px; height: 10px; border: 3px solid #111; box-sizing: border-box; background: #f2f2f2; }
 
 .middle-col { border: 3px solid #10a5df; background: #14a7de; padding: 0.15rem; }
 .shield-frame { position: relative; border: 3px solid #10a5df; background: #14a7de; padding: 0.18rem 1rem 0.12rem; }


### PR DESCRIPTION
### Motivation
- Make the BATTERY power points render as a green ring (outline with transparent center) in the Power System preview to match the requested visual style.

### Description
- Added a conditional modifier class in `renderPowerSystem` so battery points use `power-dot is-ring`, and added a CSS rule in `styles.css` to make `.power-dot.is-ring` transparent in the center while keeping the green border (changes in `starforce-commander-ship-designer/app.js` and `starforce-commander-ship-designer/styles.css`).

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js`, which completed successfully.
- Served the app via `python3 -m http.server 4173` and captured a Playwright screenshot of the preview page, which visually confirmed BATTERY circles render as rings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699908e211348332939a9175f9f15a3e)