### PR TITLE
Support HOMING range boxes and per-band bonus damage in weapon dice

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -58,8 +58,85 @@
         </label>
         <button type="button" id="clearArtBtn" class="ghost">Clear Ship Art</button>
 
-        <h2>Weapons (up to 4 lines)</h2>
-        <label><textarea name="weapons" rows="6" placeholder="MK-4 A/MAT TORPEDO|0-4|5-10|11-14|15-20"></textarea></label>
+        <h2>Weapons (up to 4)</h2>
+        <p class="muted">Each weapon supports up to 8 mounts, power circles/stops, structure, per-range dice colors, HOMING band boxes, and optional SPECIAL text (enabled by the HVY trait).</p>
+        <div class="weapon-editor-list">
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon A</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn1Name" value="WPN NAME" /></label>
+              <label>Traits (comma separated) <input name="wpn1Traits" value="HVY, FTL, NoBAT" /></label>
+            </div>
+            <label>Mount arcs (per mount as wedge values, e.g. <code>1,2|5,6</code>)
+              <input name="wpn1MountArcs" value="1,2|5,6" />
+            </label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn1PowerCircles" type="number" min="1" max="6" value="3" /></label>
+              <label>Power stop positions (comma) <input name="wpn1PowerStops" value="2" placeholder="2,4" /></label>
+              <label>Structure per mount (1-4) <input name="wpn1Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands (format <code>0-4:green,5-9:black</code> or <code>0-4,green,5-9,black</code>)
+              <input name="wpn1Ranges" value="0-4:green,5-9:black,10-13:red,14-16:red" />
+            </label>
+            <label>Dice per band (optional bonus first: <code>8,R,R|4,R,R</code>)
+              <input name="wpn1Dice" value="8,R,R|4,R,R|4,R,R|2,R,R" />
+            </label>
+            <label>Special (shown only when HVY trait is present)
+              <input name="wpn1Special" value="H(4+1), STR 2" />
+            </label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon B</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn2Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn2Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn2MountArcs" value="" placeholder="1,2|5,6" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn2PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn2PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn2Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn2Ranges" value="" placeholder="0-6:green,7-12:black" /></label>
+            <label>Dice per band <input name="wpn2Dice" value="" placeholder="R,R|Y,Y" /></label>
+            <label>Special <input name="wpn2Special" value="" /></label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon C</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn3Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn3Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn3MountArcs" value="" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn3PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn3PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn3Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn3Ranges" value="" /></label>
+            <label>Dice per band <input name="wpn3Dice" value="" /></label>
+            <label>Special <input name="wpn3Special" value="" /></label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon D</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn4Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn4Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn4MountArcs" value="" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn4PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn4PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn4Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn4Ranges" value="" /></label>
+            <label>Dice per band <input name="wpn4Dice" value="" /></label>
+            <label>Special <input name="wpn4Special" value="" /></label>
+          </fieldset>
+        </div>
 
         <h2>Functions / Power / Maneuvering</h2>
         <div class="functions-editor">

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -289,11 +289,47 @@ button.ghost { background: #273055; }
 .crew-icon { font-size: 1.6rem; line-height: 1; }
 .crew-img { width: 28px; height: 28px; display: block; }
 
+.weapon-editor-list { display: grid; gap: 0.5rem; }
+.weapon-editor-card { border: 1px solid #32427a; border-radius: 8px; padding: 0.45rem 0.5rem; background: #0f1731; }
+.weapon-editor-card legend { font-weight: 900; color: #dbe7ff; padding: 0 0.22rem; text-transform: uppercase; font-size: 0.8rem; }
+.weapon-editor-card code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; }
+.weapon-editor-card label { color: #dbe7ff; font-weight: 700; }
+.weapon-editor-card input { border-color: #32427a; }
+.weapon-editor-card .grid2,
+.weapon-editor-card .grid3 { grid-template-columns: 1fr; gap: 0.45rem; }
+
 .right-col { border: 3px solid #ff0000; background: #fafafa; }
 .weapon-slot { border-top: 2px solid #ff0000; height: 170px; min-height: 170px; display: flex; flex-direction: column; }
 .weapon-slot:first-of-type { border-top: 0; }
 .slot-title { background: #ff0000; color: #fff; font-weight: 900; padding: 0.17rem 0.3rem; }
-.slot-body { white-space: pre-wrap; color: #233; padding: 0.35rem 0.38rem; min-height: 0; flex: 1; overflow: auto; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
+.slot-body { color: #233; padding: 0.35rem 0.38rem; min-height: 0; flex: 1; overflow: auto; font-family: Arial, Helvetica, sans-serif; font-size: 0.74rem; }
+.wpn-mount-row,.wpn-power-row,.wpn-structure-row,.wpn-special-row,.wpn-trait-row { display: flex; align-items: center; gap: 0.18rem; margin-bottom: 0.18rem; flex-wrap: wrap; }
+.wpn-mount { display: grid; gap: 0.12rem; justify-items: center; }
+.wpn-mount-svg { width: 48px; height: 48px; display: block; }
+.wpn-sector { fill: #ffffff; stroke: #6b1717; stroke-width: 0.9; }
+.wpn-sector.active { fill: #ff1212; }
+.wpn-mount-outline { fill: none; stroke: #6b1717; stroke-width: 1.4; }
+.wpn-mount-structure { display: inline-flex; gap: 0.08rem; }
+.wpn-mount-power { display: inline-flex; align-items: center; gap: 0.08rem; }
+.wpn-power-circle { width: 12px; height: 12px; border-radius: 999px; border: 3px solid #11a854; display: inline-block; box-sizing: border-box; }
+.wpn-power-stop { width: 8px; height: 8px; background: #11a854; transform: rotate(45deg); display: inline-block; }
+.wpn-structure-row b { margin-right: 0.25rem; }
+.wpn-structure-box { width: 10px; height: 10px; border: 2px solid #111; display: inline-block; }
+.wpn-range-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(56px, 1fr)); gap: 0.15rem 0.24rem; align-items: start; }
+.wpn-range-col { display: grid; grid-template-rows: auto auto; gap: 0.1rem; justify-items: center; }
+.wpn-range-col.homing { border: 2px solid #ff0000; padding: 0.08rem 0.15rem 0.12rem; }
+.wpn-range-band { text-align: center; font-weight: 800; font-size: 0.74rem; }
+.wpn-range-band.green { color: #10b981; }
+.wpn-range-band.black { color: #111827; }
+.wpn-range-band.red { color: #dc2626; }
+.wpn-dice-row { display: flex; justify-content: center; gap: 0.08rem; flex-wrap: wrap; }
+.wpn-bonus { color: #111; font-weight: 900; font-size: 0.72rem; margin-right: 0.06rem; }
+.wpn-die { width: 13px; height: 13px; border-radius: 999px; color: #fff; display: inline-flex; align-items: center; justify-content: center; font-size: 0.48rem; font-weight: 900; }
+.wpn-die.r { background: #ef4444; }
+.wpn-die.y { background: #eab308; color: #111; }
+.wpn-die.g { background: #22c55e; }
+.wpn-die.b { background: #3b82f6; }
+.wpn-special-row b,.wpn-trait-row b { color: #0b67b2; }
 
 .template-bottom {
   --structure-box-size: 12px;


### PR DESCRIPTION
### Motivation
- Provide a visual indicator for HOMING weapons by boxing each range band so authors can immediately see HOMING-enabled ranges in the preview.
- Allow an optional numeric bonus at the front of each band dice group (e.g. `8,R,R|4,R,R`) to represent additive damage (`+N`) on hit and make this format round-trip through the editor.

### Description
- Extended dice parsing so `parseWeaponDice` accepts an optional leading numeric token per `|`-separated band and returns `{ bonus, dice[] }` for each band.
- Updated range profile normalization (`buildRangeProfile`, `normalizeWeapon`, `readWeaponsFromForm`, and related code) to carry `bonus` alongside `dice[]` and preserve compatibility with legacy data.
- Updated preview rendering to show a `+N` badge before dice icons and to add a red boxed style (`.wpn-range-col.homing`) when the weapon has the `HOMING` trait, as well as corresponding CSS (`.wpn-bonus`, `.wpn-range-col.homing`).
- Improved the weapons editor UI and helper text in `index.html` with an example and guidance for the bonus-prefixed dice format and HOMING behavior.

### Testing
- Ran `node --check /workspace/CrazyVulcan.github.io/starforce-commander-ship-designer/app.js` which completed successfully.
- Ran `git -C /workspace/CrazyVulcan.github.io diff --check` with no issues reported.
- Launched a local server and executed a Playwright script that set `HOMING, HVY` and used the bonus dice string `8,R,R|6,R,R|4,R,R|2,R,R`, then captured a screenshot showing HOMING boxed bands and `+N` bonus rendering; the run succeeded and produced the artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999bd125e608332b54b6dc78a3542bb)