### PR TITLE
Update Starforce SSD defaults and remove size class icon URL input

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -145,7 +145,6 @@ function getBuild() {
     identity: {
       name: form.elements.name.value,
       classType: form.elements.classType.value,
-      sizeClassIcon: form.elements.sizeClassIcon.value,
       faction: form.elements.faction.value,
       era: form.elements.era.value
     },
@@ -327,13 +326,7 @@ function renderPreview(build) {
   document.getElementById('pvName').textContent = build.identity.name || 'SHIP NAME / ID';
   document.getElementById('pvClass').textContent = build.identity.classType || 'CLASSNAME ID-class Weight Class';
   document.getElementById('pvFaction').textContent = build.identity.faction || 'COMMON';
-  const sizeClassIcon = document.getElementById('pvSizeClassIcon');
-  const defaultSizeClassIcon = 'assets/size-class-icon.svg';
-  sizeClassIcon.onerror = () => {
-    if (sizeClassIcon.src.endsWith(defaultSizeClassIcon)) return;
-    sizeClassIcon.src = defaultSizeClassIcon;
-  };
-  sizeClassIcon.src = build.identity.sizeClassIcon || build.identity.hullIcon || defaultSizeClassIcon;
+  document.getElementById('pvSizeClassIcon').src = 'assets/size-class-icon.svg';
   document.getElementById('pvEra').textContent = build.identity.era || 'ERA';
 
   document.getElementById('pvMove').textContent = build.engineering.move;
@@ -641,14 +634,13 @@ function renderDrafts() {
 function restoreDraft(draft) {
   form.elements.name.value = draft.identity?.name ?? '';
   form.elements.classType.value = draft.identity?.classType ?? '';
-  form.elements.sizeClassIcon.value = draft.identity?.sizeClassIcon ?? draft.identity?.hullIcon ?? 'assets/size-class-icon.svg';
   form.elements.faction.value = draft.identity?.faction ?? '';
   form.elements.era.value = draft.identity?.era ?? '';
 
-  form.elements.move.value = draft.engineering?.move ?? 0;
-  form.elements.vector.value = draft.engineering?.vector ?? 0;
-  form.elements.turn.value = draft.engineering?.turn ?? 0;
-  form.elements.special.value = draft.engineering?.special ?? 0;
+  form.elements.move.value = draft.engineering?.move ?? 3;
+  form.elements.vector.value = draft.engineering?.vector ?? 2;
+  form.elements.turn.value = draft.engineering?.turn ?? 2;
+  form.elements.special.value = draft.engineering?.special ?? 3;
 
   form.elements.shieldFwd.value = draft.shields?.forward ?? 0;
   form.elements.shieldAft.value = draft.shields?.aft ?? 0;

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -16,7 +16,6 @@
         <h2>Identity</h2>
         <label>Ship Name / ID <input name="name" value="SHIP NAME / ID" /></label>
         <label>Class Label <input name="classType" value="CLASSNAME ID-class Weight Class" /></label>
-        <label>Size Class Icon URL <input name="sizeClassIcon" value="assets/size-class-icon.svg" /></label>
         <div class="grid2">
           <label>Faction <input name="faction" value="COMMON" /></label>
           <label>Era <input name="era" value="ERA" /></label>
@@ -24,10 +23,10 @@
 
         <h2>Engineering</h2>
         <div class="grid2">
-          <label>Size Class <input name="move" type="number" min="0" value="0" /></label>
-          <label>Acceleration <input name="vector" type="number" min="0" value="0" /></label>
-          <label>Stress Damage <input name="turn" type="number" min="0" value="0" /></label>
-          <label>Damage Control <input name="special" type="number" min="0" value="0" /></label>
+          <label>Size Class <input name="move" type="number" min="0" value="3" /></label>
+          <label>Acceleration <input name="vector" type="number" min="0" value="2" /></label>
+          <label>Stress Damage <input name="turn" type="number" min="0" value="2" /></label>
+          <label>Damage Control <input name="special" type="number" min="0" value="3" /></label>
         </div>
 
         <h2>Shields</h2>


### PR DESCRIPTION
### Motivation
- The Size Class Icon URL field is no longer needed and should not be editable from the SSD designer form. 
- Starforce Commander SSDs should use a consistent built-in size-class icon instead of accepting a user-supplied URL. 
- Default engineering stats should be set to the standard values used for Starforce Commander SSDs.

### Description
- Removed the `Size Class Icon URL` input from the form in `starforce-commander-ship-designer/index.html` and set the visible input defaults for engineering to `move=3`, `vector=2`, `turn=2`, and `special=3`.
- Stopped serializing the now-unused `sizeClassIcon` field in `starforce-commander-ship-designer/app.js` so builds no longer include a user-provided icon value.
- Updated preview rendering to always set `pvSizeClassIcon.src` to the built-in asset `assets/size-class-icon.svg` instead of using a form value.
- Updated draft restore fallbacks in `app.js` so missing engineering values default to the new `3/2/2/3` values.

### Testing
- Ran a static server (`python3 -m http.server`) and manually verified the designer UI loads and the updated engineering defaults are shown. 
- Executed a Playwright script to load `http://127.0.0.1:4173/starforce-commander-ship-designer/` and captured a full-page screenshot to validate the updated form and preview rendering. 
- Verified via a grep check that `sizeClassIcon` is no longer referenced in the edited `index.html`/`app.js` files and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69992c04a81083328b5913e1e52acaec)