### PR TITLE
UX: first-free toggles, 4 weapon power rows, and weapon slot linkage

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -63,7 +63,24 @@
         <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
 
         <h2>Functions / Power / Maneuvering</h2>
-        <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
+        <div class="functions-editor">
+          <strong>Functions Tracks</strong>
+          <p class="muted">Use comma-separated values for exact power levels. Free pips render as filled green dots.</p>
+          <div class="functions-grid-head"><span>Function</span><span>Values</span><span>Free</span><span>Extra</span><span>Lvls</span></div>
+          <div class="functions-grid">
+            <label>ACC/DEC</label><input name="fnAccDecValues" value="1,2,3,4,5,6" /><input name="fnAccDecFree" type="checkbox" checked /><span></span><span></span>
+            <label>SIF/IDF</label><input name="fnSifIdfValues" value="1,2,3" /><input name="fnSifIdfFree" type="checkbox" /><label class="inline-check">EMER <input name="fnSifIdfEmer" type="checkbox" checked /></label><span></span>
+            <label>BAT RECH</label><input name="fnBatRechLinked" value="Linked to BATTERY points" readonly /><span class="muted tiny">auto</span><span></span><span></span>
+            <label>FTL</label><input name="fnFtlEmpty" type="number" min="0" max="6" value="2" /><span class="muted tiny">empty circles only</span><span></span><span></span>
+            <label>CLOAK</label><input name="fnCloakEmpty" type="number" min="0" max="6" value="3" /><input name="fnCloakEnabled" type="checkbox" /><span class="muted tiny">optional</span><span></span>
+            <label>SENSOR</label><input name="fnSensorValues" value="2,4,6" /><input name="fnSensorFree" type="checkbox" checked /><span class="muted tiny">placeholder</span><span></span>
+            <label>GEN SYS</label><input name="fnGenSysValues" value="NRM,MAX" /><input name="fnGenSysFree" type="checkbox" checked /><span></span><span></span>
+            <label>WPN A</label><input name="fnWpnALabel" value="A/MAT TRP" /><input name="fnWpnAFree" type="checkbox" checked /><label class="inline-check">ON <input name="fnWpnAEnabled" type="checkbox" checked /></label><input name="fnWpnALevels" type="number" min="0" max="8" value="2" />
+            <label>WPN B</label><input name="fnWpnBLabel" value="PHASER" /><input name="fnWpnBFree" type="checkbox" checked /><label class="inline-check">ON <input name="fnWpnBEnabled" type="checkbox" checked /></label><input name="fnWpnBLevels" type="number" min="0" max="8" value="4" />
+            <label>WPN C</label><input name="fnWpnCLabel" value="WPN C" /><input name="fnWpnCFree" type="checkbox" checked /><label class="inline-check">ON <input name="fnWpnCEnabled" type="checkbox" checked /></label><input name="fnWpnCLevels" type="number" min="0" max="8" value="3" />
+            <label>WPN D</label><input name="fnWpnDLabel" value="WPN D" /><input name="fnWpnDFree" type="checkbox" /><label class="inline-check">ON <input name="fnWpnDEnabled" type="checkbox" /></label><input name="fnWpnDLevels" type="number" min="0" max="8" value="0" />
+          </div>
+        </div>
         <div class="power-system-editor">
           <strong>Power System Tracks</strong>
           <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
@@ -139,7 +156,7 @@
             </div>
             <div class="green-block block-functions">
               <h4><span>FUNCTIONS</span><span>POWER LEVEL</span></h4>
-              <pre id="pvFunctions"></pre>
+              <div id="pvFunctions" class="functions-preview"></div>
             </div>
             <div class="green-block block-power">
               <h4><span>POWER SYSTEM</span><span id="pvMaxPower"></span></h4>
@@ -197,10 +214,10 @@
 
           <section class="col right-col">
             <h3>WEAPONS</h3>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn1Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn1Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn2Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn2Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn3Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn3Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn4Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn4Body"></div></div>
+            <div class="weapon-slot" id="pvWpn1Slot"><div class="slot-title" id="pvWpn1Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn1Body"></div></div>
+            <div class="weapon-slot" id="pvWpn2Slot"><div class="slot-title" id="pvWpn2Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn2Body"></div></div>
+            <div class="weapon-slot" id="pvWpn3Slot"><div class="slot-title" id="pvWpn3Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn3Body"></div></div>
+            <div class="weapon-slot" id="pvWpn4Slot"><div class="slot-title" id="pvWpn4Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn4Body"></div></div>
           </section>
         </div>
 

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -30,6 +30,17 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .power-grid label { margin: 0; font-weight: 700; }
 .power-grid input { margin: 0; }
 .power-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: center; }
