### PR TITLE
Restructure Functions editor UI to match reference UX layout

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -63,7 +63,79 @@
         <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
 
         <h2>Functions / Power / Maneuvering</h2>
-        <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
+        <div class="functions-editor">
+          <strong>Functions Tracks</strong>
+          <p class="muted">Use comma-separated values for exact power levels.<br />Free pips render as filled green dots.</p>
+          <div class="functions-mini-head"><span>Function</span><span>Values</span></div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">ACC/DEC</label>
+            <input name="fnAccDecValues" value="1,2,3,4,5,6" />
+            <label class="inline-check free-check">FREE <input name="fnAccDecFree" type="checkbox" checked /></label>
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">SIF/IDF</label>
+            <input name="fnSifIdfValues" value="1,2,3" />
+            <label class="inline-check free-check">FREE <input name="fnSifIdfFree" type="checkbox" /></label>
+          </div>
+
+          <div class="fn-edit-row fn-edit-subrow">
+            <label class="inline-check">EMER <input name="fnSifIdfEmer" type="checkbox" checked /></label>
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">FTL</label>
+            <input name="fnFtlEmpty" type="number" min="0" max="6" value="2" />
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="inline-check fn-edit-label">SPECIAL <input name="fnCloakEnabled" type="checkbox" /></label>
+            <input name="fnCloakEmpty" type="number" min="0" max="6" value="3" />
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">SENSOR</label>
+            <input name="fnSensorValues" value="2,4,6" />
+            <label class="inline-check free-check">FREE <input name="fnSensorFree" type="checkbox" checked /></label>
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">GEN SYS</label>
+            <input name="fnGenSysValues" value="NRM,MAX" />
+            <label class="inline-check free-check">FREE <input name="fnGenSysFree" type="checkbox" /></label>
+          </div>
+
+          <div class="fn-divider"></div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnAEnabled" type="checkbox" checked /> A</label>
+            <input name="fnWpnALabel" value="A/MAT TRP" />
+            <label class="inline-check free-check">FREE <input name="fnWpnAFree" type="checkbox" checked /></label>
+            <input name="fnWpnALevels" type="number" min="0" max="8" value="2" />
+          </div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnBEnabled" type="checkbox" checked /> B</label>
+            <input name="fnWpnBLabel" value="PHASER" />
+            <label class="inline-check free-check">FREE <input name="fnWpnBFree" type="checkbox" /></label>
+            <input name="fnWpnBLevels" type="number" min="0" max="8" value="4" />
+          </div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnCEnabled" type="checkbox" /> C</label>
+            <input name="fnWpnCLabel" value="WPN C" />
+            <label class="inline-check free-check">FREE <input name="fnWpnCFree" type="checkbox" /></label>
+            <input name="fnWpnCLevels" type="number" min="0" max="8" value="0" />
+          </div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnDEnabled" type="checkbox" /> D</label>
+            <input name="fnWpnDLabel" value="WPN D" />
+            <label class="inline-check free-check">FREE <input name="fnWpnDFree" type="checkbox" /></label>
+            <input name="fnWpnDLevels" type="number" min="0" max="8" value="0" />
+          </div>
+        </div>
         <div class="power-system-editor">
           <strong>Power System Tracks</strong>
           <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
@@ -139,7 +211,7 @@
             </div>
             <div class="green-block block-functions">
               <h4><span>FUNCTIONS</span><span>POWER LEVEL</span></h4>
-              <pre id="pvFunctions"></pre>
+              <div id="pvFunctions" class="functions-preview"></div>
             </div>
             <div class="green-block block-power">
               <h4><span>POWER SYSTEM</span><span id="pvMaxPower"></span></h4>
@@ -197,10 +269,10 @@
 
           <section class="col right-col">
             <h3>WEAPONS</h3>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn1Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn1Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn2Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn2Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn3Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn3Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn4Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn4Body"></div></div>
+            <div class="weapon-slot" id="pvWpn1Slot"><div class="slot-title" id="pvWpn1Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn1Body"></div></div>
+            <div class="weapon-slot" id="pvWpn2Slot"><div class="slot-title" id="pvWpn2Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn2Body"></div></div>
+            <div class="weapon-slot" id="pvWpn3Slot"><div class="slot-title" id="pvWpn3Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn3Body"></div></div>
+            <div class="weapon-slot" id="pvWpn4Slot"><div class="slot-title" id="pvWpn4Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn4Body"></div></div>
           </section>
         </div>
 

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -30,6 +30,22 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .power-grid label { margin: 0; font-weight: 700; }
 .power-grid input { margin: 0; }
 .power-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: center; }
