### PR TITLE
Add SVG/PNG export and print-fit support for SSD designer

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -1135,15 +1135,126 @@ function clearDrafts() {
   renderDrafts();
 }
 
-function exportCurrent() {
-  const name = form.elements.name.value || 'starforce-ssd';
-  const blob = new Blob([JSON.stringify(getBuild(), null, 2)], { type: 'application/json' });
+
+function slugifyFileName(raw) {
+  return String(raw || 'starforce-ssd')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '') || 'starforce-ssd';
+}
+
+function blobToDataUrl(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ''));
+    reader.onerror = () => reject(reader.error || new Error('Failed to read blob')); 
+    reader.readAsDataURL(blob);
+  });
+}
+
+function downloadBlob(blob, filename) {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `${name}.json`;
+  a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+function collectExportCss() {
+  return Array.from(document.styleSheets)
+    .map((sheet) => {
+      try {
+        return Array.from(sheet.cssRules || []).map((rule) => rule.cssText).join('\n');
+      } catch (_error) {
+        return '';
+      }
+    })
+    .join('\n');
+}
+
+async function inlineImagesForExport(container) {
+  const images = Array.from(container.querySelectorAll('img'));
+  await Promise.all(images.map(async (img) => {
+    const src = img.getAttribute('src') || '';
+    if (!src || src.startsWith('data:')) {
+      return;
+    }
+
+    const response = await fetch(new URL(src, window.location.href));
+    const blob = await response.blob();
+    img.setAttribute('src', await blobToDataUrl(blob));
+  }));
+}
+
+async function buildSsdSvgMarkup() {
+  const card = document.getElementById('ssdCard');
+  const width = Math.round(card.offsetWidth);
+  const height = Math.round(card.offsetHeight);
+
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  const clone = card.cloneNode(true);
+  clone.style.margin = '0';
+  wrapper.appendChild(clone);
+
+  await inlineImagesForExport(wrapper);
+
+  const cssText = collectExportCss();
+  const html = new XMLSerializer().serializeToString(wrapper);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <defs>
+    <style><![CDATA[${cssText}]]></style>
+  </defs>
+  <foreignObject x="0" y="0" width="100%" height="100%">${html}</foreignObject>
+</svg>`;
+}
+
+async function exportSsdSvg() {
+  render();
+  const svgMarkup = await buildSsdSvgMarkup();
+  const filename = `${slugifyFileName(form.elements.name.value)}.svg`;
+  downloadBlob(new Blob([svgMarkup], { type: 'image/svg+xml;charset=utf-8' }), filename);
+}
+
+async function exportSsdPng() {
+  render();
+  const svgMarkup = await buildSsdSvgMarkup();
+  const blob = new Blob([svgMarkup], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const image = await new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = reject;
+      img.src = url;
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(image, 0, 0);
+
+    const pngBlob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png', 1));
+    if (!pngBlob) {
+      throw new Error('Failed to create PNG image.');
+    }
+    const filename = `${slugifyFileName(form.elements.name.value)}.png`;
+    downloadBlob(pngBlob, filename);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function exportCurrent() {
+  const name = slugifyFileName(form.elements.name.value);
+  const blob = new Blob([JSON.stringify(getBuild(), null, 2)], { type: 'application/json' });
+  downloadBlob(blob, `${name}.json`);
 }
 
 form.addEventListener('input', render);
@@ -1151,6 +1262,9 @@ form.addEventListener('change', render);
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+document.getElementById('exportSvgBtn').addEventListener('click', () => exportSsdSvg().catch((error) => console.error(error)));
+document.getElementById('exportPngBtn').addEventListener('click', () => exportSsdPng().catch((error) => console.error(error)));
+document.getElementById('printBtn').addEventListener('click', () => window.print());
 
 const shipArtInput = document.getElementById('shipArt');
 document.getElementById('clearArtBtn').addEventListener('click', () => {

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -258,9 +258,12 @@
           <label>Permanent Structure Boxes <input name="structureRed" type="number" min="0" value="12" /></label>
         </div>
 
-        <div class="row">
+        <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="exportSvgBtn">Export SVG</button>
+          <button type="button" id="exportPngBtn">Export PNG</button>
+          <button type="button" id="printBtn" class="ghost">Print to Paper</button>
           <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>
         </div>
       </form>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -13,6 +13,7 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .shield-stat-card label { margin: 0.28rem 0 0; }
 .shield-stat-card input { margin-top: 0.15rem; }
 .row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0.5rem; margin-top: 0.75rem; }
+.row-actions { grid-template-columns: 1fr 1fr; }
 
 .grid3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0.55rem; }
 .maneuver-editor { border: 1px solid #32427a; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #0f1731; }
@@ -53,6 +54,11 @@ button.ghost { background: #273055; }
 .live-badge { background: #11b96b; color: #072b19; font-size: 0.76rem; font-weight: 800; border-radius: 999px; padding: 0.12rem 0.5rem; }
 
 .ssd-template {
+  width: min(100%, 1400px);
+  margin: 0 auto;
+  aspect-ratio: 1403 / 1001;
+  display: flex;
+  flex-direction: column;
   border: 3px solid #0b71ba;
   background: #d9d9d9;
   color: #04111f;
@@ -103,7 +109,7 @@ button.ghost { background: #273055; }
   color: #000;
   text-align: right;
 }
-.template-columns { display: grid; grid-template-columns: 1.06fr 0.94fr 0.72fr; gap: 0.4rem; padding: 0.25rem 0.15rem 0.2rem; align-items: stretch; }
+.template-columns { display: grid; grid-template-columns: 1.06fr 0.94fr 0.72fr; gap: 0.35rem; padding: 0.2rem 0.15rem 0.12rem; align-items: stretch; flex: 1; min-height: 0; }
 .col h3 { margin: 0 0 0.2rem; background: #566674; color: #f3f3f3; text-align: center; padding: 0.1rem 0.3rem; border: 3px solid #111; font-size: 1.02rem; letter-spacing: 0.02em; }
 
 .left-col,
@@ -113,12 +119,13 @@ button.ghost { background: #273055; }
   flex-direction: column;
 }
 
-.left-col {
-  min-height: 920px;
-}
+.left-col { min-height: 0; }
 
-.functions-preview { height: 220px; max-height: 220px; overflow: auto; padding: 0.2rem 0.35rem 0.28rem; color: #111; font-family: Arial, Helvetica, sans-serif; }
+.functions-preview { min-height: 0; overflow: auto; padding: 0.2rem 0.35rem 0.28rem; color: #111; font-family: Arial, Helvetica, sans-serif; }
 .block-maneuver { display: flex; flex-direction: column; }
+.block-functions { flex: 1.05; min-height: 0; }
+.block-power { flex: 0.52; min-height: 0; }
+.block-maneuver { flex: 0.3; min-height: 0; }
 .block-maneuver .maneuver-preview { height: 110px; max-height: 110px; overflow: hidden; }
 
 .eng-stats { display: grid; grid-template-columns: repeat(6, 1fr); gap: 0.15rem; margin-bottom: 0.2rem; }
@@ -149,7 +156,7 @@ button.ghost { background: #273055; }
 }
 .fn-dot.filled { background: #09a84f; }
 .fn-end-round { font-size: 0.65rem; margin-left: 0.35rem; color: #2f2f2f; }
-.power-track-list { min-height: 156px; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
+.power-track-list { min-height: 0; margin: 0; padding: 0.25rem 0.3rem; color: #111; font-family: Arial, Helvetica, sans-serif; overflow: auto; }
 .power-track-row { display: grid; grid-template-columns: 132px minmax(0, 1fr); align-items: center; gap: 0.45rem; margin-bottom: 0.2rem; font-size: 0.72rem; font-weight: 700; }
 .power-track-name { text-transform: uppercase; white-space: nowrap; }
 .power-track-units { display: flex; flex-wrap: wrap; gap: 0.38rem; }
@@ -279,7 +286,7 @@ button.ghost { background: #273055; }
 .systems-box { border-top: 0; margin-top: 0.3rem; border: 2px solid #f0b500; background: #f8f8f8; padding-bottom: 0.25rem; }
 .systems-box h3 { border-color: #f0b500; }
 .systems-layout { display: grid; grid-template-columns: 1fr 72px; gap: 0.35rem; padding: 0.2rem 0.25rem 0.1rem; align-items: start; }
-.systems-grid { min-height: 158px; display: grid; grid-template-columns: 1fr 1fr; column-gap: 0.4rem; align-content: start; }
+.systems-grid { min-height: 0; display: grid; grid-template-columns: 1fr 1fr; column-gap: 0.4rem; align-content: start; }
 .system-row { display: flex; align-items: center; gap: 3px; font-family: Arial, Helvetica, sans-serif; font-size: 0.72rem; font-weight: 900; color: #111; margin-bottom: 0.08rem; }
 .system-key { min-width: 42px; }
 .system-box { width: 10px; height: 10px; border: 2px solid #111; box-sizing: border-box; background: #f7f7f7; }
@@ -299,7 +306,7 @@ button.ghost { background: #273055; }
 .weapon-editor-card .grid3 { grid-template-columns: 1fr; gap: 0.45rem; }
 
 .right-col { border: 3px solid #ff0000; background: #fafafa; }
-.weapon-slot { border-top: 2px solid #ff0000; height: 170px; min-height: 170px; display: flex; flex-direction: column; }
+.weapon-slot { border-top: 2px solid #ff0000; min-height: 0; flex: 1; display: flex; flex-direction: column; }
 .weapon-slot:first-of-type { border-top: 0; }
 .slot-title { background: #ff0000; color: #fff; font-weight: 900; padding: 0.17rem 0.3rem; }
 .slot-body { color: #233; padding: 0.35rem 0.38rem; min-height: 0; flex: 1; overflow: auto; font-family: Arial, Helvetica, sans-serif; font-size: 0.74rem; }
@@ -433,6 +440,42 @@ pre { background: #0b1128; color: #d5e2ff; padding: 0.65rem; border-radius: 8px;
   .preview-wrap { position: static; }
   .grid3 { grid-template-columns: 1fr; }
   .shield-stat-grid { grid-template-columns: 1fr; }
+}
+
+@media print {
+  @page {
+    size: letter portrait;
+    margin: 0.35in;
+  }
+
+  :root { color-scheme: light; }
+  body { background: #fff; }
+  .layout {
+    display: block;
+    padding: 0;
+  }
+  .controls,
+  .preview-head,
+  #drafts,
+  #jsonPreview,
+  .preview-wrap > h3,
+  .live-badge {
+    display: none !important;
+  }
+  .panel {
+    border: 0;
+    background: transparent;
+    padding: 0;
+  }
+  .preview-wrap {
+    position: static;
+  }
+  .ssd-template {
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+    break-inside: avoid;
+  }
 }
 @media (max-width: 980px) {
   .template-columns { grid-template-columns: 1fr; }


### PR DESCRIPTION
### Motivation
- Provide one-click export of the live SSD preview as `SVG` and `PNG` and a `Print to Paper` action that produces a print-friendly, page-filling SSD image for standard letter paper. 
- Reduce empty space and layout gaps in the preview so the exported/printed card fills the printable area and text/blocks scale harmoniously. 
- Keep the existing JSON export/draft workflow and the Yorktown default loadout intact.

### Description
- UI: added action buttons to the editor controls: `Export SVG`, `Export PNG`, and `Print to Paper` (keeps `Export JSON`/save/clear). (updated `index.html`).
- Export pipeline: added utilities in `app.js` (`slugifyFileName`, `blobToDataUrl`, `downloadBlob`, `collectExportCss`, `inlineImagesForExport`, `buildSsdSvgMarkup`) plus `exportSsdSvg` and `exportSsdPng` functions that inline images, embed CSS into an SVG `foreignObject`, download a standalone `SVG`, and rasterize to `PNG` via a canvas. The existing JSON export was refactored to use the shared download helper. (updated `app.js`).
- Print & layout: updated `styles.css` to give the SSD card a stable aspect ratio and flexible column distribution to eliminate large gaps, make preview blocks fill available space, and add a `@media print` rule that hides editor chrome and fits the SSD onto a standard letter page with margins. (updated `styles.css`).
- Wiring: hooked the new buttons to the new export and print handlers and preserved all existing behavior including the Yorktown default loadout.

### Testing
- `node --check starforce-commander-ship-designer/app.js` — succeeded with no syntax errors.
- Loaded the app via a local `python3 -m http.server` and captured a screenshot of the updated UI using Playwright to validate the preview/layout changes (screenshot artifact produced). — succeeded.
- Attempted automated Playwright download-event verification for the `export` buttons in the headless container, but waiting for the browser download event timed out in that environment; however, triggering the export buttons via a simulated click produced no page JS errors in the headless run. — download-event verification timed out but no JS errors observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d18007e48332ad01fe529b961d7a)