+.functions-editor { border: 1px solid #32427a; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #0f1731; }
+.functions-editor strong { display: block; margin-bottom: 0.2rem; }
+.functions-editor .muted { margin: 0 0 0.5rem; font-size: 0.82rem; }
+.functions-grid-head, .functions-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) 74px 66px minmax(0, 1fr) 56px; gap: 0.35rem; align-items: center; }
+.functions-grid-head { margin: 0.2rem 0; color: #a7b4da; font-size: 0.78rem; }
+.functions-grid label { margin: 0; font-weight: 700; }
+.functions-grid input { margin: 0; }
+.functions-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: start; }
+.inline-check { display: inline-flex !important; align-items: center; gap: 0.4rem; font-weight: 700; }
+.inline-check input { width: 18px; margin: 0; }
+.tiny { font-size: 0.72rem; }
 button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
 button.ghost { background: #273055; }
 .muted { color: #a7b4da; }
@@ -101,7 +112,7 @@ button.ghost { background: #273055; }
   min-height: 920px;
 }
 
-.block-functions pre { height: 220px; max-height: 220px; overflow: auto; }
+.functions-preview { height: 220px; max-height: 220px; overflow: auto; padding: 0.2rem 0.35rem 0.28rem; color: #111; font-family: Arial, Helvetica, sans-serif; }
 .block-maneuver { display: flex; flex-direction: column; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
@@ -113,6 +124,26 @@ button.ghost { background: #273055; }
 .green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
 .block-power h4 span:last-child { color: #d8ffd8; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.fn-row { display: grid; grid-template-columns: 120px minmax(0, 1fr); align-items: center; gap: 0.35rem; margin-bottom: 0.12rem; font-weight: 900; font-size: 0.75rem; }
+.fn-name { text-transform: uppercase; letter-spacing: 0.01em; }
+.fn-name.green { color: #0aa14e; }
+.fn-name.magenta { color: #d31ce0; }
+.fn-name.cyan { color: #08a7df; }
+.fn-name.gold { color: #e3ab00; }
+.fn-name.red { color: #ff0000; }
+.fn-levels { display: flex; flex-wrap: wrap; align-items: center; gap: 0.24rem; font-weight: 900; }
+.fn-token { display: inline-flex; align-items: center; justify-content: center; min-width: 12px; }
+.fn-emer { margin-left: auto; display: inline-flex; align-items: center; gap: 0.24rem; }
+.fn-dot {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #09a84f;
+  border-radius: 50%;
+  box-sizing: border-box;
+  display: inline-block;
+}
+.fn-dot.filled { background: #09a84f; }
+.fn-end-round { font-size: 0.65rem; margin-left: 0.35rem; color: #2f2f2f; }
 .power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
 .power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.2rem; font-size: 0.72rem; font-weight: 700; }
 .power-track-name { text-transform: uppercase; white-space: nowrap; }


### PR DESCRIPTION
### Motivation
- Ensure only the first function pip can be marked free by replacing numeric "free" counts with a first-pip toggle.
- Let authors declare up to four per-weapon power tracks (WPN A–D) and control whether each weapon track is present.
- Keep the preview consistent by hiding right-side weapon slots unless the corresponding function weapon track is enabled and has levels.

### Description
- Updated the editor UI in `index.html` to use checkboxes for first-free toggles, added ON/OFF toggles and level inputs for four weapon rows (`fnWpnA..D*`), and added `pvWpn{1..4}Slot` ids so slots can be shown/hidden.
- Reworked functions handling in `app.js` by adding `buildSequentialValues`, moving functions settings into `readFunctionsConfig()` (capturing `enabled`, `free`, `levels`, and generated `values`), adding `renderFunctions()` to draw dots/tokens, and wiring `functionsConfig` into `getBuild()` and draft restore.
- Linked functions -> preview by changing `weaponSlot` to accept an `enabled` flag and hiding a slot when its function weapon track is disabled or `levels === 0`, and updated rendering so weapons only appear in the FUNCTIONS preview when enabled.
- Added small sync helpers (`syncDerivedFunctionInputs`) and CSS for the new editor and preview (`.functions-editor`, `.fn-row`, `.fn-dot`, `.functions-preview`, etc.) to match the new controls and visuals.

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` which completed successfully. 
- Served the site locally with `python -m http.server --directory .` and validated startup without errors. 
- Captured a Playwright screenshot of the updated editor/preview which ran successfully and produced the artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699910322fd88332b3ce1cf19f7504bf)