### PR TITLE
Use comma-separated weapon values in Functions editor

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -65,6 +65,61 @@ function parsePowerPattern(raw) {
     .map((value) => clamp(Math.round(value), 1, 3));
 }
 
+
+
+function parseFunctionValues(raw) {
+  return String(raw || '')
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+
+function readFunctionsConfig() {
+  const batteryPoints = Math.max(0, num('powerBatteryPoints'));
+  const batteryValues = Array.from({ length: batteryPoints }, (_, idx) => String(idx + 1));
+
+  return {
+    accDec: { values: parseFunctionValues(form.elements.fnAccDecValues?.value), free: form.elements.fnAccDecFree?.checked ? 1 : 0 },
+    sifIdf: {
+      values: parseFunctionValues(form.elements.fnSifIdfValues?.value),
+      free: form.elements.fnSifIdfFree?.checked ? 1 : 0,
+      emer: Boolean(form.elements.fnSifIdfEmer?.checked)
+    },
+    batRech: { values: batteryValues, free: 0 },
+    ftl: { empty: clamp(num('fnFtlEmpty'), 0, 6) },
+    cloak: { enabled: Boolean(form.elements.fnCloakEnabled?.checked), empty: clamp(num('fnCloakEmpty'), 0, 6) },
+    sensor: { values: parseFunctionValues(form.elements.fnSensorValues?.value), free: form.elements.fnSensorFree?.checked ? 1 : 0 },
+    genSys: { values: parseFunctionValues(form.elements.fnGenSysValues?.value), free: form.elements.fnGenSysFree?.checked ? 1 : 0 },
+    weapons: [
+      {
+        label: form.elements.fnWpnALabel?.value || 'WPN A',
+        enabled: Boolean(form.elements.fnWpnAEnabled?.checked),
+        free: form.elements.fnWpnAFree?.checked ? 1 : 0,
+        values: parseFunctionValues(form.elements.fnWpnAValues?.value)
+      },
+      {
+        label: form.elements.fnWpnBLabel?.value || 'WPN B',
+        enabled: Boolean(form.elements.fnWpnBEnabled?.checked),
+        free: form.elements.fnWpnBFree?.checked ? 1 : 0,
+        values: parseFunctionValues(form.elements.fnWpnBValues?.value)
+      },
+      {
+        label: form.elements.fnWpnCLabel?.value || 'WPN C',
+        enabled: Boolean(form.elements.fnWpnCEnabled?.checked),
+        free: form.elements.fnWpnCFree?.checked ? 1 : 0,
+        values: parseFunctionValues(form.elements.fnWpnCValues?.value)
+      },
+      {
+        label: form.elements.fnWpnDLabel?.value || 'WPN D',
+        enabled: Boolean(form.elements.fnWpnDEnabled?.checked),
+        free: form.elements.fnWpnDFree?.checked ? 1 : 0,
+        values: parseFunctionValues(form.elements.fnWpnDValues?.value)
+      }
+    ]
+  };
+}
+
 function readPowerSystem() {
   return {
     tracks: POWER_TRACK_CONFIG.map((track) => ({
@@ -76,6 +131,13 @@ function readPowerSystem() {
       hasDot: Boolean(form.elements[track.hasDotField]?.checked)
     }))
   };
+}
+
+
+function syncDerivedFunctionInputs() {
+  if (form.elements.fnBatRechLinked) {
+    form.elements.fnBatRechLinked.value = `Linked to BATTERY points (${num('powerBatteryPoints')})`;
+  }
 }
 
 function getBuild() {
@@ -107,9 +169,9 @@ function getBuild() {
     },
     shieldGen: num('shieldGen'),
     textBlocks: {
-      functions: form.elements.functions.value,
       powerSystem: form.elements.powerSystem?.value ?? ''
     },
+    functionsConfig: readFunctionsConfig(),
     powerSystem: readPowerSystem(),
     sublight: readSublight(),
     structure: {
@@ -132,9 +194,19 @@ function renderBoxes(containerId, count, className) {
   }
 }
 
-function weaponSlot(id, weapon) {
+function weaponSlot(id, weapon, enabled = true) {
+  const slot = document.getElementById(`pvWpn${id}Slot`);
   const title = document.getElementById(`pvWpn${id}Title`);
   const body = document.getElementById(`pvWpn${id}Body`);
+
+  if (!enabled) {
+    slot.style.display = 'none';
+    title.textContent = 'WPN NAME TYP';
+    body.textContent = '';
+    return;
+  }
+
+  slot.style.display = 'flex';
   if (!weapon) {
     title.textContent = 'WPN NAME TYP';
     body.textContent = '';
@@ -306,18 +378,126 @@ function renderPreview(build) {
     silhouetteEl.style.display = 'block';
   }
 
-  document.getElementById('pvFunctions').textContent = build.textBlocks.functions;
+  renderFunctions(build.functionsConfig);
   renderPowerSystem(build.powerSystem);
   renderManeuvering(build.sublight);
 
-  weaponSlot(1, build.weapons[0]);
-  weaponSlot(2, build.weapons[1]);
-  weaponSlot(3, build.weapons[2]);
-  weaponSlot(4, build.weapons[3]);
+  const weaponPower = (build.functionsConfig?.weapons ?? []).map((weapon) => Boolean(weapon?.enabled) && Array.isArray(weapon?.values) && weapon.values.length > 0);
+  weaponSlot(1, build.weapons[0], weaponPower[0] !== false);
+  weaponSlot(2, build.weapons[1], weaponPower[1] !== false);
+  weaponSlot(3, build.weapons[2], weaponPower[2] !== false);
+  weaponSlot(4, build.weapons[3], weaponPower[3] !== false);
 
   const systemsText = build.systems.map((entry) => `${entry.key} ${entry.value}`.trim()).join('\n');
   document.getElementById('pvSystems').textContent = systemsText;
   renderStructure(build);
+}
+
+
+
+function renderFunctions(functionsConfig) {
+  const container = document.getElementById('pvFunctions');
+  container.innerHTML = '';
+  const cfg = functionsConfig || {};
+
+  const addDot = (parent, filled = false) => {
+    const dot = document.createElement('span');
+    dot.className = `fn-dot${filled ? ' filled' : ''}`;
+    parent.appendChild(dot);
+  };
+
+  const addToken = (parent, text) => {
+    const tok = document.createElement('span');
+    tok.className = 'fn-token';
+    tok.textContent = text;
+    parent.appendChild(tok);
+  };
+
+  const addRow = (name, colorClass = '') => {
+    const row = document.createElement('div');
+    row.className = 'fn-row';
+    const label = document.createElement('span');
+    label.className = `fn-name${colorClass ? ` ${colorClass}` : ''}`;
+    label.textContent = name;
+    row.appendChild(label);
+
+    const levels = document.createElement('span');
+    levels.className = 'fn-levels';
+    row.appendChild(levels);
+
+    container.appendChild(row);
+    return levels;
+  };
+
+  const addValueDots = (levelsEl, values = [], free = 0) => {
+    const freeCount = Number(free || 0);
+    for (let i = 0; i < freeCount; i += 1) addDot(levelsEl, true);
+
+    values.forEach((value, idx) => {
+      if (idx >= freeCount) {
+        addDot(levelsEl, false);
+      }
+      addToken(levelsEl, String(value));
+    });
+  };
+
+  const acc = cfg.accDec || { values: ['1', '2', '3', '4', '5', '6'], free: 1 };
+  addValueDots(addRow('ACC/DEC', 'green'), acc.values, acc.free);
+
+  const sif = cfg.sifIdf || { values: ['1', '2', '3'], free: 0, emer: true };
+  const sifLevels = addRow('SIF/IDF', 'green');
+  addValueDots(sifLevels, sif.values, sif.free);
+  if (sif.emer) {
+    const emer = document.createElement('span');
+    emer.className = 'fn-emer';
+    const emerDot = document.createElement('span');
+    emerDot.className = 'fn-dot';
+    const emerText = document.createElement('span');
+    emerText.className = 'fn-token';
+    emerText.textContent = 'EMER';
+    emer.appendChild(emerDot);
+    emer.appendChild(emerText);
+    sifLevels.appendChild(emer);
+  }
+
+  const bat = cfg.batRech || { values: ['1'], free: 0 };
+  addValueDots(addRow('BAT RECH', 'green'), bat.values, 0);
+
+  const ftl = cfg.ftl || { empty: 2 };
+  const ftlLevels = addRow('FTL', 'green');
+  for (let i = 0; i < Number(ftl.empty || 0); i += 1) addDot(ftlLevels, false);
+
+  const cloak = cfg.cloak || { enabled: false, empty: 3 };
+  if (cloak.enabled) {
+    const cloakLevels = addRow('CLOAK', 'magenta');
+    for (let i = 0; i < Number(cloak.empty || 0); i += 1) addDot(cloakLevels, false);
+  }
+
+  const shldRenf = addRow('SHLD RNFC', 'cyan');
+  ['F', 'P', 'S', 'A'].forEach((part) => {
+    addDot(shldRenf, false);
+    addToken(shldRenf, part);
+  });
+
+  const shldRepr = addRow('SHLD REPR', 'cyan');
+  ['F', 'P', 'S', 'A'].forEach((part) => {
+    addDot(shldRepr, false);
+    addToken(shldRepr, part);
+  });
+
+  const sensor = cfg.sensor || { values: ['2', '4', '6'], free: 1 };
+  addValueDots(addRow('SENSOR', 'gold'), sensor.values, sensor.free);
+
+  const gen = cfg.genSys || { values: ['NRM', 'MAX'], free: 1 };
+  addValueDots(addRow('GEN SYS', 'gold'), gen.values, gen.free);
+
+  const weapons = Array.isArray(cfg.weapons) ? cfg.weapons : [];
+  weapons.forEach((weapon, idx) => {
+    const values = Array.isArray(weapon?.values) ? weapon.values : [];
+    if (!weapon?.enabled || values.length <= 0) return;
+    const row = addRow(weapon.label || `WPN ${String.fromCharCode(65 + idx)}`, 'red');
+    addValueDots(row, values, Number(weapon.free || 0));
+  });
 }
 
 function renderPowerSystem(powerSystem) {
@@ -397,6 +577,7 @@ function pulseLiveBadge() {
 }
 
 function render() {
+  syncDerivedFunctionInputs();
   const build = getBuild();
   renderPreview(build);
   jsonPreview.textContent = getJsonPreview(build);
@@ -449,7 +630,37 @@ function restoreDraft(draft) {
 
   form.elements.shieldGen.value = draft.shieldGen ?? 0;
 
-  form.elements.functions.value = draft.textBlocks?.functions ?? '';
+  const fn = draft.functionsConfig || {};
+  form.elements.fnAccDecValues.value = (fn.accDec?.values ?? ['1', '2', '3', '4', '5', '6']).join(',');
+  form.elements.fnAccDecFree.checked = Boolean(fn.accDec?.free ?? 1);
+  form.elements.fnSifIdfValues.value = (fn.sifIdf?.values ?? ['1', '2', '3']).join(',');
+  form.elements.fnSifIdfFree.checked = Boolean(fn.sifIdf?.free ?? 0);
+  form.elements.fnSifIdfEmer.checked = Boolean(fn.sifIdf?.emer ?? true);
+  form.elements.fnFtlEmpty.value = fn.ftl?.empty ?? 2;
+  form.elements.fnCloakEnabled.checked = Boolean(fn.cloak?.enabled ?? false);
+  form.elements.fnCloakEmpty.value = fn.cloak?.empty ?? 3;
+  form.elements.fnSensorValues.value = (fn.sensor?.values ?? ['2', '4', '6']).join(',');
+  form.elements.fnSensorFree.checked = Boolean(fn.sensor?.free ?? 1);
+  form.elements.fnGenSysValues.value = (fn.genSys?.values ?? ['NRM', 'MAX']).join(',');
+  form.elements.fnGenSysFree.checked = Boolean(fn.genSys?.free ?? 1);
+  const fnWpn = fn.weapons ?? [];
+  form.elements.fnWpnALabel.value = fnWpn[0]?.label ?? 'A/MAT TRP';
+  form.elements.fnWpnAFree.checked = Boolean(fnWpn[0]?.free ?? 1);
+  form.elements.fnWpnAEnabled.checked = Boolean(fnWpn[0]?.enabled ?? true);
+  form.elements.fnWpnAValues.value = (fnWpn[0]?.values ?? ['2']).join(',');
+  form.elements.fnWpnBLabel.value = fnWpn[1]?.label ?? 'PHASER';
+  form.elements.fnWpnBFree.checked = Boolean(fnWpn[1]?.free ?? 1);
+  form.elements.fnWpnBEnabled.checked = Boolean(fnWpn[1]?.enabled ?? true);
+  form.elements.fnWpnBValues.value = (fnWpn[1]?.values ?? ['4']).join(',');
+  form.elements.fnWpnCLabel.value = fnWpn[2]?.label ?? 'WPN C';
+  form.elements.fnWpnCFree.checked = Boolean(fnWpn[2]?.free ?? 1);
+  form.elements.fnWpnCEnabled.checked = Boolean(fnWpn[2]?.enabled ?? true);
+  form.elements.fnWpnCValues.value = (fnWpn[2]?.values ?? []).join(',');
+  form.elements.fnWpnDLabel.value = fnWpn[3]?.label ?? 'WPN D';
+  form.elements.fnWpnDFree.checked = Boolean(fnWpn[3]?.free ?? 0);
+  form.elements.fnWpnDEnabled.checked = Boolean(fnWpn[3]?.enabled ?? false);
+  form.elements.fnWpnDValues.value = (fnWpn[3]?.values ?? []).join(',');
+
   if (form.elements.powerSystem) {
     form.elements.powerSystem.value = draft.textBlocks?.powerSystem ?? '';
   }

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -63,7 +63,79 @@
         <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
 
         <h2>Functions / Power / Maneuvering</h2>
-        <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
+        <div class="functions-editor">
+          <strong>Functions Tracks</strong>
+          <p class="muted">Use comma-separated values for exact power levels.<br />Free pips render as filled green dots.</p>
+          <div class="functions-mini-head"><span>Function</span><span>Values</span></div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">ACC/DEC</label>
+            <input name="fnAccDecValues" value="1,2,3,4,5,6" />
+            <label class="inline-check free-check">FREE <input name="fnAccDecFree" type="checkbox" checked /></label>
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">SIF/IDF</label>
+            <input name="fnSifIdfValues" value="1,2,3" />
+            <label class="inline-check free-check">FREE <input name="fnSifIdfFree" type="checkbox" /></label>
+          </div>
+
+          <div class="fn-edit-row fn-edit-subrow">
+            <label class="inline-check">EMER <input name="fnSifIdfEmer" type="checkbox" checked /></label>
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">FTL</label>
+            <input name="fnFtlEmpty" type="number" min="0" max="6" value="2" />
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="inline-check fn-edit-label">SPECIAL <input name="fnCloakEnabled" type="checkbox" /></label>
+            <input name="fnCloakEmpty" type="number" min="0" max="6" value="3" />
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">SENSOR</label>
+            <input name="fnSensorValues" value="2,4,6" />
+            <label class="inline-check free-check">FREE <input name="fnSensorFree" type="checkbox" checked /></label>
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">GEN SYS</label>
+            <input name="fnGenSysValues" value="NRM,MAX" />
+            <label class="inline-check free-check">FREE <input name="fnGenSysFree" type="checkbox" /></label>
+          </div>
+
+          <div class="fn-divider"></div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnAEnabled" type="checkbox" checked /> A</label>
+            <input name="fnWpnALabel" value="A/MAT TRP" />
+            <label class="inline-check free-check">FREE <input name="fnWpnAFree" type="checkbox" checked /></label>
+            <input name="fnWpnAValues" value="2" placeholder="1,2,6" />
+          </div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnBEnabled" type="checkbox" checked /> B</label>
+            <input name="fnWpnBLabel" value="PHASER" />
+            <label class="inline-check free-check">FREE <input name="fnWpnBFree" type="checkbox" /></label>
+            <input name="fnWpnBValues" value="4" placeholder="1,2,6" />
+          </div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnCEnabled" type="checkbox" /> C</label>
+            <input name="fnWpnCLabel" value="WPN C" />
+            <label class="inline-check free-check">FREE <input name="fnWpnCFree" type="checkbox" /></label>
+            <input name="fnWpnCValues" value="" placeholder="1,2,6" />
+          </div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnDEnabled" type="checkbox" /> D</label>
+            <input name="fnWpnDLabel" value="WPN D" />
+            <label class="inline-check free-check">FREE <input name="fnWpnDFree" type="checkbox" /></label>
+            <input name="fnWpnDValues" value="" placeholder="1,2,6" />
+          </div>
+        </div>
         <div class="power-system-editor">
           <strong>Power System Tracks</strong>
           <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
@@ -139,7 +211,7 @@
             </div>
             <div class="green-block block-functions">
               <h4><span>FUNCTIONS</span><span>POWER LEVEL</span></h4>
-              <pre id="pvFunctions"></pre>
+              <div id="pvFunctions" class="functions-preview"></div>
             </div>
             <div class="green-block block-power">
               <h4><span>POWER SYSTEM</span><span id="pvMaxPower"></span></h4>
@@ -197,10 +269,10 @@
 
           <section class="col right-col">
             <h3>WEAPONS</h3>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn1Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn1Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn2Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn2Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn3Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn3Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn4Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn4Body"></div></div>
+            <div class="weapon-slot" id="pvWpn1Slot"><div class="slot-title" id="pvWpn1Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn1Body"></div></div>
+            <div class="weapon-slot" id="pvWpn2Slot"><div class="slot-title" id="pvWpn2Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn2Body"></div></div>
+            <div class="weapon-slot" id="pvWpn3Slot"><div class="slot-title" id="pvWpn3Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn3Body"></div></div>
+            <div class="weapon-slot" id="pvWpn4Slot"><div class="slot-title" id="pvWpn4Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn4Body"></div></div>
           </section>
         </div>
 

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -30,6 +30,22 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .power-grid label { margin: 0; font-weight: 700; }
 .power-grid input { margin: 0; }
 .power-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: center; }
+.functions-editor { border: 1px solid #3557c7; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #07133e; }
+.functions-editor strong { display: block; margin-bottom: 0.15rem; font-size: 1.02rem; }
+.functions-editor .muted { margin: 0 0 0.5rem; font-size: 0.82rem; color: #bdd0ff; }
+.functions-mini-head { display: grid; grid-template-columns: 108px 1fr; margin-bottom: 0.2rem; color: #a7b4da; font-size: 0.85rem; }
+.fn-edit-row { display: grid; grid-template-columns: 108px minmax(0, 1fr) auto; gap: 0.35rem; align-items: center; margin-bottom: 0.34rem; }
+.fn-edit-row input { margin: 0; }
+.fn-edit-row input[type="checkbox"] { width: 16px; height: 16px; }
+.fn-edit-label { font-weight: 900; }
+.fn-edit-subrow { grid-template-columns: 108px auto; }
+.fn-divider { height: 1px; background: #1f3b8e; margin: 0.35rem 0 0.45rem; }
+.fn-wpn-row { grid-template-columns: 72px minmax(0, 1fr) auto 90px; }
+.fn-on-label { white-space: nowrap; }
+.inline-check { display: inline-flex !important; align-items: center; gap: 0.35rem; font-weight: 800; }
+.inline-check input { width: 16px; margin: 0; }
+.free-check { color: #e6ecff; }
+.tiny { font-size: 0.72rem; }
 button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
 button.ghost { background: #273055; }
 .muted { color: #a7b4da; }
@@ -101,7 +117,7 @@ button.ghost { background: #273055; }
   min-height: 920px;
 }
 
-.block-functions pre { height: 220px; max-height: 220px; overflow: auto; }
+.functions-preview { height: 220px; max-height: 220px; overflow: auto; padding: 0.2rem 0.35rem 0.28rem; color: #111; font-family: Arial, Helvetica, sans-serif; }
 .block-maneuver { display: flex; flex-direction: column; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
@@ -113,6 +129,26 @@ button.ghost { background: #273055; }
 .green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
 .block-power h4 span:last-child { color: #d8ffd8; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.fn-row { display: grid; grid-template-columns: 120px minmax(0, 1fr); align-items: center; gap: 0.35rem; margin-bottom: 0.12rem; font-weight: 900; font-size: 0.75rem; }
+.fn-name { text-transform: uppercase; letter-spacing: 0.01em; }
+.fn-name.green { color: #0aa14e; }
+.fn-name.magenta { color: #d31ce0; }
+.fn-name.cyan { color: #08a7df; }
+.fn-name.gold { color: #e3ab00; }
+.fn-name.red { color: #ff0000; }
+.fn-levels { display: flex; flex-wrap: wrap; align-items: center; gap: 0.24rem; font-weight: 900; }
+.fn-token { display: inline-flex; align-items: center; justify-content: center; min-width: 12px; }
+.fn-emer { margin-left: auto; display: inline-flex; align-items: center; gap: 0.24rem; }
+.fn-dot {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #09a84f;
+  border-radius: 50%;
+  box-sizing: border-box;
+  display: inline-block;
+}
+.fn-dot.filled { background: #09a84f; }
+.fn-end-round { font-size: 0.65rem; margin-left: 0.35rem; color: #2f2f2f; }
 .power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
 .power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.2rem; font-size: 0.72rem; font-weight: 700; }
 .power-track-name { text-transform: uppercase; white-space: nowrap; }


### PR DESCRIPTION
### Motivation
- Allow entering explicit weapon power levels as comma-separated values (e.g. `1,2,6`) instead of a single numeric level count so the Functions editor can express arbitrary, non-sequential level sets. 
- Make preview linkage and slot visibility driven by the presence of parsed values rather than a numeric level field so UI behavior matches the new input shape.

### Description
- Replaced per-weapon numeric `levels` inputs with comma-separated text inputs `fnWpn[A-D]Values` and added `parseFunctionValues(raw)` to parse and trim the CSV tokens. 
- Replaced the old sequential-builder approach (removed `buildSequentialValues`) by reading `weapons[*].values` from `readFunctionsConfig()` and using value presence/length for logic. 
- Implemented `renderFunctions(functionsConfig)` to render function rows as dots/tokens in the preview and updated preview wiring to call it; updated `weaponSlot()` to accept an `enabled` flag and hide slots when the corresponding function track is off or has no parsed values. 
- Updated draft restore and form defaults to round-trip comma-separated weapon value fields and added `syncDerivedFunctionInputs()` to keep derived labels in sync; refreshed `index.html` and `styles.css` to add the new editor inputs, placeholders, and visual styling. 

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` which completed with no errors (success). 
- Launched a local server using `python -m http.server --directory .` and loaded the page to validate UI (success). 
- Captured a Playwright screenshot of `http://127.0.0.1:8008/starforce-commander-ship-designer/index.html` to verify layout and the comma-separated inputs render and behave as expected (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699910322fd88332b3ce1cf19f7504bf)