### PR TITLE
Add per-weapon power-level count controls to FUNCTIONS editor

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -65,6 +65,54 @@ function parsePowerPattern(raw) {
     .map((value) => clamp(Math.round(value), 1, 3));
 }
 
+
+
+function parseFunctionValues(raw) {
+  return String(raw || '')
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function readFunctionsConfig() {
+  const batteryPoints = Math.max(0, num('powerBatteryPoints'));
+  const batteryValues = Array.from({ length: batteryPoints }, (_, idx) => String(idx + 1));
+
+  return {
+    accDec: { values: parseFunctionValues(form.elements.fnAccDecValues?.value), free: clamp(num('fnAccDecFree'), 0, 4) },
+    sifIdf: {
+      values: parseFunctionValues(form.elements.fnSifIdfValues?.value),
+      free: clamp(num('fnSifIdfFree'), 0, 4),
+      emer: Boolean(form.elements.fnSifIdfEmer?.checked)
+    },
+    batRech: { values: batteryValues, free: 0 },
+    ftl: { empty: clamp(num('fnFtlEmpty'), 0, 6) },
+    cloak: { enabled: Boolean(form.elements.fnCloakEnabled?.checked), empty: clamp(num('fnCloakEmpty'), 0, 6) },
+    sensor: { values: parseFunctionValues(form.elements.fnSensorValues?.value), free: clamp(num('fnSensorFree'), 0, 3) },
+    genSys: { values: parseFunctionValues(form.elements.fnGenSysValues?.value), free: clamp(num('fnGenSysFree'), 0, 3) },
+    weapons: [
+      {
+        label: form.elements.fnWpnALabel?.value || 'WPN A',
+        values: parseFunctionValues(form.elements.fnWpnAValues?.value),
+        free: clamp(num('fnWpnAFree'), 0, 3),
+        levels: clamp(num('fnWpnALevels'), 0, 8)
+      },
+      {
+        label: form.elements.fnWpnBLabel?.value || 'WPN B',
+        values: parseFunctionValues(form.elements.fnWpnBValues?.value),
+        free: clamp(num('fnWpnBFree'), 0, 3),
+        levels: clamp(num('fnWpnBLevels'), 0, 8)
+      },
+      {
+        label: form.elements.fnWpnCLabel?.value || 'WPN C',
+        values: parseFunctionValues(form.elements.fnWpnCValues?.value),
+        free: clamp(num('fnWpnCFree'), 0, 3),
+        levels: clamp(num('fnWpnCLevels'), 0, 8)
+      }
+    ]
+  };
+}
+
 function readPowerSystem() {
   return {
     tracks: POWER_TRACK_CONFIG.map((track) => ({
@@ -76,6 +124,13 @@ function readPowerSystem() {
       hasDot: Boolean(form.elements[track.hasDotField]?.checked)
     }))
   };
+}
+
+
+function syncDerivedFunctionInputs() {
+  if (form.elements.fnBatRechLinked) {
+    form.elements.fnBatRechLinked.value = `Linked to BATTERY points (${num('powerBatteryPoints')})`;
+  }
 }
 
 function getBuild() {
@@ -107,9 +162,9 @@ function getBuild() {
     },
     shieldGen: num('shieldGen'),
     textBlocks: {
-      functions: form.elements.functions.value,
       powerSystem: form.elements.powerSystem?.value ?? ''
     },
+    functionsConfig: readFunctionsConfig(),
     powerSystem: readPowerSystem(),
     sublight: readSublight(),
     structure: {
@@ -306,7 +361,7 @@ function renderPreview(build) {
     silhouetteEl.style.display = 'block';
   }
 
-  document.getElementById('pvFunctions').textContent = build.textBlocks.functions;
+  renderFunctions(build.functionsConfig);
   renderPowerSystem(build.powerSystem);
   renderManeuvering(build.sublight);
 
@@ -318,6 +373,113 @@ function renderPreview(build) {
   const systemsText = build.systems.map((entry) => `${entry.key} ${entry.value}`.trim()).join('\n');
   document.getElementById('pvSystems').textContent = systemsText;
   renderStructure(build);
+}
+
+
+
+function renderFunctions(functionsConfig) {
+  const container = document.getElementById('pvFunctions');
+  container.innerHTML = '';
+  const cfg = functionsConfig || {};
+
+  const addDot = (parent, filled = false) => {
+    const dot = document.createElement('span');
+    dot.className = `fn-dot${filled ? ' filled' : ''}`;
+    parent.appendChild(dot);
+  };
+
+  const addToken = (parent, text) => {
+    const tok = document.createElement('span');
+    tok.className = 'fn-token';
+    tok.textContent = text;
+    parent.appendChild(tok);
+  };
+
+  const addRow = (name, colorClass = '') => {
+    const row = document.createElement('div');
+    row.className = 'fn-row';
+    const label = document.createElement('span');
+    label.className = `fn-name${colorClass ? ` ${colorClass}` : ''}`;
+    label.textContent = name;
+    row.appendChild(label);
+
+    const levels = document.createElement('span');
+    levels.className = 'fn-levels';
+    row.appendChild(levels);
+
+    container.appendChild(row);
+    return levels;
+  };
+
+  const addValueDots = (levelsEl, values = [], free = 0) => {
+    const freeCount = Number(free || 0);
+    for (let i = 0; i < freeCount; i += 1) addDot(levelsEl, true);
+
+    values.forEach((value, idx) => {
+      if (idx >= freeCount) {
+        addDot(levelsEl, false);
+      }
+      addToken(levelsEl, String(value));
+    });
+  };
+
+  const acc = cfg.accDec || { values: ['1', '2', '3', '4', '5', '6'], free: 1 };
+  addValueDots(addRow('ACC/DEC', 'green'), acc.values, acc.free);
+
+  const sif = cfg.sifIdf || { values: ['1', '2', '3'], free: 0, emer: true };
+  const sifLevels = addRow('SIF/IDF', 'green');
+  addValueDots(sifLevels, sif.values, sif.free);
+  if (sif.emer) {
+    const emer = document.createElement('span');
+    emer.className = 'fn-emer';
+    const emerDot = document.createElement('span');
+    emerDot.className = 'fn-dot';
+    const emerText = document.createElement('span');
+    emerText.className = 'fn-token';
+    emerText.textContent = 'EMER';
+    emer.appendChild(emerDot);
+    emer.appendChild(emerText);
+    sifLevels.appendChild(emer);
+  }
+
+  const bat = cfg.batRech || { values: ['1'], free: 0 };
+  addValueDots(addRow('BAT RECH', 'green'), bat.values, 0);
+
+  const ftl = cfg.ftl || { empty: 2 };
+  const ftlLevels = addRow('FTL', 'green');
+  for (let i = 0; i < Number(ftl.empty || 0); i += 1) addDot(ftlLevels, false);
+
+  const cloak = cfg.cloak || { enabled: false, empty: 3 };
+  if (cloak.enabled) {
+    const cloakLevels = addRow('CLOAK', 'magenta');
+    for (let i = 0; i < Number(cloak.empty || 0); i += 1) addDot(cloakLevels, false);
+  }
+
+  const shldRenf = addRow('SHLD RNFC', 'cyan');
+  ['F', 'P', 'S', 'A'].forEach((part) => {
+    addDot(shldRenf, false);
+    addToken(shldRenf, part);
+  });
+
+  const shldRepr = addRow('SHLD REPR', 'cyan');
+  ['F', 'P', 'S', 'A'].forEach((part) => {
+    addDot(shldRepr, false);
+    addToken(shldRepr, part);
+  });
+
+  const sensor = cfg.sensor || { values: ['2', '4', '6'], free: 1 };
+  addValueDots(addRow('SENSOR', 'gold'), sensor.values, sensor.free);
+
+  const gen = cfg.genSys || { values: ['NRM', 'MAX'], free: 1 };
+  addValueDots(addRow('GEN SYS', 'gold'), gen.values, gen.free);
+
+  const weapons = Array.isArray(cfg.weapons) ? cfg.weapons : [];
+  weapons.forEach((weapon, idx) => {
+    const row = addRow(weapon.label || `WPN ${String.fromCharCode(65 + idx)}`, 'red');
+    const values = Array.isArray(weapon.values) ? weapon.values : [];
+    const levelCount = Math.max(0, Number(weapon.levels ?? values.length));
+    addValueDots(row, values.slice(0, levelCount), Number(weapon.free || 0));
+  });
 }
 
 function renderPowerSystem(powerSystem) {
@@ -397,6 +559,7 @@ function pulseLiveBadge() {
 }
 
 function render() {
+  syncDerivedFunctionInputs();
   const build = getBuild();
   renderPreview(build);
   jsonPreview.textContent = getJsonPreview(build);
@@ -449,7 +612,33 @@ function restoreDraft(draft) {
 
   form.elements.shieldGen.value = draft.shieldGen ?? 0;
 
-  form.elements.functions.value = draft.textBlocks?.functions ?? '';
+  const fn = draft.functionsConfig || {};
+  form.elements.fnAccDecValues.value = (fn.accDec?.values ?? ['1', '2', '3', '4', '5', '6']).join(',');
+  form.elements.fnAccDecFree.value = fn.accDec?.free ?? 1;
+  form.elements.fnSifIdfValues.value = (fn.sifIdf?.values ?? ['1', '2', '3']).join(',');
+  form.elements.fnSifIdfFree.value = fn.sifIdf?.free ?? 0;
+  form.elements.fnSifIdfEmer.checked = Boolean(fn.sifIdf?.emer ?? true);
+  form.elements.fnFtlEmpty.value = fn.ftl?.empty ?? 2;
+  form.elements.fnCloakEnabled.checked = Boolean(fn.cloak?.enabled ?? false);
+  form.elements.fnCloakEmpty.value = fn.cloak?.empty ?? 3;
+  form.elements.fnSensorValues.value = (fn.sensor?.values ?? ['2', '4', '6']).join(',');
+  form.elements.fnSensorFree.value = fn.sensor?.free ?? 1;
+  form.elements.fnGenSysValues.value = (fn.genSys?.values ?? ['NRM', 'MAX']).join(',');
+  form.elements.fnGenSysFree.value = fn.genSys?.free ?? 1;
+  const fnWpn = fn.weapons ?? [];
+  form.elements.fnWpnALabel.value = fnWpn[0]?.label ?? 'A/MAT TRP';
+  form.elements.fnWpnAValues.value = (fnWpn[0]?.values ?? ['1', '4']).join(',');
+  form.elements.fnWpnAFree.value = fnWpn[0]?.free ?? 1;
+  form.elements.fnWpnALevels.value = fnWpn[0]?.levels ?? 2;
+  form.elements.fnWpnBLabel.value = fnWpn[1]?.label ?? 'PHASER';
+  form.elements.fnWpnBValues.value = (fnWpn[1]?.values ?? ['1', '4', '6', '8']).join(',');
+  form.elements.fnWpnBFree.value = fnWpn[1]?.free ?? 1;
+  form.elements.fnWpnBLevels.value = fnWpn[1]?.levels ?? 4;
+  form.elements.fnWpnCLabel.value = fnWpn[2]?.label ?? 'T-31 DISR';
+  form.elements.fnWpnCValues.value = (fnWpn[2]?.values ?? ['1', '3', '6']).join(',');
+  form.elements.fnWpnCFree.value = fnWpn[2]?.free ?? 1;
+  form.elements.fnWpnCLevels.value = fnWpn[2]?.levels ?? 3;
+
   if (form.elements.powerSystem) {
     form.elements.powerSystem.value = draft.textBlocks?.powerSystem ?? '';
   }

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -63,7 +63,23 @@
         <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
 
         <h2>Functions / Power / Maneuvering</h2>
-        <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
+        <div class="functions-editor">
+          <strong>Functions Tracks</strong>
+          <p class="muted">Use comma-separated values for exact power levels. Free pips render as filled green dots.</p>
+          <div class="functions-grid-head"><span>Function</span><span>Values</span><span>Free</span><span>Extra</span><span>Lvls</span></div>
+          <div class="functions-grid">
+            <label>ACC/DEC</label><input name="fnAccDecValues" value="1,2,3,4,5,6" /><input name="fnAccDecFree" type="number" min="0" max="4" value="1" /><span></span><span></span>
+            <label>SIF/IDF</label><input name="fnSifIdfValues" value="1,2,3" /><input name="fnSifIdfFree" type="number" min="0" max="4" value="0" /><label class="inline-check">EMER <input name="fnSifIdfEmer" type="checkbox" checked /></label><span></span>
+            <label>BAT RECH</label><input name="fnBatRechLinked" value="Linked to BATTERY points" readonly /><span class="muted tiny">auto</span><span></span><span></span>
+            <label>FTL</label><input name="fnFtlEmpty" type="number" min="0" max="6" value="2" /><span class="muted tiny">empty circles only</span><span></span><span></span>
+            <label>CLOAK</label><input name="fnCloakEmpty" type="number" min="0" max="6" value="3" /><input name="fnCloakEnabled" type="checkbox" /><span class="muted tiny">optional</span><span></span>
+            <label>SENSOR</label><input name="fnSensorValues" value="2,4,6" /><input name="fnSensorFree" type="number" min="0" max="3" value="1" /><span class="muted tiny">placeholder</span><span></span>
+            <label>GEN SYS</label><input name="fnGenSysValues" value="NRM,MAX" /><input name="fnGenSysFree" type="number" min="0" max="3" value="1" /><span></span><span></span>
+            <label>WPN A</label><input name="fnWpnALabel" value="A/MAT TRP" /><input name="fnWpnAFree" type="number" min="0" max="3" value="1" /><input name="fnWpnAValues" value="1,4" placeholder="values" /><input name="fnWpnALevels" type="number" min="0" max="8" value="2" />
+            <label>WPN B</label><input name="fnWpnBLabel" value="PHASER" /><input name="fnWpnBFree" type="number" min="0" max="3" value="1" /><input name="fnWpnBValues" value="1,4,6,8" placeholder="values" /><input name="fnWpnBLevels" type="number" min="0" max="8" value="4" />
+            <label>WPN C</label><input name="fnWpnCLabel" value="T-31 DISR" /><input name="fnWpnCFree" type="number" min="0" max="3" value="1" /><input name="fnWpnCValues" value="1,3,6" placeholder="values" /><input name="fnWpnCLevels" type="number" min="0" max="8" value="3" />
+          </div>
+        </div>
         <div class="power-system-editor">
           <strong>Power System Tracks</strong>
           <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
@@ -139,7 +155,7 @@
             </div>
             <div class="green-block block-functions">
               <h4><span>FUNCTIONS</span><span>POWER LEVEL</span></h4>
-              <pre id="pvFunctions"></pre>
+              <div id="pvFunctions" class="functions-preview"></div>
             </div>
             <div class="green-block block-power">
               <h4><span>POWER SYSTEM</span><span id="pvMaxPower"></span></h4>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -30,6 +30,17 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .power-grid label { margin: 0; font-weight: 700; }
 .power-grid input { margin: 0; }
 .power-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: center; }
+.functions-editor { border: 1px solid #32427a; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #0f1731; }
+.functions-editor strong { display: block; margin-bottom: 0.2rem; }
+.functions-editor .muted { margin: 0 0 0.5rem; font-size: 0.82rem; }
+.functions-grid-head, .functions-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) 74px 66px minmax(0, 1fr) 56px; gap: 0.35rem; align-items: center; }
+.functions-grid-head { margin: 0.2rem 0; color: #a7b4da; font-size: 0.78rem; }
+.functions-grid label { margin: 0; font-weight: 700; }
+.functions-grid input { margin: 0; }
+.functions-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: start; }
+.inline-check { display: inline-flex !important; align-items: center; gap: 0.4rem; font-weight: 700; }
+.inline-check input { width: 18px; margin: 0; }
+.tiny { font-size: 0.72rem; }
 button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
 button.ghost { background: #273055; }
 .muted { color: #a7b4da; }
@@ -101,7 +112,7 @@ button.ghost { background: #273055; }
   min-height: 920px;
 }
 
-.block-functions pre { height: 220px; max-height: 220px; overflow: auto; }
+.functions-preview { height: 220px; max-height: 220px; overflow: auto; padding: 0.2rem 0.35rem 0.28rem; color: #111; font-family: Arial, Helvetica, sans-serif; }
 .block-maneuver { display: flex; flex-direction: column; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
@@ -113,6 +124,26 @@ button.ghost { background: #273055; }
 .green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
 .block-power h4 span:last-child { color: #d8ffd8; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.fn-row { display: grid; grid-template-columns: 120px minmax(0, 1fr); align-items: center; gap: 0.35rem; margin-bottom: 0.12rem; font-weight: 900; font-size: 0.75rem; }
+.fn-name { text-transform: uppercase; letter-spacing: 0.01em; }
+.fn-name.green { color: #0aa14e; }
+.fn-name.magenta { color: #d31ce0; }
+.fn-name.cyan { color: #08a7df; }
+.fn-name.gold { color: #e3ab00; }
+.fn-name.red { color: #ff0000; }
+.fn-levels { display: flex; flex-wrap: wrap; align-items: center; gap: 0.24rem; font-weight: 900; }
+.fn-token { display: inline-flex; align-items: center; justify-content: center; min-width: 12px; }
+.fn-emer { margin-left: auto; display: inline-flex; align-items: center; gap: 0.24rem; }
+.fn-dot {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #09a84f;
+  border-radius: 50%;
+  box-sizing: border-box;
+  display: inline-block;
+}
+.fn-dot.filled { background: #09a84f; }
+.fn-end-round { font-size: 0.65rem; margin-left: 0.35rem; color: #2f2f2f; }
 .power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
 .power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.2rem; font-size: 0.72rem; font-weight: 700; }
 .power-track-name { text-transform: uppercase; white-space: nowrap; }


### PR DESCRIPTION
### Motivation
- Allow each weapon power track to specify an explicit number of power levels independent of its values list so one weapon can have 2 levels and another 4 while still allowing the first level to be `free`.
- Improve the FUNCTIONS preview rendering so free pips are honored without producing duplicate/open bubbles for covered slots.

### Description
- Added a small functions editor UI with a new `Lvls` column and per-weapon inputs (`fnWpnALevels`, `fnWpnBLevels`, `fnWpnCLevels`) in `index.html` so authors can set level counts directly.
- Introduced `readFunctionsConfig()` to parse the editor into a `functionsConfig` object and wired it into `getBuild()` so functions settings are saved/restored with drafts and exports.
- Implemented `renderFunctions()` in `app.js` to render a structured FUNCTIONS preview and `addValueDots()` to render filled free dots and only add open dots for values whose index is `>= freeCount`, preventing duplicate bubbles.
- Updated CSS (`styles.css`) to add editor grid layout and preview styles for function rows/dots and added small sync helpers (`syncDerivedFunctionInputs`) and draft restore handling to populate the new fields.

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` which completed successfully.
- Served the site with `python -m http.server --directory .` to validate the new editor and preview render code startup succeeded.
- Attempted a Playwright screenshot run against the local preview but the headless browser crashed with a SIGSEGV in this environment, so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699910322fd88332b3ce1cf19f7504bf)