### PR TITLE
Add patterned power boxes and optional per-track dot markers

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -64,7 +64,20 @@
 
         <h2>Functions / Power / Maneuvering</h2>
         <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
-        <label>Power System <textarea name="powerSystem" rows="3" placeholder="L MAIN, R MAIN, BATTERY..."></textarea></label>
+        <div class="power-system-editor">
+          <strong>Power System Tracks</strong>
+          <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
+          <div class="power-grid-head"><span>Track</span><span>Points</span><span>Boxes/Point</span><span>Pattern</span><span>Dot</span></div>
+          <div class="power-grid">
+            <label>L MAIN</label><input name="powerLMainPoints" type="number" min="0" value="4" /><input name="powerLMainBoxes" type="number" min="1" max="3" value="2" /><input name="powerLMainPattern" value="" placeholder="1,2,1,2" /><input name="powerLMainHasDot" type="checkbox" checked />
+            <label>R MAIN</label><input name="powerRMainPoints" type="number" min="0" value="4" /><input name="powerRMainBoxes" type="number" min="1" max="3" value="2" /><input name="powerRMainPattern" value="" placeholder="1,2,1,2" /><input name="powerRMainHasDot" type="checkbox" checked />
+            <label>C MAIN</label><input name="powerCMainPoints" type="number" min="0" value="0" /><input name="powerCMainBoxes" type="number" min="1" max="3" value="2" /><input name="powerCMainPattern" value="" placeholder="1,2,1,2" /><input name="powerCMainHasDot" type="checkbox" checked />
+            <label>SL REAC</label><input name="powerSlReacPoints" type="number" min="0" value="1" /><input name="powerSlReacBoxes" type="number" min="1" max="3" value="2" /><input name="powerSlReacPattern" value="" placeholder="1,2,1,2" /><input name="powerSlReacHasDot" type="checkbox" checked />
+            <label>AUX PWR</label><input name="powerAuxPwrPoints" type="number" min="0" value="1" /><input name="powerAuxPwrBoxes" type="number" min="1" max="3" value="2" /><input name="powerAuxPwrPattern" value="" placeholder="1,2,1,2" /><input name="powerAuxPwrHasDot" type="checkbox" checked />
+            <label>BATTERY</label><input name="powerBatteryPoints" type="number" min="0" value="1" /><input name="powerBatteryBoxes" type="number" min="1" max="3" value="1" /><input name="powerBatteryPattern" value="" placeholder="1,2,1,2" /><input name="powerBatteryHasDot" type="checkbox" checked />
+            <label>FTL DRIVE</label><input name="powerFtlDrivePoints" type="number" min="0" value="1" /><input name="powerFtlDriveBoxes" type="number" min="1" max="3" value="2" /><input name="powerFtlDrivePattern" value="" placeholder="1,2,1,2" /><input name="powerFtlDriveHasDot" type="checkbox" />
+          </div>
+        </div>
         <div class="maneuver-editor">
           <strong>Sublight Drive & Maneuvering</strong>
           <div class="grid3">
@@ -129,8 +142,8 @@
               <pre id="pvFunctions"></pre>
             </div>
             <div class="green-block block-power">
-              <h4>POWER SYSTEM</h4>
-              <pre id="pvPowerSystem"></pre>
+              <h4><span>POWER SYSTEM</span><span id="pvMaxPower"></span></h4>
+              <div id="pvPowerTracks" class="power-track-list"></div>
             </div>
             <div class="green-block block-maneuver">
               <h4>SUBLIGHT DRIVE AND MANEUVERING</h4>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -22,6 +22,14 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .maneuver-grid label { margin: 0; font-weight: 700; }
 .maneuver-grid input[type="checkbox"] { width: 20px; height: 20px; margin: 0; justify-self: start; }
 .maneuver-grid input[type="number"] { margin: 0; }
