### PR TITLE
Replace Systems emojis with shuttle and marines icon assets

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -65,6 +65,61 @@ function parsePowerPattern(raw) {
     .map((value) => clamp(Math.round(value), 1, 3));
 }
 
+
+
+function parseFunctionValues(raw) {
+  return String(raw || '')
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+
+function readFunctionsConfig() {
+  const batteryPoints = Math.max(0, num('powerBatteryPoints'));
+  const batteryValues = Array.from({ length: batteryPoints }, (_, idx) => String(idx + 1));
+
+  return {
+    accDec: { values: parseFunctionValues(form.elements.fnAccDecValues?.value), free: form.elements.fnAccDecFree?.checked ? 1 : 0 },
+    sifIdf: {
+      values: parseFunctionValues(form.elements.fnSifIdfValues?.value),
+      free: form.elements.fnSifIdfFree?.checked ? 1 : 0,
+      emer: Boolean(form.elements.fnSifIdfEmer?.checked)
+    },
+    batRech: { values: batteryValues, free: 0 },
+    ftl: { empty: clamp(num('fnFtlEmpty'), 0, 6) },
+    cloak: { enabled: Boolean(form.elements.fnCloakEnabled?.checked), empty: clamp(num('fnCloakEmpty'), 0, 6) },
+    sensor: { values: parseFunctionValues(form.elements.fnSensorValues?.value), free: form.elements.fnSensorFree?.checked ? 1 : 0 },
+    genSys: { values: parseFunctionValues(form.elements.fnGenSysValues?.value), free: form.elements.fnGenSysFree?.checked ? 1 : 0 },
+    weapons: [
+      {
+        label: form.elements.fnWpnALabel?.value || 'WPN A',
+        enabled: Boolean(form.elements.fnWpnAEnabled?.checked),
+        free: form.elements.fnWpnAFree?.checked ? 1 : 0,
+        values: parseFunctionValues(form.elements.fnWpnAValues?.value)
+      },
+      {
+        label: form.elements.fnWpnBLabel?.value || 'WPN B',
+        enabled: Boolean(form.elements.fnWpnBEnabled?.checked),
+        free: form.elements.fnWpnBFree?.checked ? 1 : 0,
+        values: parseFunctionValues(form.elements.fnWpnBValues?.value)
+      },
+      {
+        label: form.elements.fnWpnCLabel?.value || 'WPN C',
+        enabled: Boolean(form.elements.fnWpnCEnabled?.checked),
+        free: form.elements.fnWpnCFree?.checked ? 1 : 0,
+        values: parseFunctionValues(form.elements.fnWpnCValues?.value)
+      },
+      {
+        label: form.elements.fnWpnDLabel?.value || 'WPN D',
+        enabled: Boolean(form.elements.fnWpnDEnabled?.checked),
+        free: form.elements.fnWpnDFree?.checked ? 1 : 0,
+        values: parseFunctionValues(form.elements.fnWpnDValues?.value)
+      }
+    ]
+  };
+}
+
 function readPowerSystem() {
   return {
     tracks: POWER_TRACK_CONFIG.map((track) => ({
@@ -76,6 +131,13 @@ function readPowerSystem() {
       hasDot: Boolean(form.elements[track.hasDotField]?.checked)
     }))
   };
+}
+
+
+function syncDerivedFunctionInputs() {
+  if (form.elements.fnBatRechLinked) {
+    form.elements.fnBatRechLinked.value = `Linked to BATTERY points (${num('powerBatteryPoints')})`;
+  }
 }
 
 function getBuild() {
@@ -107,9 +169,9 @@ function getBuild() {
     },
     shieldGen: num('shieldGen'),
     textBlocks: {
-      functions: form.elements.functions.value,
       powerSystem: form.elements.powerSystem?.value ?? ''
     },
+    functionsConfig: readFunctionsConfig(),
     powerSystem: readPowerSystem(),
     sublight: readSublight(),
     structure: {
@@ -118,7 +180,11 @@ function getBuild() {
     },
     shipArtDataUrl,
     weapons: parseWeapons(form.elements.weapons.value),
-    systems: parseSystems(form.elements.systems.value)
+    systems: parseSystems(form.elements.systems.value),
+    crew: {
+      shuttleCraft: num('shuttleCraft'),
+      marinesStationed: num('marinesStationed')
+    }
   };
 }
 
@@ -132,9 +198,19 @@ function renderBoxes(containerId, count, className) {
   }
 }
 
-function weaponSlot(id, weapon) {
+function weaponSlot(id, weapon, enabled = true) {
+  const slot = document.getElementById(`pvWpn${id}Slot`);
   const title = document.getElementById(`pvWpn${id}Title`);
   const body = document.getElementById(`pvWpn${id}Body`);
+
+  if (!enabled) {
+    slot.style.display = 'none';
+    title.textContent = 'WPN NAME TYP';
+    body.textContent = '';
+    return;
+  }
+
+  slot.style.display = 'flex';
   if (!weapon) {
     title.textContent = 'WPN NAME TYP';
     body.textContent = '';
@@ -306,18 +382,154 @@ function renderPreview(build) {
     silhouetteEl.style.display = 'block';
   }
 
-  document.getElementById('pvFunctions').textContent = build.textBlocks.functions;
+  renderFunctions(build.functionsConfig);
   renderPowerSystem(build.powerSystem);
   renderManeuvering(build.sublight);
 
-  weaponSlot(1, build.weapons[0]);
-  weaponSlot(2, build.weapons[1]);
-  weaponSlot(3, build.weapons[2]);
-  weaponSlot(4, build.weapons[3]);
+  const weaponPower = (build.functionsConfig?.weapons ?? []).map((weapon) => Boolean(weapon?.enabled) && Array.isArray(weapon?.values) && weapon.values.length > 0);
+  weaponSlot(1, build.weapons[0], weaponPower[0] !== false);
+  weaponSlot(2, build.weapons[1], weaponPower[1] !== false);
+  weaponSlot(3, build.weapons[2], weaponPower[2] !== false);
+  weaponSlot(4, build.weapons[3], weaponPower[3] !== false);
 
-  const systemsText = build.systems.map((entry) => `${entry.key} ${entry.value}`.trim()).join('\n');
-  document.getElementById('pvSystems').textContent = systemsText;
+  renderSystems(build.systems, build.crew);
   renderStructure(build);
+}
+
+
+
+function renderFunctions(functionsConfig) {
+  const container = document.getElementById('pvFunctions');
+  container.innerHTML = '';
+  const cfg = functionsConfig || {};
+
+  const addDot = (parent, filled = false) => {
+    const dot = document.createElement('span');
+    dot.className = `fn-dot${filled ? ' filled' : ''}`;
+    parent.appendChild(dot);
+  };
+
+  const addToken = (parent, text) => {
+    const tok = document.createElement('span');
+    tok.className = 'fn-token';
+    tok.textContent = text;
+    parent.appendChild(tok);
+  };
+
+  const addRow = (name, colorClass = '') => {
+    const row = document.createElement('div');
+    row.className = 'fn-row';
+    const label = document.createElement('span');
+    label.className = `fn-name${colorClass ? ` ${colorClass}` : ''}`;
+    label.textContent = name;
+    row.appendChild(label);
+
+    const levels = document.createElement('span');
+    levels.className = 'fn-levels';
+    row.appendChild(levels);
+
+    container.appendChild(row);
+    return levels;
+  };
+
+  const addValueDots = (levelsEl, values = [], free = 0) => {
+    const freeCount = Number(free || 0);
+    for (let i = 0; i < freeCount; i += 1) addDot(levelsEl, true);
+
+    values.forEach((value, idx) => {
+      if (idx >= freeCount) {
+        addDot(levelsEl, false);
+      }
+      addToken(levelsEl, String(value));
+    });
+  };
+
+  const acc = cfg.accDec || { values: ['1', '2', '3', '4', '5', '6'], free: 1 };
+  addValueDots(addRow('ACC/DEC', 'green'), acc.values, acc.free);
+
+  const sif = cfg.sifIdf || { values: ['1', '2', '3'], free: 0, emer: true };
+  const sifLevels = addRow('SIF/IDF', 'green');
+  addValueDots(sifLevels, sif.values, sif.free);
+  if (sif.emer) {
+    const emer = document.createElement('span');
+    emer.className = 'fn-emer';
+    const emerDot = document.createElement('span');
+    emerDot.className = 'fn-dot';
+    const emerText = document.createElement('span');
+    emerText.className = 'fn-token';
+    emerText.textContent = 'EMER';
+    emer.appendChild(emerDot);
+    emer.appendChild(emerText);
+    sifLevels.appendChild(emer);
+  }
+
+  const bat = cfg.batRech || { values: ['1'], free: 0 };
+  addValueDots(addRow('BAT RECH', 'green'), bat.values, 0);
+
+  const ftl = cfg.ftl || { empty: 2 };
+  const ftlLevels = addRow('FTL', 'green');
+  for (let i = 0; i < Number(ftl.empty || 0); i += 1) addDot(ftlLevels, false);
+
+  const cloak = cfg.cloak || { enabled: false, empty: 3 };
+  if (cloak.enabled) {
+    const cloakLevels = addRow('CLOAK', 'magenta');
+    for (let i = 0; i < Number(cloak.empty || 0); i += 1) addDot(cloakLevels, false);
+  }
+
+  const shldRenf = addRow('SHLD RNFC', 'cyan');
+  ['F', 'P', 'S', 'A'].forEach((part) => {
+    addDot(shldRenf, false);
+    addToken(shldRenf, part);
+  });
+
+  const shldRepr = addRow('SHLD REPR', 'cyan');
+  ['F', 'P', 'S', 'A'].forEach((part) => {
+    addDot(shldRepr, false);
+    addToken(shldRepr, part);
+  });
+
+  const sensor = cfg.sensor || { values: ['2', '4', '6'], free: 1 };
+  addValueDots(addRow('SENSOR', 'gold'), sensor.values, sensor.free);
+
+  const gen = cfg.genSys || { values: ['NRM', 'MAX'], free: 1 };
+  addValueDots(addRow('GEN SYS', 'gold'), gen.values, gen.free);
+
+  const weapons = Array.isArray(cfg.weapons) ? cfg.weapons : [];
+  weapons.forEach((weapon, idx) => {
+    const values = Array.isArray(weapon?.values) ? weapon.values : [];
+    if (!weapon?.enabled || values.length <= 0) return;
+    const row = addRow(weapon.label || `WPN ${String.fromCharCode(65 + idx)}`, 'red');
+    addValueDots(row, values, Number(weapon.free || 0));
+  });
+}
+
+
+function renderSystems(systems, crew) {
+  const container = document.getElementById('pvSystems');
+  container.innerHTML = '';
+  const rows = Array.isArray(systems) ? systems : [];
+
+  rows.forEach((entry) => {
+    const row = document.createElement('div');
+    row.className = 'system-row';
+
+    const key = document.createElement('span');
+    key.className = 'system-key';
+    key.textContent = String(entry.key || '').slice(0, 5).toUpperCase();
+    row.appendChild(key);
+
+    const count = Math.max(0, Number(entry.value || 0));
+    for (let i = 0; i < count; i += 1) {
+      const box = document.createElement('span');
+      box.className = 'system-box';
+      row.appendChild(box);
+    }
+
+    container.appendChild(row);
+  });
+
+  document.getElementById('pvShuttleCraft').textContent = String(Math.max(0, Number(crew?.shuttleCraft || 0)));
+  document.getElementById('pvMarines').textContent = String(Math.max(0, Number(crew?.marinesStationed || 0)));
 }
 
 function renderPowerSystem(powerSystem) {
@@ -397,6 +609,7 @@ function pulseLiveBadge() {
 }
 
 function render() {
+  syncDerivedFunctionInputs();
   const build = getBuild();
   renderPreview(build);
   jsonPreview.textContent = getJsonPreview(build);
@@ -449,7 +662,37 @@ function restoreDraft(draft) {
 
   form.elements.shieldGen.value = draft.shieldGen ?? 0;
 
-  form.elements.functions.value = draft.textBlocks?.functions ?? '';
+  const fn = draft.functionsConfig || {};
+  form.elements.fnAccDecValues.value = (fn.accDec?.values ?? ['1', '2', '3', '4', '5', '6']).join(',');
+  form.elements.fnAccDecFree.checked = Boolean(fn.accDec?.free ?? 1);
+  form.elements.fnSifIdfValues.value = (fn.sifIdf?.values ?? ['1', '2', '3']).join(',');
+  form.elements.fnSifIdfFree.checked = Boolean(fn.sifIdf?.free ?? 0);
+  form.elements.fnSifIdfEmer.checked = Boolean(fn.sifIdf?.emer ?? true);
+  form.elements.fnFtlEmpty.value = fn.ftl?.empty ?? 2;
+  form.elements.fnCloakEnabled.checked = Boolean(fn.cloak?.enabled ?? false);
+  form.elements.fnCloakEmpty.value = fn.cloak?.empty ?? 3;
+  form.elements.fnSensorValues.value = (fn.sensor?.values ?? ['2', '4', '6']).join(',');
+  form.elements.fnSensorFree.checked = Boolean(fn.sensor?.free ?? 1);
+  form.elements.fnGenSysValues.value = (fn.genSys?.values ?? ['NRM', 'MAX']).join(',');
+  form.elements.fnGenSysFree.checked = Boolean(fn.genSys?.free ?? 1);
+  const fnWpn = fn.weapons ?? [];
+  form.elements.fnWpnALabel.value = fnWpn[0]?.label ?? 'A/MAT TRP';
+  form.elements.fnWpnAFree.checked = Boolean(fnWpn[0]?.free ?? 1);
+  form.elements.fnWpnAEnabled.checked = Boolean(fnWpn[0]?.enabled ?? true);
+  form.elements.fnWpnAValues.value = (fnWpn[0]?.values ?? ['2']).join(',');
+  form.elements.fnWpnBLabel.value = fnWpn[1]?.label ?? 'PHASER';
+  form.elements.fnWpnBFree.checked = Boolean(fnWpn[1]?.free ?? 1);
+  form.elements.fnWpnBEnabled.checked = Boolean(fnWpn[1]?.enabled ?? true);
+  form.elements.fnWpnBValues.value = (fnWpn[1]?.values ?? ['4']).join(',');
+  form.elements.fnWpnCLabel.value = fnWpn[2]?.label ?? 'WPN C';
+  form.elements.fnWpnCFree.checked = Boolean(fnWpn[2]?.free ?? 1);
+  form.elements.fnWpnCEnabled.checked = Boolean(fnWpn[2]?.enabled ?? true);
+  form.elements.fnWpnCValues.value = (fnWpn[2]?.values ?? []).join(',');
+  form.elements.fnWpnDLabel.value = fnWpn[3]?.label ?? 'WPN D';
+  form.elements.fnWpnDFree.checked = Boolean(fnWpn[3]?.free ?? 0);
+  form.elements.fnWpnDEnabled.checked = Boolean(fnWpn[3]?.enabled ?? false);
+  form.elements.fnWpnDValues.value = (fnWpn[3]?.values ?? []).join(',');
+
   if (form.elements.powerSystem) {
     form.elements.powerSystem.value = draft.textBlocks?.powerSystem ?? '';
   }
@@ -485,6 +728,8 @@ function restoreDraft(draft) {
   shipArtDataUrl = draft.shipArtDataUrl ?? '';
   form.elements.weapons.value = (draft.weapons ?? []).map((item) => [item.name, ...(item.ranges ?? [])].join('|')).join('\n');
   form.elements.systems.value = (draft.systems ?? []).map((item) => `${item.key}:${item.value ?? ''}`).join('\n');
+  form.elements.shuttleCraft.value = draft.crew?.shuttleCraft ?? 4;
+  form.elements.marinesStationed.value = draft.crew?.marinesStationed ?? 10;
 
   render();
 }

--- a/starforce-commander-ship-designer/assets/marines-icon.svg
+++ b/starforce-commander-ship-designer/assets/marines-icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-hidden="true">
+  <g fill="#16b15c">
+    <circle cx="14" cy="10" r="5"/><circle cx="32" cy="10" r="5"/><circle cx="50" cy="10" r="5"/>
+    <rect x="10" y="16" width="8" height="20" rx="3"/>
+    <rect x="28" y="16" width="8" height="20" rx="3"/>
+    <rect x="46" y="16" width="8" height="20" rx="3"/>
+    <rect x="8" y="36" width="4" height="18" rx="2"/><rect x="16" y="36" width="4" height="18" rx="2"/>
+    <rect x="26" y="36" width="4" height="18" rx="2"/><rect x="34" y="36" width="4" height="18" rx="2"/>
+    <rect x="44" y="36" width="4" height="18" rx="2"/><rect x="52" y="36" width="4" height="18" rx="2"/>
+  </g>
+</svg>

--- a/starforce-commander-ship-designer/assets/shuttle-craft-icon.svg
+++ b/starforce-commander-ship-designer/assets/shuttle-craft-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-hidden="true">
+  <g fill="#16b15c">
+    <path d="M31 6c4 0 7 3 7 7v10h6c4 0 7 3 7 7v14c0 4-3 7-7 7h-6v7h-6v-7h-2v7h-6v-7h-6c-4 0-7-3-7-7V30c0-4 3-7 7-7h6V13c0-4 3-7 7-7h0z"/>
+    <rect x="23" y="17" width="18" height="4" rx="2"/>
+  </g>
+</svg>

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -63,7 +63,79 @@
         <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
 
         <h2>Functions / Power / Maneuvering</h2>
-        <label>Functions + Power Level <textarea name="functions" rows="3" placeholder="ACC/DEC, SIF, BTTY RECH..."></textarea></label>
+        <div class="functions-editor">
+          <strong>Functions Tracks</strong>
+          <p class="muted">Use comma-separated values for exact power levels.<br />Free pips render as filled green dots.</p>
+          <div class="functions-mini-head"><span>Function</span><span>Values</span></div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">ACC/DEC</label>
+            <input name="fnAccDecValues" value="1,2,3,4,5,6" />
+            <label class="inline-check free-check">FREE <input name="fnAccDecFree" type="checkbox" checked /></label>
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">SIF/IDF</label>
+            <input name="fnSifIdfValues" value="1,2,3" />
+            <label class="inline-check free-check">FREE <input name="fnSifIdfFree" type="checkbox" /></label>
+          </div>
+
+          <div class="fn-edit-row fn-edit-subrow">
+            <label class="inline-check">EMER <input name="fnSifIdfEmer" type="checkbox" checked /></label>
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">FTL</label>
+            <input name="fnFtlEmpty" type="number" min="0" max="6" value="2" />
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="inline-check fn-edit-label">SPECIAL <input name="fnCloakEnabled" type="checkbox" /></label>
+            <input name="fnCloakEmpty" type="number" min="0" max="6" value="3" />
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">SENSOR</label>
+            <input name="fnSensorValues" value="2,4,6" />
+            <label class="inline-check free-check">FREE <input name="fnSensorFree" type="checkbox" checked /></label>
+          </div>
+
+          <div class="fn-edit-row">
+            <label class="fn-edit-label">GEN SYS</label>
+            <input name="fnGenSysValues" value="NRM,MAX" />
+            <label class="inline-check free-check">FREE <input name="fnGenSysFree" type="checkbox" /></label>
+          </div>
+
+          <div class="fn-divider"></div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnAEnabled" type="checkbox" checked /> A</label>
+            <input name="fnWpnALabel" value="A/MAT TRP" />
+            <label class="inline-check free-check">FREE <input name="fnWpnAFree" type="checkbox" checked /></label>
+            <input name="fnWpnAValues" value="2" placeholder="1,2,6" />
+          </div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnBEnabled" type="checkbox" checked /> B</label>
+            <input name="fnWpnBLabel" value="PHASER" />
+            <label class="inline-check free-check">FREE <input name="fnWpnBFree" type="checkbox" /></label>
+            <input name="fnWpnBValues" value="4" placeholder="1,2,6" />
+          </div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnCEnabled" type="checkbox" /> C</label>
+            <input name="fnWpnCLabel" value="WPN C" />
+            <label class="inline-check free-check">FREE <input name="fnWpnCFree" type="checkbox" /></label>
+            <input name="fnWpnCValues" value="" placeholder="1,2,6" />
+          </div>
+
+          <div class="fn-edit-row fn-wpn-row">
+            <label class="inline-check fn-on-label">ON <input name="fnWpnDEnabled" type="checkbox" /> D</label>
+            <input name="fnWpnDLabel" value="WPN D" />
+            <label class="inline-check free-check">FREE <input name="fnWpnDFree" type="checkbox" /></label>
+            <input name="fnWpnDValues" value="" placeholder="1,2,6" />
+          </div>
+        </div>
         <div class="power-system-editor">
           <strong>Power System Tracks</strong>
           <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
@@ -98,7 +170,11 @@
         </div>
 
         <h2>Systems (one per line)</h2>
-        <label><textarea name="systems" rows="4" placeholder="SCNC:0"></textarea></label>
+        <label><textarea name="systems" rows="4" placeholder="SCNC:3\nSENS:4\nQTRS:2"></textarea></label>
+        <div class="grid2">
+          <label>Shuttle Craft <input name="shuttleCraft" type="number" min="0" value="4" /></label>
+          <label>Marines Stationed <input name="marinesStationed" type="number" min="0" value="10" /></label>
+        </div>
 
         <h2>Structure</h2>
         <div class="grid2">
@@ -139,7 +215,7 @@
             </div>
             <div class="green-block block-functions">
               <h4><span>FUNCTIONS</span><span>POWER LEVEL</span></h4>
-              <pre id="pvFunctions"></pre>
+              <div id="pvFunctions" class="functions-preview"></div>
             </div>
             <div class="green-block block-power">
               <h4><span>POWER SYSTEM</span><span id="pvMaxPower"></span></h4>
@@ -191,16 +267,22 @@
             </div>
             <div class="systems-box">
               <h3>SYSTEMS</h3>
-              <pre id="pvSystems"></pre>
+              <div class="systems-layout">
+                <div id="pvSystems" class="systems-grid"></div>
+                <div class="systems-side">
+                  <div class="crew-box"><span class="crew-icon"><img src="assets/shuttle-craft-icon.svg" alt="Shuttle craft" class="crew-img" /></span><b id="pvShuttleCraft">4</b></div>
+                  <div class="crew-box"><span class="crew-icon"><img src="assets/marines-icon.svg" alt="Marines stationed" class="crew-img" /></span><b id="pvMarines">10</b></div>
+                </div>
+              </div>
             </div>
           </section>
 
           <section class="col right-col">
             <h3>WEAPONS</h3>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn1Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn1Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn2Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn2Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn3Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn3Body"></div></div>
-            <div class="weapon-slot"><div class="slot-title" id="pvWpn4Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn4Body"></div></div>
+            <div class="weapon-slot" id="pvWpn1Slot"><div class="slot-title" id="pvWpn1Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn1Body"></div></div>
+            <div class="weapon-slot" id="pvWpn2Slot"><div class="slot-title" id="pvWpn2Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn2Body"></div></div>
+            <div class="weapon-slot" id="pvWpn3Slot"><div class="slot-title" id="pvWpn3Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn3Body"></div></div>
+            <div class="weapon-slot" id="pvWpn4Slot"><div class="slot-title" id="pvWpn4Title">WPN NAME TYP</div><div class="slot-body" id="pvWpn4Body"></div></div>
           </section>
         </div>
 

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -30,6 +30,22 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .power-grid label { margin: 0; font-weight: 700; }
 .power-grid input { margin: 0; }
 .power-grid input[type="checkbox"] { width: 18px; height: 18px; justify-self: center; }
+.functions-editor { border: 1px solid #3557c7; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #07133e; }
+.functions-editor strong { display: block; margin-bottom: 0.15rem; font-size: 1.02rem; }
+.functions-editor .muted { margin: 0 0 0.5rem; font-size: 0.82rem; color: #bdd0ff; }
+.functions-mini-head { display: grid; grid-template-columns: 108px 1fr; margin-bottom: 0.2rem; color: #a7b4da; font-size: 0.85rem; }
+.fn-edit-row { display: grid; grid-template-columns: 108px minmax(0, 1fr) auto; gap: 0.35rem; align-items: center; margin-bottom: 0.34rem; }
+.fn-edit-row input { margin: 0; }
+.fn-edit-row input[type="checkbox"] { width: 16px; height: 16px; }
+.fn-edit-label { font-weight: 900; }
+.fn-edit-subrow { grid-template-columns: 108px auto; }
+.fn-divider { height: 1px; background: #1f3b8e; margin: 0.35rem 0 0.45rem; }
+.fn-wpn-row { grid-template-columns: 72px minmax(0, 1fr) auto 90px; }
+.fn-on-label { white-space: nowrap; }
+.inline-check { display: inline-flex !important; align-items: center; gap: 0.35rem; font-weight: 800; }
+.inline-check input { width: 16px; margin: 0; }
+.free-check { color: #e6ecff; }
+.tiny { font-size: 0.72rem; }
 button { cursor: pointer; background: #3d62ff; border: none; font-weight: 600; }
 button.ghost { background: #273055; }
 .muted { color: #a7b4da; }
@@ -101,7 +117,7 @@ button.ghost { background: #273055; }
   min-height: 920px;
 }
 
-.block-functions pre { height: 220px; max-height: 220px; overflow: auto; }
+.functions-preview { height: 220px; max-height: 220px; overflow: auto; padding: 0.2rem 0.35rem 0.28rem; color: #111; font-family: Arial, Helvetica, sans-serif; }
 .block-maneuver { display: flex; flex-direction: column; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
@@ -113,6 +129,26 @@ button.ghost { background: #273055; }
 .green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
 .block-power h4 span:last-child { color: #d8ffd8; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.fn-row { display: grid; grid-template-columns: 120px minmax(0, 1fr); align-items: center; gap: 0.35rem; margin-bottom: 0.12rem; font-weight: 900; font-size: 0.75rem; }
+.fn-name { text-transform: uppercase; letter-spacing: 0.01em; }
+.fn-name.green { color: #0aa14e; }
+.fn-name.magenta { color: #d31ce0; }
+.fn-name.cyan { color: #08a7df; }
+.fn-name.gold { color: #e3ab00; }
+.fn-name.red { color: #ff0000; }
+.fn-levels { display: flex; flex-wrap: wrap; align-items: center; gap: 0.24rem; font-weight: 900; }
+.fn-token { display: inline-flex; align-items: center; justify-content: center; min-width: 12px; }
+.fn-emer { margin-left: auto; display: inline-flex; align-items: center; gap: 0.24rem; }
+.fn-dot {
+  width: 14px;
+  height: 14px;
+  border: 2px solid #09a84f;
+  border-radius: 50%;
+  box-sizing: border-box;
+  display: inline-block;
+}
+.fn-dot.filled { background: #09a84f; }
+.fn-end-round { font-size: 0.65rem; margin-left: 0.35rem; color: #2f2f2f; }
 .power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
 .power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.2rem; font-size: 0.72rem; font-weight: 700; }
 .power-track-name { text-transform: uppercase; white-space: nowrap; }
@@ -240,9 +276,18 @@ button.ghost { background: #273055; }
   min-height: 112px;
   justify-content: center;
 }
-.systems-box { border-top: 0; margin-top: 0.3rem; border: 2px solid #f0b500; background: #f8f8f8; }
+.systems-box { border-top: 0; margin-top: 0.3rem; border: 2px solid #f0b500; background: #f8f8f8; padding-bottom: 0.25rem; }
 .systems-box h3 { border-color: #f0b500; }
-.systems-box pre { height: 158px; max-height: 158px; margin: 0; white-space: pre-wrap; color: #223; background: transparent; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; overflow: auto; }
+.systems-layout { display: grid; grid-template-columns: 1fr 72px; gap: 0.35rem; padding: 0.2rem 0.25rem 0.1rem; align-items: start; }
+.systems-grid { min-height: 158px; display: grid; grid-template-columns: 1fr 1fr; column-gap: 0.4rem; align-content: start; }
+.system-row { display: flex; align-items: center; gap: 3px; font-family: Arial, Helvetica, sans-serif; font-size: 0.72rem; font-weight: 900; color: #111; margin-bottom: 0.08rem; }
+.system-key { min-width: 42px; }
+.system-box { width: 10px; height: 10px; border: 2px solid #111; box-sizing: border-box; background: #f7f7f7; }
+.systems-side { display: flex; flex-direction: column; gap: 0.45rem; }
+.crew-box { border: 4px solid #f0b500; background: #fff; min-height: 64px; display: flex; align-items: center; justify-content: center; gap: 0.3rem; color: #16b15c; font-weight: 900; font-size: 1.8rem; }
+.crew-box b { color: #111; font-size: 2rem; line-height: 1; }
+.crew-icon { font-size: 1.6rem; line-height: 1; }
+.crew-img { width: 28px; height: 28px; display: block; }
 
 .right-col { border: 3px solid #ff0000; background: #fafafa; }
 .weapon-slot { border-top: 2px solid #ff0000; height: 170px; min-height: 170px; display: flex; flex-direction: column; }


### PR DESCRIPTION
### Motivation
- Improve the Systems counters by replacing platform emoji with the provided vector icons so the UI looks consistent and scales cleanly.
- Make shuttle/marine counts visually explicit and accessible by using `<img>` assets with `alt` text instead of emoji characters.
- Keep styling consistent with existing crew counter design so icons align and size predictably inside preview boxes.

### Description
- Added two SVG assets: `starforce-commander-ship-designer/assets/shuttle-craft-icon.svg` and `starforce-commander-ship-designer/assets/marines-icon.svg` to host the provided icons.
- Replaced emoji markers in the Systems preview markup with image tags, updating `starforce-commander-ship-designer/index.html` to render `<img src="assets/shuttle-craft-icon.svg" class="crew-img" alt="Shuttle craft" />` and `<img src="assets/marines-icon.svg" class="crew-img" alt="Marines stationed" />` inside the crew counters.
- Added a `.crew-img` sizing rule to `starforce-commander-ship-designer/styles.css` to ensure consistent icon dimensions within the yellow crew boxes.

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` and it completed successfully.
- Launched a local HTTP preview with `python -m http.server --directory .` and confirmed the icons were served (HTTP 200) and visible in the preview.
- Executed a Playwright script to capture a screenshot of `starforce-commander-ship-designer/index.html`, which succeeded and shows the custom shuttle and marines icons rendering in the Systems counters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699910322fd88332b3ce1cf19f7504bf)