### PR TITLE
Redesign Starforce Commander SSD weapons editor and preview

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -58,8 +58,85 @@
         </label>
         <button type="button" id="clearArtBtn" class="ghost">Clear Ship Art</button>
 
-        <h2>Weapons (up to 4 lines)</h2>
-        <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
+        <h2>Weapons (up to 4)</h2>
+        <p class="muted">Each weapon supports up to 8 mounts, power circles/stops, structure, per-range dice colors, and optional SPECIAL text (enabled by the HVY trait).</p>
+        <div class="weapon-editor-list">
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon A</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn1Name" value="WPN NAME" /></label>
+              <label>Traits (comma separated) <input name="wpn1Traits" value="HVY, FTL, NoBAT" /></label>
+            </div>
+            <label>Mount arcs (up to 8, comma separated from: N, NE, E, SE, S, SW, W, NW)
+              <input name="wpn1MountArcs" value="N,NE" />
+            </label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn1PowerCircles" type="number" min="1" max="6" value="3" /></label>
+              <label>Power stop positions (comma) <input name="wpn1PowerStops" value="2" placeholder="2,4" /></label>
+              <label>Structure per mount (1-4) <input name="wpn1Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands (format band:color like <code>0-4:green</code>, comma separated)
+              <input name="wpn1Ranges" value="0-4:green,5-9:black,10-13:red,14-16:red" />
+            </label>
+            <label>Dice per band (use R,Y,G,B per structure point, separated by commas)
+              <input name="wpn1Dice" value="R,R,R,R|R,R,R,R|R,R,R,R|Y,Y,Y" />
+            </label>
+            <label>Special (shown only when HVY trait is present)
+              <input name="wpn1Special" value="H(4+1), STR 2" />
+            </label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon B</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn2Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn2Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn2MountArcs" value="" placeholder="N,E" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn2PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn2PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn2Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn2Ranges" value="" placeholder="0-6:green,7-12:black" /></label>
+            <label>Dice per band <input name="wpn2Dice" value="" placeholder="R,R|Y,Y" /></label>
+            <label>Special <input name="wpn2Special" value="" /></label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon C</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn3Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn3Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn3MountArcs" value="" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn3PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn3PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn3Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn3Ranges" value="" /></label>
+            <label>Dice per band <input name="wpn3Dice" value="" /></label>
+            <label>Special <input name="wpn3Special" value="" /></label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon D</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn4Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn4Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn4MountArcs" value="" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn4PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn4PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn4Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn4Ranges" value="" /></label>
+            <label>Dice per band <input name="wpn4Dice" value="" /></label>
+            <label>Special <input name="wpn4Special" value="" /></label>
+          </fieldset>
+        </div>
 
         <h2>Functions / Power / Maneuvering</h2>
         <div class="functions-editor">

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -289,11 +289,34 @@ button.ghost { background: #273055; }
 .crew-icon { font-size: 1.6rem; line-height: 1; }
 .crew-img { width: 28px; height: 28px; display: block; }
 
+.weapon-editor-list { display: grid; gap: 0.55rem; }
+.weapon-editor-card { border: 1px solid #9ca3af; border-radius: 10px; padding: 0.55rem; background: #f8fafc; }
+.weapon-editor-card legend { font-weight: 800; color: #0f172a; padding: 0 0.3rem; }
+.weapon-editor-card code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; }
+
 .right-col { border: 3px solid #ff0000; background: #fafafa; }
 .weapon-slot { border-top: 2px solid #ff0000; height: 170px; min-height: 170px; display: flex; flex-direction: column; }
 .weapon-slot:first-of-type { border-top: 0; }
 .slot-title { background: #ff0000; color: #fff; font-weight: 900; padding: 0.17rem 0.3rem; }
-.slot-body { white-space: pre-wrap; color: #233; padding: 0.35rem 0.38rem; min-height: 0; flex: 1; overflow: auto; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.slot-body { color: #233; padding: 0.35rem 0.38rem; min-height: 0; flex: 1; overflow: auto; font-family: Arial, Helvetica, sans-serif; font-size: 0.74rem; }
+.wpn-mount-row,.wpn-power-row,.wpn-structure-row,.wpn-special-row,.wpn-trait-row { display: flex; align-items: center; gap: 0.18rem; margin-bottom: 0.18rem; flex-wrap: wrap; }
+.wpn-mount-token { min-width: 1.45rem; text-align: center; border: 1px solid #64748b; color: #0f172a; font-weight: 800; background: #e2e8f0; padding: 0.04rem 0.15rem; border-radius: 3px; }
+.wpn-power-circle { width: 12px; height: 12px; border-radius: 999px; border: 3px solid #11a854; display: inline-block; box-sizing: border-box; }
+.wpn-power-stop { width: 8px; height: 8px; background: #11a854; transform: rotate(45deg); display: inline-block; }
+.wpn-structure-row b { margin-right: 0.25rem; }
+.wpn-structure-box { width: 10px; height: 10px; border: 2px solid #111; display: inline-block; }
+.wpn-range-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.12rem 0.2rem; align-items: center; }
+.wpn-range-band { text-align: center; font-weight: 800; font-size: 0.74rem; }
+.wpn-range-band.green { color: #10b981; }
+.wpn-range-band.black { color: #111827; }
+.wpn-range-band.red { color: #dc2626; }
+.wpn-dice-row { display: flex; justify-content: center; gap: 0.08rem; flex-wrap: wrap; }
+.wpn-die { width: 13px; height: 13px; border-radius: 999px; color: #fff; display: inline-flex; align-items: center; justify-content: center; font-size: 0.48rem; font-weight: 900; }
+.wpn-die.r { background: #ef4444; }
+.wpn-die.y { background: #eab308; color: #111; }
+.wpn-die.g { background: #22c55e; }
+.wpn-die.b { background: #3b82f6; }
+.wpn-special-row b,.wpn-trait-row b { color: #0b67b2; }
 
 .template-bottom {
   --structure-box-size: 12px;


### PR DESCRIPTION
### Motivation
- Provide a structured, feature-rich weapons editor to model mounts, arcs, power circles/stops, structure, per-range dice colors, and SPECIAL effects (enabled by the `HVY` trait) instead of the old freeform textarea. 
- Make weapon data first-class in the build model so the preview can render the multiple moving parts required by the SSD rules.

### Description
- Replaced the freeform weapons textarea in `index.html` with a 4-card per-weapon editor exposing fields: `name`, `traits`, `mountArcs`, `powerCircles`, `powerStops`, `structure`, `ranges`, `diceByRange`, and `special`.
- Added parsing and normalization utilities in `app.js`: `parseList`, `parseLegacyWeapons`, `parseWeaponRanges`, `parseWeaponDice`, `readWeaponsFromForm`, and `normalizeWeapon`, and switched `getBuild()` to use `readWeaponsFromForm()`.
- Reworked the preview renderer via an enhanced `weaponSlot` to visually display mount tokens, power circles and stops, structure boxes, colored range bands with dice pips, and trait/special rows (SPECIAL text only shown if `HVY` trait is present).
- Updated draft restore/serialization logic to hydrate the new editor fields and to normalize older legacy weapon payloads, and added CSS rules in `styles.css` for editor cards and preview elements.

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` to validate JS syntax, which succeeded.
- Ran `git diff --check` to ensure no diff-check issues, which returned no problems.
- Launched a local static server and used an automated headless browser script to load the page and capture a screenshot of the new editor/preview, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999bd125e608332b54b6dc78a3542bb)