### PR TITLE
Add configurable FUNCTIONS track editor and SSD preview rendering

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -63,7 +63,23 @@
         <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
 
         <h2>Functions / Power / Maneuvering</h2>
-        <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
+        <div class="functions-editor">
+          <strong>Functions Tracks</strong>
+          <p class="muted">Tune power levels and free pips for the Engineering FUNCTIONS block.</p>
+          <div class="functions-grid-head"><span>Function</span><span>Levels</span><span>Free Pips</span><span>Extra</span></div>
+          <div class="functions-grid">
+            <label>ACC/DEC</label><input name="fnAccDecLevels" type="number" min="1" max="9" value="7" /><input name="fnAccDecFree" type="number" min="0" max="3" value="0" /><span></span>
+            <label>SIF/IDF</label><input name="fnSifIdfLevels" type="number" min="1" max="6" value="4" /><input name="fnSifIdfFree" type="number" min="0" max="3" value="0" /><label class="inline-check">EMER <input name="fnSifIdfEmer" type="checkbox" checked /></label>
+            <label>BAT RECH</label><input name="fnBatRechLevels" type="number" min="1" max="5" value="3" /><input name="fnBatRechFree" type="number" min="0" max="3" value="0" /><span></span>
+            <label>FTL</label><input name="fnFtlLevels" type="number" min="0" max="5" value="3" /><input name="fnFtlFree" type="number" min="0" max="3" value="0" /><span></span>
+            <label>OTHER</label><input name="fnOtherLevels" type="number" min="0" max="5" value="3" /><input name="fnOtherFree" type="number" min="0" max="3" value="0" /><span></span>
+            <label>SENSOR</label><input name="fnSensorLevels" type="number" min="0" max="5" value="3" /><input name="fnSensorFree" type="number" min="0" max="3" value="1" /><span class="muted tiny">future tuning</span>
+            <label>GEN SYS</label><input name="fnGenSysLevels" type="number" min="1" max="3" value="2" /><input name="fnGenSysFree" type="number" min="0" max="2" value="1" /><span></span>
+            <label>WPN A</label><input name="fnWpnALevels" type="number" min="0" max="6" value="4" /><input name="fnWpnAFree" type="number" min="0" max="3" value="0" /><input name="fnWpnAEndRound" type="number" min="0" max="6" value="0" />
+            <label>WPN B</label><input name="fnWpnBLevels" type="number" min="0" max="6" value="4" /><input name="fnWpnBFree" type="number" min="0" max="3" value="0" /><input name="fnWpnBEndRound" type="number" min="0" max="6" value="0" />
+            <label>WPN C</label><input name="fnWpnCLevels" type="number" min="0" max="6" value="4" /><input name="fnWpnCFree" type="number" min="0" max="3" value="0" /><input name="fnWpnCEndRound" type="number" min="0" max="6" value="0" />
+          </div>
+        </div>
         <div class="power-system-editor">
           <strong>Power System Tracks</strong>
           <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
@@ -139,7 +155,7 @@
             </div>
             <div class="green-block block-functions">
               <h4><span>FUNCTIONS</span><span>POWER LEVEL</span></h4>
-              <pre id="pvFunctions"></pre>
+              <div id="pvFunctions" class="functions-preview"></div>
             </div>
             <div class="green-block block-power">
               <h4><span>POWER SYSTEM</span><span id="pvMaxPower"></span></h4>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -30,6 +30,16 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .power-grid label { margin: 0; font-weight: 700; }
 .power-grid input { margin: 0; }
 .power-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: center; }
