### PR TITLE
Refine FUNCTIONS mockup to better emulate real game sample

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -63,7 +63,22 @@
         <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
 
         <h2>Functions / Power / Maneuvering</h2>
-        <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
+        <div class="functions-editor">
+          <strong>Functions Tracks</strong>
+          <p class="muted">Use comma-separated values for exact power levels. Free pips render as filled green dots.</p>
+          <div class="functions-grid-head"><span>Function</span><span>Values</span><span>Free</span><span>Extra</span></div>
+          <div class="functions-grid">
+            <label>ACC/DEC</label><input name="fnAccDecValues" value="1,2,3,4,5,6" /><input name="fnAccDecFree" type="number" min="0" max="4" value="1" /><span></span>
+            <label>SIF/IDF</label><input name="fnSifIdfValues" value="1,2,3" /><input name="fnSifIdfFree" type="number" min="0" max="4" value="0" /><label class="inline-check">EMER <input name="fnSifIdfEmer" type="checkbox" checked /></label>
+            <label>BAT RECH</label><input name="fnBatRechValues" value="1" /><input name="fnBatRechFree" type="number" min="0" max="4" value="0" /><span></span>
+            <label>WARP</label><input name="fnWarpValues" value="" /><input name="fnWarpFree" type="number" min="0" max="4" value="3" /><span></span>
+            <label>SENSOR</label><input name="fnSensorValues" value="2,4,6" /><input name="fnSensorFree" type="number" min="0" max="3" value="1" /><span class="muted tiny">placeholder</span>
+            <label>GEN SYS</label><input name="fnGenSysValues" value="NRM,MAX" /><input name="fnGenSysFree" type="number" min="0" max="3" value="1" /><span></span>
+            <label>WPN A</label><input name="fnWpnALabel" value="A/MAT TRP" /><input name="fnWpnAFree" type="number" min="0" max="3" value="0" /><input name="fnWpnAValues" value="2" placeholder="values" />
+            <label>WPN B</label><input name="fnWpnBLabel" value="T-37 DISR" /><input name="fnWpnBFree" type="number" min="0" max="3" value="1" /><input name="fnWpnBValues" value="2" placeholder="values" />
+            <label>WPN C</label><input name="fnWpnCLabel" value="T-31 DISR" /><input name="fnWpnCFree" type="number" min="0" max="3" value="1" /><input name="fnWpnCValues" value="3,5" placeholder="values" />
+          </div>
+        </div>
         <div class="power-system-editor">
           <strong>Power System Tracks</strong>
           <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
@@ -139,7 +154,7 @@
             </div>
             <div class="green-block block-functions">
               <h4><span>FUNCTIONS</span><span>POWER LEVEL</span></h4>
-              <pre id="pvFunctions"></pre>
+              <div id="pvFunctions" class="functions-preview"></div>
             </div>
             <div class="green-block block-power">
               <h4><span>POWER SYSTEM</span><span id="pvMaxPower"></span></h4>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -30,6 +30,16 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .power-grid label { margin: 0; font-weight: 700; }
 .power-grid input { margin: 0; }
 .power-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: center; }
+.functions-editor { border: 1px solid #32427a; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #0f1731; }
+.functions-editor strong { display: block; margin-bottom: 0.2rem; }
+.functions-editor .muted { margin: 0 0 0.5rem; font-size: 0.82rem; }
+.functions-grid-head, .functions-grid { display: grid; grid-template-columns: minmax(0, 1.2fr) 74px 74px minmax(0, 1fr); gap: 0.4rem; align-items: center; }
+.functions-grid-head { margin: 0.2rem 0; color: #a7b4da; font-size: 0.78rem; }
+.functions-grid label { margin: 0; font-weight: 700; }
+.functions-grid input { margin: 0; }
+.inline-check { display: inline-flex !important; align-items: center; gap: 0.4rem; font-weight: 700; }
+.inline-check input { width: 18px; margin: 0; }
+.tiny { font-size: 0.72rem; }
 button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
 button.ghost { background: #273055; }
 .muted { color: #a7b4da; }
@@ -101,7 +111,7 @@ button.ghost { background: #273055; }
   min-height: 920px;
 }
 
-.block-functions pre { height: 220px; max-height: 220px; overflow: auto; }
+.functions-preview { height: 220px; max-height: 220px; overflow: auto; padding: 0.2rem 0.35rem 0.28rem; color: #111; font-family: Arial, Helvetica, sans-serif; }
 .block-maneuver { display: flex; flex-direction: column; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
@@ -113,6 +123,25 @@ button.ghost { background: #273055; }
 .green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
 .block-power h4 span:last-child { color: #d8ffd8; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.fn-row { display: grid; grid-template-columns: 120px minmax(0, 1fr); align-items: center; gap: 0.35rem; margin-bottom: 0.12rem; font-weight: 900; font-size: 0.75rem; }
+.fn-name { text-transform: uppercase; letter-spacing: 0.01em; }
+.fn-name.green { color: #0aa14e; }
+.fn-name.magenta { color: #d31ce0; }
+.fn-name.cyan { color: #08a7df; }
+.fn-name.gold { color: #e3ab00; }
+.fn-name.red { color: #ff0000; }
+.fn-levels { display: flex; flex-wrap: wrap; align-items: center; gap: 0.24rem; font-weight: 900; }
+.fn-token { display: inline-flex; align-items: center; justify-content: center; min-width: 12px; }
+.fn-dot {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #09a84f;
+  border-radius: 50%;
+  box-sizing: border-box;
+  display: inline-block;
+}
+.fn-dot.filled { background: #09a84f; }
+.fn-end-round { font-size: 0.65rem; margin-left: 0.35rem; color: #2f2f2f; }
 .power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
 .power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.2rem; font-size: 0.72rem; font-weight: 700; }
 .power-track-name { text-transform: uppercase; white-space: nowrap; }


### PR DESCRIPTION
### Motivation
- Replace the previous freeform FUNCTIONS textarea with a structured, value-driven editor so function tracks can express non-linear/sparse levels and independent free pips like the real SSD sample.
- Provide a preview renderer that draws filled free pips and open-dot + token pairs from configured values and includes static SHLD RNFC/REPR rows and SIF/IDF EMER support for closer visual fidelity.

### Description
- Replaced the freeform functions textarea with a `functions-editor` grid in `index.html` to accept comma-separated value lists, per-track free pip counts, and editable weapon labels/values.
- Added `parseFunctionValues()` and `readFunctionsConfig()` to `app.js` and wired `functionsConfig` into `getBuild()` and the draft restore flow so structured function data persists and restores.
- Implemented `renderFunctions()` in `app.js` to render rows (filled free dots, open-dot + token pairs, EMER token, static SHLD RNFC/REPR) and switched the preview container to a renderable `div` (`.functions-preview`).
- Tuned CSS in `styles.css` for denser function row spacing, color classes, and dot/token styling to better match the provided game sample.

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` to validate JavaScript syntax and it completed successfully.
- Launched a local HTTP server with `python -m http.server 8001 --directory /workspace/CrazyVulcan.github.io` and verified the page loaded for visual testing.
- Captured a Playwright screenshot of `/starforce-commander-ship-designer/index.html` to confirm the new editor and preview render correctly (screenshot generation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699910322fd88332b3ce1cf19f7504bf)