+.functions-editor { border: 1px solid #3557c7; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #07133e; }
+.functions-editor strong { display: block; margin-bottom: 0.15rem; font-size: 1.02rem; }
+.functions-editor .muted { margin: 0 0 0.5rem; font-size: 0.82rem; color: #bdd0ff; }
+.functions-mini-head { display: grid; grid-template-columns: 108px 1fr; margin-bottom: 0.2rem; color: #a7b4da; font-size: 0.85rem; }
+.fn-edit-row { display: grid; grid-template-columns: 108px minmax(0, 1fr) auto; gap: 0.35rem; align-items: center; margin-bottom: 0.34rem; }
+.fn-edit-row input { margin: 0; }
+.fn-edit-row input[type="checkbox"] { width: 16px; height: 16px; }
+.fn-edit-label { font-weight: 900; }
+.fn-edit-subrow { grid-template-columns: 108px auto; }
+.fn-divider { height: 1px; background: #1f3b8e; margin: 0.35rem 0 0.45rem; }
+.fn-wpn-row { grid-template-columns: 72px minmax(0, 1fr) auto 90px; }
+.fn-on-label { white-space: nowrap; }
+.inline-check { display: inline-flex !important; align-items: center; gap: 0.35rem; font-weight: 800; }
+.inline-check input { width: 16px; margin: 0; }
+.free-check { color: #e6ecff; }
+.tiny { font-size: 0.72rem; }
 button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
 button.ghost { background: #273055; }
 .muted { color: #a7b4da; }
@@ -101,7 +117,7 @@ button.ghost { background: #273055; }
   min-height: 920px;
 }
 
-.block-functions pre { height: 220px; max-height: 220px; overflow: auto; }
+.functions-preview { height: 220px; max-height: 220px; overflow: auto; padding: 0.2rem 0.35rem 0.28rem; color: #111; font-family: Arial, Helvetica, sans-serif; }
 .block-maneuver { display: flex; flex-direction: column; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
@@ -113,6 +129,26 @@ button.ghost { background: #273055; }
 .green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
 .block-power h4 span:last-child { color: #d8ffd8; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.fn-row { display: grid; grid-template-columns: 120px minmax(0, 1fr); align-items: center; gap: 0.35rem; margin-bottom: 0.12rem; font-weight: 900; font-size: 0.75rem; }
+.fn-name { text-transform: uppercase; letter-spacing: 0.01em; }
+.fn-name.green { color: #0aa14e; }
+.fn-name.magenta { color: #d31ce0; }
+.fn-name.cyan { color: #08a7df; }
+.fn-name.gold { color: #e3ab00; }
+.fn-name.red { color: #ff0000; }
+.fn-levels { display: flex; flex-wrap: wrap; align-items: center; gap: 0.24rem; font-weight: 900; }
+.fn-token { display: inline-flex; align-items: center; justify-content: center; min-width: 12px; }
+.fn-emer { margin-left: auto; display: inline-flex; align-items: center; gap: 0.24rem; }
+.fn-dot {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #09a84f;
+  border-radius: 50%;
+  box-sizing: border-box;
+  display: inline-block;
+}
+.fn-dot.filled { background: #09a84f; }
+.fn-end-round { font-size: 0.65rem; margin-left: 0.35rem; color: #2f2f2f; }
 .power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
 .power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.2rem; font-size: 0.72rem; font-weight: 700; }
 .power-track-name { text-transform: uppercase; white-space: nowrap; }


### PR DESCRIPTION
### Motivation
- Replace the old free-count text blob with a structured, row-based Functions editor that matches the provided UX reference and is easier to edit. 
- Expose per-weapon ON/label/FREE/levels controls for up to four weapon power tracks so preview linkage is explicit. 
- Make the preview render functions as rows of dots/tokens and hide weapon slots when their function power track is disabled or has no levels. 

### Description
- Replaced the single `functions` textarea in `index.html` with a new structured editor (`.functions-editor`) containing rows for ACC/DEC, SIF/IDF (+ EMER), FTL, SPECIAL (cloak), SENSOR, GEN SYS and four weapon rows (A–D) with `ON`, label, `FREE`, and `levels` inputs. 
- Added parsing and model plumbing in `app.js`: `parseFunctionValues`, `buildSequentialValues`, and `readFunctionsConfig` to read the new form controls and produce `functionsConfig`, and wired `functionsConfig` into `getBuild()` and draft restore. 
- Implemented `renderFunctions(functionsConfig)` to draw function rows as dots/tokens in the preview and updated the preview wiring to call it instead of dumping raw text; added conditional weapon-slot behavior by changing `weaponSlot` to accept an `enabled` flag and hiding slots when their function track is disabled or has zero levels. 
- Added helper `syncDerivedFunctionInputs()` and updated draft restore logic to populate all new inputs from `draft.functionsConfig`; refreshed styles in `styles.css` to add `.functions-editor`, `.fn-edit-row`, `.fn-row`, `.fn-dot`, `.functions-preview`, and color classes to visually match the dark-blue reference card. 

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` which completed without errors. (success) 
- Launched a local preview with `python -m http.server --directory .` and validated the page served and loaded. (success) 
- Captured a Playwright screenshot of the updated editor/preview by navigating to the local server URL to verify layout and visual behavior. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699910322fd88332b3ce1cf19f7504bf)