### PR TITLE
Add per-mount facing input and wedge mount diagrams

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -16,15 +16,207 @@ const POWER_TRACK_CONFIG = [
   { key: 'ftlDrive', label: 'FTL DRIVE', pointsField: 'powerFtlDrivePoints', boxesField: 'powerFtlDriveBoxes', patternField: 'powerFtlDrivePattern', hasDotField: 'powerFtlDriveHasDot' }
 ];
 
-function parseWeapons(raw) {
-  return raw
+function parseList(raw, separator = ',') {
+  return String(raw || '')
+    .split(separator)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseLegacyWeapons(raw) {
+  return String(raw || '')
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
       const [name, ...ranges] = line.split('|').map((part) => part.trim());
-      return { name, ranges };
+      return {
+        name,
+        mountArcs: [],
+        powerCircles: 1,
+        powerStops: [],
+        structure: 1,
+        ranges: ranges.map((band) => ({ band, type: 'black' })),
+        diceByRange: ranges.map(() => ['R']),
+        traits: [],
+        special: ''
+      };
     });
+}
+
+function parseWeaponRanges(raw) {
+  const values = parseList(raw);
+  const parsed = [];
+
+  values.forEach((entry) => {
+    if (entry.includes(':')) {
+      const [band, type] = entry.split(':').map((part) => part.trim());
+      const normalizedType = ['green', 'black', 'red'].includes((type || '').toLowerCase())
+        ? type.toLowerCase()
+        : 'black';
+      parsed.push({ band: band || '?', type: normalizedType });
+    }
+  });
+
+  if (parsed.length > 0) {
+    return parsed;
+  }
+
+  for (let idx = 0; idx < values.length; idx += 2) {
+    const band = values[idx] || '?';
+    const rawType = values[idx + 1] || 'black';
+    const type = ['green', 'black', 'red'].includes(rawType.toLowerCase()) ? rawType.toLowerCase() : 'black';
+    parsed.push({ band, type });
+  }
+
+  return parsed;
+}
+
+function parseWeaponDice(raw) {
+  return String(raw || '')
+    .split('|')
+    .map((group) => parseList(group).map((token) => token.toUpperCase()));
+}
+
+function parseMountFacings(raw) {
+  return String(raw || '')
+    .split('|')
+    .map((group) => group.trim())
+    .filter(Boolean)
+    .map((group) => parseList(group).map((value) => clamp(Number(value), 1, 8)).filter((value) => Number.isFinite(value)));
+}
+
+function buildRangeProfile(ranges, diceByRange, structure = 1) {
+  return (Array.isArray(ranges) ? ranges : []).map((range, index) => ({
+    band: range.band || '?',
+    type: ['green', 'black', 'red'].includes((range.type || '').toLowerCase()) ? range.type.toLowerCase() : 'black',
+    dice: (Array.isArray(diceByRange?.[index]) ? diceByRange[index] : []).slice(0, Math.max(1, Number(structure || 1)))
+  }));
+}
+
+function readWeaponsFromForm() {
+  return [1, 2, 3, 4].map((index) => {
+    const name = form.elements[`wpn${index}Name`]?.value?.trim() || '';
+    return {
+      name,
+      mountArcs: parseList(form.elements[`wpn${index}MountArcs`]?.value),
+      mountFacings: parseMountFacings(form.elements[`wpn${index}MountArcs`]?.value),
+      powerCircles: clamp(num(`wpn${index}PowerCircles`), 1, 6),
+      powerStops: parseList(form.elements[`wpn${index}PowerStops`]?.value).map((value) => Number(value)).filter((value) => Number.isFinite(value)),
+      structure: clamp(num(`wpn${index}Structure`), 1, 4),
+      ranges: (() => {
+        const ranges = parseWeaponRanges(form.elements[`wpn${index}Ranges`]?.value);
+        const diceByRange = parseWeaponDice(form.elements[`wpn${index}Dice`]?.value);
+        return buildRangeProfile(ranges, diceByRange, clamp(num(`wpn${index}Structure`), 1, 4));
+      })(),
+      traits: parseList(form.elements[`wpn${index}Traits`]?.value),
+      special: form.elements[`wpn${index}Special`]?.value?.trim() || ''
+    };
+  });
+}
+
+function normalizeWeapon(weapon = {}) {
+  const structure = clamp(Number(weapon.structure || 1), 1, 4);
+  const normalizedRanges = Array.isArray(weapon.ranges)
+    ? weapon.ranges.map((range) => {
+      if (typeof range === 'string') {
+        return { band: range, type: 'black', dice: [] };
+      }
+      return {
+        band: range.band || '?',
+        type: ['green', 'black', 'red'].includes((range.type || '').toLowerCase()) ? range.type.toLowerCase() : 'black',
+        dice: (Array.isArray(range.dice) ? range.dice : []).slice(0, structure)
+      };
+    })
+    : [];
+
+  const rangeProfile = Array.isArray(weapon.rangeProfile)
+    ? weapon.rangeProfile.map((range) => ({
+      band: range.band || '?',
+      type: ['green', 'black', 'red'].includes((range.type || '').toLowerCase()) ? range.type.toLowerCase() : 'black',
+      dice: (Array.isArray(range.dice) ? range.dice : []).slice(0, structure)
+    }))
+    : buildRangeProfile(normalizedRanges, Array.isArray(weapon.diceByRange) ? weapon.diceByRange : [], structure).map((range, index) => ({
+      ...range,
+      dice: range.dice.length ? range.dice : (normalizedRanges[index]?.dice || []).slice(0, structure)
+    }));
+
+  const mountFacings = Array.isArray(weapon.mountFacings)
+    ? weapon.mountFacings.map((mount) => (Array.isArray(mount) ? mount.map((value) => clamp(Number(value), 1, 8)).filter((value) => Number.isFinite(value)) : []))
+    : (Array.isArray(weapon.mountArcs)
+      ? weapon.mountArcs.map((arc) => {
+        if (typeof arc === 'string' && arc.includes(',')) {
+          return parseList(arc).map((value) => clamp(Number(value), 1, 8)).filter((value) => Number.isFinite(value));
+        }
+        return [];
+      }).filter((mount) => mount.length > 0)
+      : []);
+
+  return {
+    name: weapon.name || '',
+    mountArcs: Array.isArray(weapon.mountArcs) ? weapon.mountArcs : [],
+    mountFacings,
+    powerCircles: clamp(Number(weapon.powerCircles || 1), 1, 6),
+    powerStops: Array.isArray(weapon.powerStops) ? weapon.powerStops : [],
+    structure,
+    ranges: rangeProfile,
+    rangeProfile,
+    traits: Array.isArray(weapon.traits) ? weapon.traits : [],
+    special: String(weapon.special || '')
+  };
+}
+
+function mountSectorPath(sector) {
+  const center = '24 24';
+  const pointMap = {
+    1: '2 2 24 2',
+    2: '24 2 46 2',
+    3: '46 2 46 24',
+    4: '46 24 46 46',
+    5: '46 46 24 46',
+    6: '24 46 2 46',
+    7: '2 46 2 24',
+    8: '2 24 2 2'
+  };
+  const pair = pointMap[sector] || '';
+  return pair ? `M ${center} L ${pair} Z` : '';
+}
+
+function createMountDiagram(facings, structure) {
+  const mount = document.createElement('div');
+  mount.className = 'wpn-mount';
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 48 48');
+  svg.setAttribute('class', 'wpn-mount-svg');
+
+  const allSectors = [1, 2, 3, 4, 5, 6, 7, 8];
+  allSectors.forEach((sector) => {
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', mountSectorPath(sector));
+    path.setAttribute('class', `wpn-sector${facings.includes(sector) ? ' active' : ''}`);
+    svg.appendChild(path);
+  });
+
+  const outline = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  outline.setAttribute('x', '2');
+  outline.setAttribute('y', '2');
+  outline.setAttribute('width', '44');
+  outline.setAttribute('height', '44');
+  outline.setAttribute('class', 'wpn-mount-outline');
+  svg.appendChild(outline);
+  mount.appendChild(svg);
+
+  const struct = document.createElement('div');
+  struct.className = 'wpn-mount-structure';
+  for (let i = 0; i < structure; i += 1) {
+    const box = document.createElement('span');
+    box.className = 'wpn-structure-box';
+    struct.appendChild(box);
+  }
+  mount.appendChild(struct);
+
+  return mount;
 }
 
 function parseSystems(raw) {
@@ -183,7 +375,7 @@ function getBuild() {
       permanent: num('structureRed')
     },
     shipArtDataUrl,
-    weapons: parseWeapons(form.elements.weapons.value),
+    weapons: readWeaponsFromForm(),
     systems: parseSystems(form.elements.systems.value),
     crew: {
       shuttleCraft: num('shuttleCraft'),
@@ -202,7 +394,8 @@ function renderBoxes(containerId, count, className) {
   }
 }
 
-function weaponSlot(id, weapon, enabled = true) {
+function weaponSlot(id, rawWeapon, enabled = true) {
+  const weapon = normalizeWeapon(rawWeapon);
   const slot = document.getElementById(`pvWpn${id}Slot`);
   const title = document.getElementById(`pvWpn${id}Title`);
   const body = document.getElementById(`pvWpn${id}Body`);
@@ -210,18 +403,89 @@ function weaponSlot(id, weapon, enabled = true) {
   if (!enabled) {
     slot.style.display = 'none';
     title.textContent = 'WPN NAME TYP';
-    body.textContent = '';
+    body.innerHTML = '';
     return;
   }
 
   slot.style.display = 'flex';
-  if (!weapon) {
+  if (!weapon.name) {
     title.textContent = 'WPN NAME TYP';
-    body.textContent = '';
+    body.innerHTML = '';
     return;
   }
-  title.textContent = weapon.name || 'WPN NAME TYP';
-  body.textContent = weapon.ranges.join('  •  ');
+
+  title.textContent = weapon.name;
+  body.innerHTML = '';
+
+  const mountRow = document.createElement('div');
+  mountRow.className = 'wpn-mount-row';
+  const mounts = weapon.mountFacings.slice(0, 8);
+  mounts.forEach((facings) => {
+    mountRow.appendChild(createMountDiagram(facings, weapon.structure));
+  });
+  body.appendChild(mountRow);
+
+  const powerRow = document.createElement('div');
+  powerRow.className = 'wpn-power-row';
+  for (let i = 1; i <= weapon.powerCircles; i += 1) {
+    const circle = document.createElement('span');
+    circle.className = 'wpn-power-circle';
+    powerRow.appendChild(circle);
+    if (weapon.powerStops.includes(i)) {
+      const stop = document.createElement('span');
+      stop.className = 'wpn-power-stop';
+      powerRow.appendChild(stop);
+    }
+  }
+  body.appendChild(powerRow);
+
+  const structureRow = document.createElement('div');
+  structureRow.className = 'wpn-structure-row';
+  structureRow.innerHTML = `<b>STR ${weapon.structure}</b>`;
+  body.appendChild(structureRow);
+
+  const rangeGrid = document.createElement('div');
+  rangeGrid.className = 'wpn-range-grid';
+  weapon.ranges.forEach((range) => {
+    const rangeCol = document.createElement('div');
+    rangeCol.className = 'wpn-range-col';
+
+    const band = document.createElement('span');
+    band.className = `wpn-range-band ${range.type}`;
+    band.textContent = range.band;
+    rangeCol.appendChild(band);
+
+    const dice = document.createElement('span');
+    dice.className = 'wpn-dice-row';
+    const diceValues = (range.dice || []).slice(0, weapon.structure);
+    diceValues.forEach((die) => {
+      const pip = document.createElement('span');
+      pip.className = `wpn-die ${String(die).toLowerCase()}`;
+      pip.textContent = String(die).toUpperCase();
+      dice.appendChild(pip);
+    });
+    rangeCol.appendChild(dice);
+
+    rangeGrid.appendChild(rangeCol);
+  });
+  body.appendChild(rangeGrid);
+
+  const traits = weapon.traits.map((trait) => trait.trim()).filter(Boolean);
+  const hasHvy = traits.some((trait) => trait.toUpperCase() === 'HVY');
+
+  if (hasHvy && weapon.special) {
+    const special = document.createElement('div');
+    special.className = 'wpn-special-row';
+    special.innerHTML = `<b>SPECIAL:</b> ${weapon.special}`;
+    body.appendChild(special);
+  }
+
+  if (traits.length) {
+    const traitRow = document.createElement('div');
+    traitRow.className = 'wpn-trait-row';
+    traitRow.innerHTML = `<b>TRAIT:</b> ${traits.join(', ')}`;
+    body.appendChild(traitRow);
+  }
 }
 
 function renderStructure(build) {
@@ -723,7 +987,19 @@ function restoreDraft(draft) {
   form.elements.structureRed.value = draft.structure?.permanent ?? 0;
 
   shipArtDataUrl = draft.shipArtDataUrl ?? '';
-  form.elements.weapons.value = (draft.weapons ?? []).map((item) => [item.name, ...(item.ranges ?? [])].join('|')).join('\n');
+  const normalizedWeapons = (Array.isArray(draft.weapons) ? draft.weapons : []).map((weapon) => normalizeWeapon(weapon));
+  [1, 2, 3, 4].forEach((index) => {
+    const weapon = normalizedWeapons[index - 1] || normalizeWeapon({});
+    form.elements[`wpn${index}Name`].value = weapon.name || '';
+    form.elements[`wpn${index}Traits`].value = (weapon.traits || []).join(', ');
+    form.elements[`wpn${index}MountArcs`].value = (weapon.mountFacings || []).map((mount) => mount.join(',')).join('|');
+    form.elements[`wpn${index}PowerCircles`].value = weapon.powerCircles || 1;
+    form.elements[`wpn${index}PowerStops`].value = (weapon.powerStops || []).join(', ');
+    form.elements[`wpn${index}Structure`].value = weapon.structure || 1;
+    form.elements[`wpn${index}Ranges`].value = (weapon.ranges || []).map((range) => `${range.band}:${range.type}`).join(',');
+    form.elements[`wpn${index}Dice`].value = (weapon.ranges || []).map((range) => (range.dice || []).join(',')).join('|');
+    form.elements[`wpn${index}Special`].value = weapon.special || '';
+  });
   form.elements.systems.value = (draft.systems ?? []).map((item) => `${item.key}:${item.value ?? ''}`).join('\n');
   form.elements.shuttleCraft.value = draft.crew?.shuttleCraft ?? 4;
   form.elements.marinesStationed.value = draft.crew?.marinesStationed ?? 10;

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -58,8 +58,85 @@
         </label>
         <button type="button" id="clearArtBtn" class="ghost">Clear Ship Art</button>
 
-        <h2>Weapons (up to 4 lines)</h2>
-        <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
+        <h2>Weapons (up to 4)</h2>
+        <p class="muted">Each weapon supports up to 8 mounts, power circles/stops, structure, per-range dice colors, and optional SPECIAL text (enabled by the HVY trait).</p>
+        <div class="weapon-editor-list">
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon A</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn1Name" value="WPN NAME" /></label>
+              <label>Traits (comma separated) <input name="wpn1Traits" value="HVY, FTL, NoBAT" /></label>
+            </div>
+            <label>Mount arcs (per mount as wedge values, e.g. <code>1,2|5,6</code>)
+              <input name="wpn1MountArcs" value="1,2|5,6" />
+            </label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn1PowerCircles" type="number" min="1" max="6" value="3" /></label>
+              <label>Power stop positions (comma) <input name="wpn1PowerStops" value="2" placeholder="2,4" /></label>
+              <label>Structure per mount (1-4) <input name="wpn1Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands (format <code>0-4:green,5-9:black</code> or <code>0-4,green,5-9,black</code>)
+              <input name="wpn1Ranges" value="0-4:green,5-9:black,10-13:red,14-16:red" />
+            </label>
+            <label>Dice per band (use R,Y,G,B per structure point, separated by commas)
+              <input name="wpn1Dice" value="R,R,R,R|R,R,R,R|R,R,R,R|Y,Y,Y" />
+            </label>
+            <label>Special (shown only when HVY trait is present)
+              <input name="wpn1Special" value="H(4+1), STR 2" />
+            </label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon B</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn2Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn2Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn2MountArcs" value="" placeholder="1,2|5,6" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn2PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn2PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn2Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn2Ranges" value="" placeholder="0-6:green,7-12:black" /></label>
+            <label>Dice per band <input name="wpn2Dice" value="" placeholder="R,R|Y,Y" /></label>
+            <label>Special <input name="wpn2Special" value="" /></label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon C</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn3Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn3Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn3MountArcs" value="" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn3PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn3PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn3Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn3Ranges" value="" /></label>
+            <label>Dice per band <input name="wpn3Dice" value="" /></label>
+            <label>Special <input name="wpn3Special" value="" /></label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon D</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn4Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn4Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn4MountArcs" value="" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn4PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn4PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn4Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn4Ranges" value="" /></label>
+            <label>Dice per band <input name="wpn4Dice" value="" /></label>
+            <label>Special <input name="wpn4Special" value="" /></label>
+          </fieldset>
+        </div>
 
         <h2>Functions / Power / Maneuvering</h2>
         <div class="functions-editor">

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -289,11 +289,40 @@ button.ghost { background: #273055; }
 .crew-icon { font-size: 1.6rem; line-height: 1; }
 .crew-img { width: 28px; height: 28px; display: block; }
 
+.weapon-editor-list { display: grid; gap: 0.5rem; }
+.weapon-editor-card { border: 2px solid #0fb366; border-radius: 0; padding: 0.45rem 0.5rem; background: #f3f4f6; }
+.weapon-editor-card legend { font-weight: 900; color: #0a3f5f; padding: 0 0.22rem; text-transform: uppercase; font-size: 0.8rem; }
+.weapon-editor-card code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; }
+
 .right-col { border: 3px solid #ff0000; background: #fafafa; }
 .weapon-slot { border-top: 2px solid #ff0000; height: 170px; min-height: 170px; display: flex; flex-direction: column; }
 .weapon-slot:first-of-type { border-top: 0; }
 .slot-title { background: #ff0000; color: #fff; font-weight: 900; padding: 0.17rem 0.3rem; }
-.slot-body { white-space: pre-wrap; color: #233; padding: 0.35rem 0.38rem; min-height: 0; flex: 1; overflow: auto; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.slot-body { color: #233; padding: 0.35rem 0.38rem; min-height: 0; flex: 1; overflow: auto; font-family: Arial, Helvetica, sans-serif; font-size: 0.74rem; }
+.wpn-mount-row,.wpn-power-row,.wpn-structure-row,.wpn-special-row,.wpn-trait-row { display: flex; align-items: center; gap: 0.18rem; margin-bottom: 0.18rem; flex-wrap: wrap; }
+.wpn-mount { display: grid; gap: 0.12rem; justify-items: center; }
+.wpn-mount-svg { width: 48px; height: 48px; display: block; }
+.wpn-sector { fill: #ffffff; stroke: #6b1717; stroke-width: 0.9; }
+.wpn-sector.active { fill: #ff1212; }
+.wpn-mount-outline { fill: none; stroke: #6b1717; stroke-width: 1.4; }
+.wpn-mount-structure { display: inline-flex; gap: 0.08rem; }
+.wpn-power-circle { width: 12px; height: 12px; border-radius: 999px; border: 3px solid #11a854; display: inline-block; box-sizing: border-box; }
+.wpn-power-stop { width: 8px; height: 8px; background: #11a854; transform: rotate(45deg); display: inline-block; }
+.wpn-structure-row b { margin-right: 0.25rem; }
+.wpn-structure-box { width: 10px; height: 10px; border: 2px solid #111; display: inline-block; }
+.wpn-range-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(56px, 1fr)); gap: 0.15rem 0.24rem; align-items: start; }
+.wpn-range-col { display: grid; grid-template-rows: auto auto; gap: 0.1rem; justify-items: center; }
+.wpn-range-band { text-align: center; font-weight: 800; font-size: 0.74rem; }
+.wpn-range-band.green { color: #10b981; }
+.wpn-range-band.black { color: #111827; }
+.wpn-range-band.red { color: #dc2626; }
+.wpn-dice-row { display: flex; justify-content: center; gap: 0.08rem; flex-wrap: wrap; }
+.wpn-die { width: 13px; height: 13px; border-radius: 999px; color: #fff; display: inline-flex; align-items: center; justify-content: center; font-size: 0.48rem; font-weight: 900; }
+.wpn-die.r { background: #ef4444; }
+.wpn-die.y { background: #eab308; color: #111; }
+.wpn-die.g { background: #22c55e; }
+.wpn-die.b { background: #3b82f6; }
+.wpn-special-row b,.wpn-trait-row b { color: #0b67b2; }
 
 .template-bottom {
   --structure-box-size: 12px;


### PR DESCRIPTION
### Motivation
- Provide a compact way to specify multiple mount facings per weapon (e.g. `1,2|5,6`) so each mount can have explicit wedge facings and show per-mount structure boxes. 
- Replace crude text tokens in the preview with a visual 8-wedge mount diagram so authors can verify facing and structure at-a-glance.

### Description
- Introduced parsing helpers `parseList`, `parseWeaponRanges`, `parseWeaponDice`, `parseMountFacings`, `buildRangeProfile`, and `parseLegacyWeapons`, and replaced the old freeform weapon input with a structured editor read path via `readWeaponsFromForm` and `getBuild` integration (`starforce-commander-ship-designer/app.js`).
- Added `mountFacings` to weapon normalization in `normalizeWeapon` with numeric clamping and backwards-compatible fallback from `mountArcs` (`app.js`).
- Implemented SVG wedge diagrams with `mountSectorPath` and `createMountDiagram` and render mounts as diagrams with per-mount structure boxes in the preview (`app.js`), and replaced mount tokens with diagram rendering in `weaponSlot`.
- Updated the editor UI in `index.html` to structured weapon cards and changed mount input labels/placeholders to show the `1,2|5,6` format; added corresponding styles in `styles.css` for the mount diagram, editor cards, dice tokens and layout.
- Restored serialization/restore behavior so `mountFacings` round-trip to the same compact `1,2|5,6` input syntax when loading drafts (`app.js`).

### Testing
- Ran `node --check /workspace/CrazyVulcan.github.io/starforce-commander-ship-designer/app.js` which completed without errors.
- Ran `git -C /workspace/CrazyVulcan.github.io diff --check` which reported no issues.
- Launched a local server and used a Playwright script to load the page, set `wpn1MountArcs=1,2|5,6`, set `wpn1Structure=2`, populated ranges/dice, and captured a screenshot confirming wedge diagrams and per-mount structure boxes rendered as expected (screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999bd125e608332b54b6dc78a3542bb)