+.power-system-editor { border: 1px solid #32427a; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #0f1731; }
+.power-system-editor strong { display: block; margin-bottom: 0.2rem; }
+.power-system-editor .muted { margin: 0 0 0.5rem; font-size: 0.82rem; }
+.power-grid-head, .power-grid { display: grid; grid-template-columns: minmax(0, 1fr) 74px 96px minmax(0, 1fr) 44px; gap: 0.4rem; align-items: center; }
+.power-grid-head { margin: 0.2rem 0; color: #a7b4da; font-size: 0.78rem; }
+.power-grid label { margin: 0; font-weight: 700; }
+.power-grid input { margin: 0; }
+.power-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: center; }
 button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
 button.ghost { background: #273055; }
 .muted { color: #a7b4da; }
@@ -94,7 +102,6 @@ button.ghost { background: #273055; }
 }
 
 .block-functions pre { height: 220px; max-height: 220px; overflow: auto; }
-.block-power pre { height: 200px; max-height: 200px; overflow: auto; }
 .block-maneuver { display: flex; flex-direction: column; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
@@ -104,7 +111,32 @@ button.ghost { background: #273055; }
 .stat-tag { color: #b8b8b8 !important; background: #e9eef3 !important; border-color: #10a5df !important; }
 .green-block { border: 2px solid #02a45c; background: #f0f0f0; margin-bottom: 0.2rem; }
 .green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
+.block-power h4 span:last-child { color: #d8ffd8; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
+.power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.2rem; font-size: 0.72rem; font-weight: 700; }
+.power-track-name { text-transform: uppercase; white-space: nowrap; }
+.power-track-units { display: flex; flex-wrap: wrap; gap: 0.38rem; }
+.power-unit { display: inline-flex; align-items: center; gap: 0.2rem; }
+.power-dot {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #09a84f;
+  border-radius: 50%;
+  background: #09a84f;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+}
+.power-dot.is-ring { background: transparent; border-width: 3px; }
+.power-box {
+  width: 14px;
+  height: 14px;
+  border: 3px solid #111;
+  box-sizing: border-box;
+  background: #f2f2f2;
+  display: inline-block;
+  flex: 0 0 auto;
+}
 
 .middle-col { border: 3px solid #10a5df; background: #14a7de; padding: 0.15rem; }
 .shield-frame { position: relative; border: 3px solid #10a5df; background: #14a7de; padding: 0.18rem 1rem 0.12rem; }


### PR DESCRIPTION
### Motivation
- Allow per-point box patterns (e.g. `1,2,1,2`) so reactor tracks can alternate box counts across points. 
- Provide an option to omit the green circle/dot per track so items like FTL DRIVE can show boxes without a dot. 
- Surface a small live summary of available power in the preview for easier visual validation (`MAX POWER`).

### Description
- Added a `POWER_TRACK_CONFIG` table and new fields per track (`patternField`, `hasDotField`) and replaced the freeform `powerSystem` textarea with a structured editor in `index.html` including `Pattern` and `Dot` controls and sensible defaults (e.g. `C MAIN` default `0`, `BATTERY` default `1`, `FTL DRIVE` default no dot and `2` boxes). 
- Implemented `parsePowerPattern()` and updated `readPowerSystem()` to parse per-track `boxPattern` and `hasDot`, and included `powerSystem` in `getBuild()` so patterns persist in the build object. 
- Replaced the old text preview with `renderPowerSystem()` which renders per-track rows, applies cycled `boxPattern` values for each point, respects `hasDot` to optionally omit dots (battery still renders as ring via `.is-ring`), and writes a `MAX POWER:base+battery` summary. 
- Updated `restoreDraft()` to restore `boxPattern` and `hasDot`, and updated CSS (`styles.css`) to add the editor grid column, checkbox sizing, and styling for `.power-track-*`, `.power-dot`, `.power-box` and `.power-unit` so markers are visible and non-shrinking.

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` which completed successfully. 
- Served the app with `python3 -m http.server 4173` and performed a live verification using Playwright to populate patterns and capture a screenshot. 
- Playwright capture `artifacts/power-pattern-ftl-no-dot.png` confirmed L/R `1,2,1,2` pattern rendering, FTL DRIVE rendered without a dot, and battery retained ring styling, all as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699908e211348332939a9175f9f15a3e)