### PR TITLE
Scale Structure footer visuals and add Point Value display

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -12,7 +12,8 @@ const STANDARD_DEFAULT_LOADOUT = {
     name: 'SHIP NAME / ID',
     classType: 'YORKTOWN II - Class Heavy Cruiser',
     faction: 'COMMON',
-    era: '3655'
+    era: '3655',
+    pointValue: 29
   },
   engineering: { move: 5, vector: 2, turn: 4, special: 4 },
   shields: { forward: 16, aft: 15, port: 15, starboard: 15 },
@@ -468,7 +469,8 @@ function getBuild() {
       name: form.elements.name.value,
       classType: form.elements.classType.value,
       faction: form.elements.faction.value,
-      era: form.elements.era.value
+      era: form.elements.era.value,
+      pointValue: num('pointValue')
     },
     engineering: {
       move: num('move'),
@@ -709,6 +711,7 @@ function renderPreview(build) {
   document.getElementById('pvClass').textContent = build.identity.classType || 'CLASSNAME ID-class Weight Class';
   document.getElementById('pvFaction').textContent = build.identity.faction || 'COMMON';
   document.getElementById('pvSizeClassIcon').src = 'assets/size-class-icon.svg';
+  document.getElementById('pvPointValue').textContent = `${Number(build.identity.pointValue) || 0}PV`;
   document.getElementById('pvEra').textContent = build.identity.era || 'ERA';
 
   document.getElementById('pvMove').textContent = build.engineering.move;
@@ -1018,6 +1021,7 @@ function restoreDraft(draft) {
   form.elements.classType.value = draft.identity?.classType ?? '';
   form.elements.faction.value = draft.identity?.faction ?? '';
   form.elements.era.value = draft.identity?.era ?? '';
+  form.elements.pointValue.value = draft.identity?.pointValue ?? 29;
 
   form.elements.move.value = draft.engineering?.move ?? 3;
   form.elements.vector.value = draft.engineering?.vector ?? 2;

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -19,6 +19,7 @@
         <div class="grid2">
           <label>Faction <input name="faction" value="COMMON" /></label>
           <label>Era <input name="era" value="ERA" /></label>
+          <label>Point Value <input name="pointValue" type="number" min="0" value="29" /></label>
         </div>
 
         <h2>Engineering</h2>
@@ -370,6 +371,7 @@
           </span>
           <span class="footer-tags">
             <span id="pvFaction">COMMON</span>
+            <span id="pvPointValue">29PV</span>
             <span id="pvEra">ERA</span>
           </span>
         </footer>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -339,8 +339,8 @@ button.ghost { background: #273055; }
 .wpn-special-row b,.wpn-trait-row b { color: #0b67b2; }
 
 .template-bottom {
-  --structure-box-size: 12px;
-  --structure-box-gap: 4px;
+  --structure-box-size: 18px;
+  --structure-box-gap: 6px;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
@@ -359,16 +359,16 @@ button.ghost { background: #273055; }
 }
 .structure-track {
   position: relative;
-  min-height: 30px;
+  min-height: 45px;
   border: 3px solid #f0b500;
   background: #fff;
-  padding: 0.14rem 0.2rem;
+  padding: 0.18rem 0.26rem;
 }
 .structure-row {
   display: flex;
   align-items: flex-start;
   flex-wrap: nowrap;
-  gap: 3px;
+  gap: var(--structure-box-gap);
   min-height: var(--structure-box-size);
   overflow: hidden;
 }
@@ -376,20 +376,20 @@ button.ghost { background: #273055; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 24px;
+  min-width: 36px;
   color: #111;
-  font-size: 0.82rem;
+  font-size: 1.23rem;
   line-height: 1;
   font-family: Arial, Helvetica, sans-serif;
-  margin: 0 1px;
-  gap: 1px;
+  margin: 0 2px;
+  gap: 2px;
 }
 .team-count {
   font-weight: 900;
 }
 .wrench-icon {
-  width: 10px;
-  height: 10px;
+  width: 15px;
+  height: 15px;
   display: inline-block;
   background: center / contain no-repeat url("assets/wrench-icon.svg");
 }
@@ -422,6 +422,7 @@ button.ghost { background: #273055; }
   gap: 0.15rem;
 }
 #pvFaction,
+#pvPointValue,
 #pvEra {
   background: #566674;
   border: 3px solid #111;
@@ -493,6 +494,7 @@ pre { background: #0b1128; color: #d5e2ff; padding: 0.65rem; border-radius: 8px;
   .slot-title,
   .structure,
   #pvFaction,
+  #pvPointValue,
   #pvEra {
     font-size: 1.18rem;
   }


### PR DESCRIPTION
### Motivation
- Improve readability and visual density of the SSD Structure footer by enlarging the structure boxes and markers so the track better uses the available space.
- Expose a ship Point Value on the editor and preview as an initial static field (`29PV`) as a first step toward dynamic on-the-fly PV calculation.

### Description
- Increased structure sizing and spacing by updating CSS variables and related rules (raised `--structure-box-size` from 12px to 18px, `--structure-box-gap` from 4px to 6px, track `min-height`, marker sizes, and wrench icon sizing) in `styles.css`.
- Added a `Point Value` input to the Identity form and a PV badge in the footer (`pvPointValue`) in `index.html` with default value `29`.
- Wired `pointValue` through the app state by adding `pointValue: 29` to the default loadout, including `pointValue` in `getBuild()`, rendering the PV badge in `renderPreview()`, and restoring it from saved drafts in `restoreDraft()` in `app.js`.
- Files changed: `starforce-commander-ship-designer/styles.css`, `starforce-commander-ship-designer/index.html`, `starforce-commander-ship-designer/app.js`.

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` to validate JavaScript syntax and it succeeded.
- Launched a local server with `python -m http.server` and captured a page render via an automated Playwright script to verify the updated Structure area and PV badge, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f23ac4b08332af49a3f74d411d1d)