+.functions-editor { border: 1px solid #32427a; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #0f1731; }
+.functions-editor strong { display: block; margin-bottom: 0.2rem; }
+.functions-editor .muted { margin: 0 0 0.5rem; font-size: 0.82rem; }
+.functions-grid-head, .functions-grid { display: grid; grid-template-columns: minmax(0, 1.2fr) 74px 74px minmax(0, 1fr); gap: 0.4rem; align-items: center; }
+.functions-grid-head { margin: 0.2rem 0; color: #a7b4da; font-size: 0.78rem; }
+.functions-grid label { margin: 0; font-weight: 700; }
+.functions-grid input { margin: 0; }
+.inline-check { display: inline-flex !important; align-items: center; gap: 0.4rem; font-weight: 700; }
+.inline-check input { width: 18px; margin: 0; }
+.tiny { font-size: 0.72rem; }
 button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
 button.ghost { background: #273055; }
 .muted { color: #a7b4da; }
@@ -101,7 +111,7 @@ button.ghost { background: #273055; }
   min-height: 920px;
 }
 
-.block-functions pre { height: 220px; max-height: 220px; overflow: auto; }
+.functions-preview { height: 220px; max-height: 220px; overflow: auto; padding: 0.2rem 0.35rem 0.28rem; color: #111; font-family: Arial, Helvetica, sans-serif; }
 .block-maneuver { display: flex; flex-direction: column; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
@@ -113,6 +123,24 @@ button.ghost { background: #273055; }
 .green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
 .block-power h4 span:last-child { color: #d8ffd8; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.fn-row { display: grid; grid-template-columns: 120px minmax(0, 1fr); align-items: center; gap: 0.35rem; margin-bottom: 0.2rem; font-weight: 900; font-size: 0.72rem; }
+.fn-name { text-transform: uppercase; }
+.fn-name.magenta { color: #d31ce0; }
+.fn-name.cyan { color: #08a7df; }
+.fn-name.gold { color: #e3ab00; }
+.fn-name.red { color: #ff0000; }
+.fn-levels { display: flex; flex-wrap: wrap; align-items: center; gap: 0.24rem; font-weight: 900; }
+.fn-token { display: inline-flex; align-items: center; justify-content: center; min-width: 12px; }
+.fn-dot {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #09a84f;
+  border-radius: 50%;
+  box-sizing: border-box;
+  display: inline-block;
+}
+.fn-dot.filled { background: #09a84f; }
+.fn-end-round { font-size: 0.65rem; margin-left: 0.35rem; color: #2f2f2f; }
 .power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
 .power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.2rem; font-size: 0.72rem; font-weight: 700; }
 .power-track-name { text-transform: uppercase; white-space: nowrap; }


### PR DESCRIPTION
### Motivation
- Replace the old freeform FUNCTIONS textarea with a structured editor so designers can precisely configure function tracks, free pips, and per-weapon end-of-round readiness in the Engineering FUNCTIONS block. 
- Provide a rendered FUNCTIONS preview that matches the SSD-style dot/token rows (including static SHLD RNFC/REPR rows and a pluggable SENSOR/GEN SYS representation) for better visual fidelity.

### Description
- Replaced the freeform Functions textarea in `index.html` with a new `functions-editor` grid of inputs for ACC/DEC, SIF/IDF (with EMER), BAT RECH, FTL, OTHER, SENSOR, GEN SYS and WPN A/B/C (including an end-of-round numeric control), and switched the preview `pvFunctions` to a renderable container. 
- Added styling in `styles.css` for the functions editor and the preview rows/dots/tokens (`.functions-editor`, `.functions-grid`, `.functions-preview`, `.fn-row`, `.fn-dot`, etc.) to match SSD look and keep readability. 
- Implemented `readFunctionsConfig()` and `renderFunctions()` in `app.js`, wired `functionsConfig` into `getBuild()` and the draft restore/export flows, and updated `renderPreview()` to call the new renderer so the preview is built from structured data. 
- Render logic includes static SHLD RNFC/REPR rows, SENSOR and GEN SYS handling, per-weapon rows with free pips and optional EOR (`EOR:nn`) annotation, and preserves existing power system and maneuver rendering.

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` to validate syntax and the new functions code, which completed successfully. 
- Launched a simple HTTP server with `python -m http.server 8000 --directory /workspace/CrazyVulcan.github.io` and used Playwright to open `http://127.0.0.1:8000/starforce-commander-ship-designer/index.html` and capture a screenshot, which succeeded and produced an artifact showing the new editor and preview. 
- Confirmed drafts restore and export paths include `functionsConfig` by exercising the UI and observing the preview update via the same Playwright inspection step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699910322fd88332b3ce1cf19f7504bf)