### PR TITLE
Recalibrate PV scaling and relocate manual PV controls

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -1,3 +1,5 @@
+import { calculatePointValue } from './pv-calculator.js';
+
 const form = document.getElementById('ssdForm');
 const draftsEl = document.getElementById('drafts');
 const jsonPreview = document.getElementById('jsonPreview');
@@ -356,7 +358,16 @@ function parseSystems(raw) {
 }
 
 function num(name) {
-  return Number(form.elements[name].value || 0);
+  const field = form.elements.namedItem(name);
+  if (!field || !('value' in field)) {
+    return 0;
+  }
+  const raw = String(field.value ?? '').trim();
+  if (raw === '') {
+    return 0;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function clamp(value, min, max) {
@@ -704,11 +715,30 @@ function renderManeuvering(sublight) {
     .join('');
 }
 
-function renderPreview(build) {
+
+function safeCalculatePointValue(build) {
+  try {
+    const pointValue = calculatePointValue(build);
+    return Number.isFinite(pointValue) ? pointValue : 29;
+  } catch {
+    return 29;
+  }
+}
+
+function renderPreview(build, options = {}) {
+  const { recalculatePointValue = true } = options;
   document.getElementById('pvName').textContent = build.identity.name || 'SHIP NAME / ID';
   document.getElementById('pvClass').textContent = build.identity.classType || 'CLASSNAME ID-class Weight Class';
   document.getElementById('pvFaction').textContent = build.identity.faction || 'COMMON';
   document.getElementById('pvSizeClassIcon').src = 'assets/size-class-icon.svg';
+  if (recalculatePointValue) {
+    const pointValue = safeCalculatePointValue(build);
+    document.getElementById('pvPointValue').textContent = `${pointValue}PV`;
+    const pointValueField = form.elements.namedItem('pointValueCalculated');
+    if (pointValueField && 'value' in pointValueField) {
+      pointValueField.value = String(pointValue);
+    }
+  }
   document.getElementById('pvEra').textContent = build.identity.era || 'ERA';
 
   document.getElementById('pvMove').textContent = build.engineering.move;
@@ -983,16 +1013,27 @@ function pulseLiveBadge() {
   }, 110);
 }
 
-function render() {
+function render(options = {}) {
+  const { recalculatePointValue = true } = options;
   syncDerivedFunctionInputs();
   const build = getBuild();
-  renderPreview(build);
+  renderPreview(build, { recalculatePointValue });
   jsonPreview.textContent = getJsonPreview(build);
   pulseLiveBadge();
 }
 
 function loadDrafts() {
-  return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    localStorage.removeItem(STORAGE_KEY);
+    return [];
+  }
 }
 
 function renderDrafts() {
@@ -1014,70 +1055,98 @@ function renderDrafts() {
 }
 
 function restoreDraft(draft) {
-  form.elements.name.value = draft.identity?.name ?? '';
-  form.elements.classType.value = draft.identity?.classType ?? '';
-  form.elements.faction.value = draft.identity?.faction ?? '';
-  form.elements.era.value = draft.identity?.era ?? '';
+  const getField = (name) => form.elements.namedItem(name);
+  const setValue = (name, value) => {
+    const field = getField(name);
+    if (field && 'value' in field) {
+      field.value = value;
+    }
+  };
+  const setChecked = (name, checked) => {
+    const field = getField(name);
+    if (field && 'checked' in field) {
+      field.checked = Boolean(checked);
+    }
+  };
 
-  form.elements.move.value = draft.engineering?.move ?? 3;
-  form.elements.vector.value = draft.engineering?.vector ?? 2;
-  form.elements.turn.value = draft.engineering?.turn ?? 2;
-  form.elements.special.value = draft.engineering?.special ?? 3;
+  setValue('name', draft.identity?.name ?? '');
+  setValue('classType', draft.identity?.classType ?? '');
+  setValue('faction', draft.identity?.faction ?? '');
+  setValue('era', draft.identity?.era ?? '');
 
-  form.elements.shieldFwd.value = draft.shields?.forward ?? 0;
-  form.elements.shieldAft.value = draft.shields?.aft ?? 0;
-  form.elements.shieldPort.value = draft.shields?.port ?? 0;
-  form.elements.shieldStbd.value = draft.shields?.starboard ?? 0;
+  setValue('move', draft.engineering?.move ?? 3);
+  setValue('vector', draft.engineering?.vector ?? 2);
+  setValue('turn', draft.engineering?.turn ?? 2);
+  setValue('special', draft.engineering?.special ?? 3);
 
-  form.elements.armorFwd.value = draft.armor?.forward ?? 0;
-  form.elements.armorAft.value = draft.armor?.aft ?? 0;
-  form.elements.armorPort.value = draft.armor?.port ?? 0;
-  form.elements.armorStbd.value = draft.armor?.starboard ?? 0;
+  setValue('shieldFwd', draft.shields?.forward ?? 0);
+  setValue('shieldAft', draft.shields?.aft ?? 0);
+  setValue('shieldPort', draft.shields?.port ?? 0);
+  setValue('shieldStbd', draft.shields?.starboard ?? 0);
 
-  form.elements.shieldGen.value = draft.shieldGen ?? 0;
+  setValue('armorFwd', draft.armor?.forward ?? 0);
+  setValue('armorAft', draft.armor?.aft ?? 0);
+  setValue('armorPort', draft.armor?.port ?? 0);
+  setValue('armorStbd', draft.armor?.starboard ?? 0);
+
+  setValue('shieldGen', draft.shieldGen ?? 0);
 
   const fn = draft.functionsConfig || {};
-  form.elements.fnAccDecValues.value = (fn.accDec?.values ?? ['1', '2', '3', '4', '5', '6']).join(',');
-  form.elements.fnAccDecFree.checked = Boolean(fn.accDec?.free ?? 1);
-  form.elements.fnSifIdfValues.value = (fn.sifIdf?.values ?? ['1', '2', '3']).join(',');
-  form.elements.fnSifIdfFree.checked = Boolean(fn.sifIdf?.free ?? 0);
-  form.elements.fnSifIdfEmer.checked = Boolean(fn.sifIdf?.emer ?? true);
-  form.elements.fnFtlEmpty.value = fn.ftl?.empty ?? 2;
-  form.elements.fnCloakEnabled.checked = Boolean(fn.cloak?.enabled ?? false);
-  form.elements.fnCloakEmpty.value = fn.cloak?.empty ?? 3;
-  form.elements.fnSensorValues.value = (fn.sensor?.values ?? ['2', '4', '6']).join(',');
-  form.elements.fnSensorFree.checked = Boolean(fn.sensor?.free ?? 1);
-  form.elements.fnGenSysValues.value = (fn.genSys?.values ?? ['NRM', 'MAX']).join(',');
-  form.elements.fnGenSysFree.checked = Boolean(fn.genSys?.free ?? 1);
-  const fnWpn = fn.weapons ?? [];
-  form.elements.fnWpnALabel.value = fnWpn[0]?.label ?? 'A/MAT TRP';
-  form.elements.fnWpnAFree.checked = Boolean(fnWpn[0]?.free ?? 1);
-  form.elements.fnWpnAEnabled.checked = Boolean(fnWpn[0]?.enabled ?? true);
-  form.elements.fnWpnAValues.value = (fnWpn[0]?.values ?? ['2']).join(',');
-  form.elements.fnWpnBLabel.value = fnWpn[1]?.label ?? 'PHASER';
-  form.elements.fnWpnBFree.checked = Boolean(fnWpn[1]?.free ?? 1);
-  form.elements.fnWpnBEnabled.checked = Boolean(fnWpn[1]?.enabled ?? true);
-  form.elements.fnWpnBValues.value = (fnWpn[1]?.values ?? ['4']).join(',');
-  form.elements.fnWpnCLabel.value = fnWpn[2]?.label ?? 'WPN C';
-  form.elements.fnWpnCFree.checked = Boolean(fnWpn[2]?.free ?? 1);
-  form.elements.fnWpnCEnabled.checked = Boolean(fnWpn[2]?.enabled ?? true);
-  form.elements.fnWpnCValues.value = (fnWpn[2]?.values ?? []).join(',');
-  form.elements.fnWpnDLabel.value = fnWpn[3]?.label ?? 'WPN D';
-  form.elements.fnWpnDFree.checked = Boolean(fnWpn[3]?.free ?? 0);
-  form.elements.fnWpnDEnabled.checked = Boolean(fnWpn[3]?.enabled ?? false);
-  form.elements.fnWpnDValues.value = (fnWpn[3]?.values ?? []).join(',');
+  setValue('fnAccDecValues', (fn.accDec?.values ?? ['1', '2', '3', '4', '5', '6']).join(','));
+  setChecked('fnAccDecFree', fn.accDec?.free ?? 1);
+  setValue('fnSifIdfValues', (fn.sifIdf?.values ?? ['1', '2', '3']).join(','));
+  setChecked('fnSifIdfFree', fn.sifIdf?.free ?? 0);
+  setChecked('fnSifIdfEmer', fn.sifIdf?.emer ?? true);
+  setValue('fnFtlEmpty', fn.ftl?.empty ?? 2);
+  setChecked('fnCloakEnabled', fn.cloak?.enabled ?? false);
+  setValue('fnCloakEmpty', fn.cloak?.empty ?? 3);
+  setValue('fnSensorValues', (fn.sensor?.values ?? ['2', '4', '6']).join(','));
+  setChecked('fnSensorFree', fn.sensor?.free ?? 1);
+  setValue('fnGenSysValues', (fn.genSys?.values ?? ['NRM', 'MAX']).join(','));
+  setChecked('fnGenSysFree', fn.genSys?.free ?? 1);
 
-  if (form.elements.powerSystem) {
-    form.elements.powerSystem.value = draft.textBlocks?.powerSystem ?? '';
+  const fnWpn = fn.weapons ?? [];
+  setValue('fnWpnALabel', fnWpn[0]?.label ?? 'A/MAT TRP');
+  setChecked('fnWpnAFree', fnWpn[0]?.free ?? 1);
+  setChecked('fnWpnAEnabled', fnWpn[0]?.enabled ?? true);
+  setValue('fnWpnAValues', (fnWpn[0]?.values ?? ['2']).join(','));
+  setValue('fnWpnBLabel', fnWpn[1]?.label ?? 'PHASER');
+  setChecked('fnWpnBFree', fnWpn[1]?.free ?? 1);
+  setChecked('fnWpnBEnabled', fnWpn[1]?.enabled ?? true);
+  setValue('fnWpnBValues', (fnWpn[1]?.values ?? ['4']).join(','));
+  setValue('fnWpnCLabel', fnWpn[2]?.label ?? 'WPN C');
+  setChecked('fnWpnCFree', fnWpn[2]?.free ?? 1);
+  setChecked('fnWpnCEnabled', fnWpn[2]?.enabled ?? true);
+  setValue('fnWpnCValues', (fnWpn[2]?.values ?? []).join(','));
+  setValue('fnWpnDLabel', fnWpn[3]?.label ?? 'WPN D');
+  setChecked('fnWpnDFree', fnWpn[3]?.free ?? 0);
+  setChecked('fnWpnDEnabled', fnWpn[3]?.enabled ?? false);
+  setValue('fnWpnDValues', (fnWpn[3]?.values ?? []).join(','));
+
+  if (getField('powerSystem')) {
+    setValue('powerSystem', draft.textBlocks?.powerSystem ?? '');
   }
 
   const draftTracks = draft.powerSystem?.tracks ?? [];
   POWER_TRACK_CONFIG.forEach((track) => {
     const trackData = draftTracks.find((entry) => entry.key === track.key || entry.label === track.label);
-    form.elements[track.pointsField].value = Math.max(0, Number(trackData?.points ?? form.elements[track.pointsField].value ?? 0));
-    form.elements[track.boxesField].value = clamp(Number(trackData?.boxesPerPoint ?? form.elements[track.boxesField].value ?? 2), 1, 3);
-    form.elements[track.patternField].value = (trackData?.boxPattern ?? []).join(',');
-    form.elements[track.hasDotField].checked = Boolean(trackData?.hasDot ?? form.elements[track.hasDotField].checked);
+    const pointsField = getField(track.pointsField);
+    const boxesField = getField(track.boxesField);
+    const patternField = getField(track.patternField);
+    const hasDotField = getField(track.hasDotField);
+
+    if (pointsField) {
+      pointsField.value = Math.max(0, Number(trackData?.points ?? pointsField.value ?? 0));
+    }
+    if (boxesField) {
+      boxesField.value = clamp(Number(trackData?.boxesPerPoint ?? boxesField.value ?? 2), 1, 3);
+    }
+    if (patternField) {
+      patternField.value = (trackData?.boxPattern ?? []).join(',');
+    }
+    if (hasDotField) {
+      hasDotField.checked = Boolean(trackData?.hasDot ?? hasDotField.checked);
+    }
   });
 
   const sublight = draft.sublight ?? {
@@ -1088,37 +1157,38 @@ function restoreDraft(draft) {
     turns: [20, 20, 20, 20, 20, 20, 20],
     dmgStops: [false, false, false, false, false, false, false]
   };
-  form.elements.sublightMaxAcc.value = sublight.maxAccPhs ?? 2;
-  form.elements.sublightGreen.value = sublight.greenCircles ?? 3;
-  form.elements.sublightRed.value = sublight.redCircles ?? 3;
+  setValue('sublightMaxAcc', sublight.maxAccPhs ?? 2);
+  setValue('sublightGreen', sublight.greenCircles ?? 3);
+  setValue('sublightRed', sublight.redCircles ?? 3);
   [6, 5, 4, 3, 2, 1, 0].forEach((speed, index) => {
-    form.elements[`sublightTurn${speed}`].value = normalizeTurnOption(sublight.turns?.[index] ?? 20);
-    form.elements[`sublightDmg${speed}`].checked = Boolean(sublight.dmgStops?.[index]);
+    setValue(`sublightTurn${speed}`, normalizeTurnOption(sublight.turns?.[index] ?? 20));
+    setChecked(`sublightDmg${speed}`, sublight.dmgStops?.[index]);
   });
 
-  form.elements.structureBlack.value = draft.structure?.repairable ?? 0;
-  form.elements.structureRed.value = draft.structure?.permanent ?? 0;
+  setValue('structureBlack', draft.structure?.repairable ?? 0);
+  setValue('structureRed', draft.structure?.permanent ?? 0);
 
   shipArtDataUrl = draft.shipArtDataUrl ?? '';
   const normalizedWeapons = (Array.isArray(draft.weapons) ? draft.weapons : []).map((weapon) => normalizeWeapon(weapon));
   [1, 2, 3, 4].forEach((index) => {
     const weapon = normalizedWeapons[index - 1] || normalizeWeapon({});
-    form.elements[`wpn${index}Name`].value = weapon.name || '';
-    form.elements[`wpn${index}Traits`].value = (weapon.traits || []).join(', ');
-    form.elements[`wpn${index}MountArcs`].value = (weapon.mountFacings || []).map((mount) => mount.join(',')).join('|');
-    form.elements[`wpn${index}PowerCircles`].value = weapon.powerCircles || 1;
-    form.elements[`wpn${index}PowerStops`].value = (weapon.powerStops || []).join(', ');
-    form.elements[`wpn${index}Structure`].value = weapon.structure || 1;
-    form.elements[`wpn${index}Ranges`].value = (weapon.ranges || []).map((range) => `${range.band}:${range.type}`).join(',');
-    form.elements[`wpn${index}Dice`].value = (weapon.ranges || []).map((range) => {
+    setValue(`wpn${index}Name`, weapon.name || '');
+    setValue(`wpn${index}Traits`, (weapon.traits || []).join(', '));
+    setValue(`wpn${index}MountArcs`, (weapon.mountFacings || []).map((mount) => mount.join(',')).join('|'));
+    setValue(`wpn${index}PowerCircles`, weapon.powerCircles || 1);
+    setValue(`wpn${index}PowerStops`, (weapon.powerStops || []).join(', '));
+    setValue(`wpn${index}Structure`, weapon.structure || 1);
+    setValue(`wpn${index}Ranges`, (weapon.ranges || []).map((range) => `${range.band}:${range.type}`).join(','));
+    setValue(`wpn${index}Dice`, (weapon.ranges || []).map((range) => {
       const dice = (range.dice || []).join(',');
       return Number(range.bonus || 0) > 0 ? `${Number(range.bonus)},${dice}` : dice;
-    }).join('|');
-    form.elements[`wpn${index}Special`].value = weapon.special || '';
+    }).join('|'));
+    setValue(`wpn${index}Special`, weapon.special || '');
   });
-  form.elements.systems.value = (draft.systems ?? []).map((item) => `${item.key}:${item.value ?? ''}`).join('\n');
-  form.elements.shuttleCraft.value = draft.crew?.shuttleCraft ?? 4;
-  form.elements.marinesStationed.value = draft.crew?.marinesStationed ?? 10;
+
+  setValue('systems', (draft.systems ?? []).map((item) => `${item.key}:${item.value ?? ''}`).join('\n'));
+  setValue('shuttleCraft', draft.crew?.shuttleCraft ?? 4);
+  setValue('marinesStationed', draft.crew?.marinesStationed ?? 10);
 
   render();
 }
@@ -1159,12 +1229,13 @@ function exportCurrent() {
   downloadBlob(blob, `${name}.json`);
 }
 
-form.addEventListener('input', render);
-form.addEventListener('change', render);
+form.addEventListener('input', () => render({ recalculatePointValue: false }));
+form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
 document.getElementById('printBtn').addEventListener('click', () => window.print());
+document.getElementById('updatePvBtn').addEventListener('click', () => render({ recalculatePointValue: true }));
 
 const shipArtInput = document.getElementById('shipArt');
 document.getElementById('clearArtBtn').addEventListener('click', () => {

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -258,6 +258,11 @@
           <label>Permanent Structure Boxes <input name="structureRed" type="number" min="0" value="12" /></label>
         </div>
 
+        <div class="row row-pv-controls">
+          <label>Point Value (Auto) <input name="pointValueCalculated" id="pointValueCalculated" value="29" readonly /></label>
+          <button type="button" id="updatePvBtn">Update PV</button>
+        </div>
+
         <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
@@ -370,6 +375,7 @@
           </span>
           <span class="footer-tags">
             <span id="pvFaction">COMMON</span>
+            <span id="pvPointValue">29PV</span>
             <span id="pvEra">ERA</span>
           </span>
         </footer>

--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -1,0 +1,109 @@
+function num(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function sum(values) {
+  return values.reduce((total, value) => total + num(value), 0);
+}
+
+function bandSpan(rawBand) {
+  const [start, end] = String(rawBand || '')
+    .split('-')
+    .map((part) => Number(part.trim()));
+
+  if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
+    return Math.max(1, end - start + 1);
+  }
+
+  return 1;
+}
+
+function rangeTypeWeight(type) {
+  if (type === 'green') {
+    return 1.15;
+  }
+  if (type === 'red') {
+    return 0.9;
+  }
+  return 1;
+}
+
+function normalizeWeapons(weapons) {
+  return Array.isArray(weapons) ? weapons.filter((weapon) => weapon && weapon.name) : [];
+}
+
+function offenseScore(build) {
+  const weapons = normalizeWeapons(build.weapons);
+
+  return weapons.reduce((score, weapon) => {
+    const mountCount = Math.max(1, weapon.mountArcs?.length || weapon.mountFacings?.length || 1);
+    const structure = Math.max(1, num(weapon.structure));
+    const ranges = Array.isArray(weapon.ranges) ? weapon.ranges : [];
+
+    const rangeWeights = ranges.map((range) => {
+      const dice = Array.isArray(range.dice) ? range.dice.length : 0;
+      const bonus = Math.max(0, num(range.bonus));
+      const rawPower = (dice + (bonus * 0.3)) * rangeTypeWeight(String(range.type || 'black').toLowerCase());
+      return {
+        span: bandSpan(range.band),
+        power: rawPower
+      };
+    });
+
+    const spanTotal = sum(rangeWeights.map((entry) => entry.span)) || 1;
+    const weightedRangePower = sum(rangeWeights.map((entry) => entry.power * entry.span)) / spanTotal;
+
+    const traitCount = Array.isArray(weapon.traits) ? weapon.traits.length : 0;
+    const traitBonus = traitCount * 0.18;
+    const specialBonus = String(weapon.special || '').trim() ? 0.3 : 0;
+    const powerReqBonus = num(weapon.powerCircles) * 0.08;
+
+    return score + ((mountCount * structure * weightedRangePower * 0.62) + traitBonus + specialBonus + powerReqBonus);
+  }, 0);
+}
+
+function durabilityScore(build) {
+  const structure = build.structure || {};
+  const shields = build.shields || {};
+  const armor = build.armor || {};
+
+  const structureTotal = num(structure.repairable) + num(structure.permanent);
+  const shieldTotal = sum([shields.forward, shields.aft, shields.port, shields.starboard]);
+  const armorTotal = sum([armor.forward, armor.aft, armor.port, armor.starboard]);
+
+  return (structureTotal * 1.4) + (shieldTotal * 0.18) + (armorTotal * 0.24) + (num(build.shieldGen) * 1.1);
+}
+
+function mobilityAndSystemsScore(build) {
+  const engineering = build.engineering || {};
+  const systems = Array.isArray(build.systems) ? build.systems : [];
+  const crew = build.crew || {};
+
+  const mobility = (num(engineering.move) * 0.7)
+    + (num(engineering.vector) * 0.9)
+    + (num(engineering.turn) * 0.45)
+    + (num(engineering.special) * 0.4);
+
+  const systemDepth = systems.length * 0.35;
+  const crewSupport = (num(crew.shuttleCraft) * 0.08) + (num(crew.marinesStationed) * 0.04);
+
+  return mobility + systemDepth + crewSupport;
+}
+
+export function calculatePointValue(build) {
+  const offense = offenseScore(build);
+  const durability = durabilityScore(build);
+  const utility = mobilityAndSystemsScore(build);
+
+  // Core philosophy: value sustained combat pressure over burst.
+  // A ship that keeps firing while absorbing return fire scales faster than linearly.
+  const sustainedCombatPressure = offense * (1 + (durability / 50));
+
+  // Calibrated targets:
+  // - Yorktown II baseline remains in the 25-35 PV band.
+  // - Yorktown V advanced fit lands in the 75-80 PV band.
+  const total = -30 + sustainedCombatPressure + (utility * 0.2);
+
+  return Math.max(1, Math.round(total));
+}

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -14,6 +14,16 @@ textarea, input, button { width: 100%; margin-top: 0.25rem; padding: 0.45rem; bo
 .shield-stat-card input { margin-top: 0.15rem; }
 .row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0.5rem; margin-top: 0.75rem; }
 .row-actions { grid-template-columns: 1fr 1fr; }
+.row-pv-controls {
+  grid-template-columns: minmax(0, 1fr) 150px;
+  align-items: end;
+}
+.row-pv-controls label {
+  margin: 0;
+}
+.row-pv-controls button {
+  margin-top: 0;
+}
 
 .grid3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0.55rem; }
 .maneuver-editor { border: 1px solid #32427a; border-radius: 8px; padding: 0.6rem; margin-top: 0.5rem; background: #0f1731; }
@@ -339,8 +349,8 @@ button.ghost { background: #273055; }
 .wpn-special-row b,.wpn-trait-row b { color: #0b67b2; }
 
 .template-bottom {
-  --structure-box-size: 12px;
-  --structure-box-gap: 4px;
+  --structure-box-size: 18px;
+  --structure-box-gap: 6px;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
@@ -359,16 +369,18 @@ button.ghost { background: #273055; }
 }
 .structure-track {
   position: relative;
-  min-height: 30px;
+  min-height: 34px;
   border: 3px solid #f0b500;
   background: #fff;
-  padding: 0.14rem 0.2rem;
+  padding: 0.08rem 0.26rem;
+  display: flex;
+  align-items: center;
 }
 .structure-row {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   flex-wrap: nowrap;
-  gap: 3px;
+  gap: var(--structure-box-gap);
   min-height: var(--structure-box-size);
   overflow: hidden;
 }
@@ -376,20 +388,20 @@ button.ghost { background: #273055; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 24px;
+  min-width: 36px;
   color: #111;
-  font-size: 0.82rem;
+  font-size: 1.23rem;
   line-height: 1;
   font-family: Arial, Helvetica, sans-serif;
-  margin: 0 1px;
-  gap: 1px;
+  margin: 0 2px;
+  gap: 2px;
 }
 .team-count {
   font-weight: 900;
 }
 .wrench-icon {
-  width: 10px;
-  height: 10px;
+  width: 15px;
+  height: 15px;
   display: inline-block;
   background: center / contain no-repeat url("assets/wrench-icon.svg");
 }
@@ -422,6 +434,7 @@ button.ghost { background: #273055; }
   gap: 0.15rem;
 }
 #pvFaction,
+#pvPointValue,
 #pvEra {
   background: #566674;
   border: 3px solid #111;
@@ -493,6 +506,7 @@ pre { background: #0b1128; color: #d5e2ff; padding: 0.65rem; border-radius: 8px;
   .slot-title,
   .structure,
   #pvFaction,
+  #pvPointValue,
   #pvEra {
     font-size: 1.18rem;
   }


### PR DESCRIPTION
### Motivation

- Make Point Value (PV) scale more aggressively for heavily upgraded ships by valuing sustained offense while absorbing damage so Yorktown V-like fits land in the requested 75–80 PV band. 
- Move the manual PV display and Update button out of the Identity block and place them with export/print actions for clearer workflow. 
- Keep PV computation robust so a calculation error won't break preview/JSON rendering.

### Description

- Reworked the PV engine in `starforce-commander-ship-designer/pv-calculator.js` to compute a sustained combat pressure metric (`sustainedCombatPressure = offense * (1 + durability/50)`) and use `total = -30 + sustainedCombatPressure + (utility * 0.2)` to produce the final PV. 
- Relocated the readonly `pointValueCalculated` input and `updatePvBtn` from the Identity section to a new bottom control row next to `Export/Print` in `starforce-commander-ship-designer/index.html`. 
- Added `.row-pv-controls` styles and minor SSD layout/structure tuning in `starforce-commander-ship-designer/styles.css` so the moved control aligns with action buttons and the structure track displays more cleanly. 
- Integrated the calculator safely into the preview flow in `starforce-commander-ship-designer/app.js` via `safeCalculatePointValue(build)`, made PV recalculation opt-in via render options, and wired the `Update PV` button to trigger PV recomputation (`render({ recalculatePointValue: true })`).

### Testing

- Syntax/type checks: `node --check starforce-commander-ship-designer/app.js` and `node --check starforce-commander-ship-designer/pv-calculator.js` both passed. 
- Calibration run using the PV function produced the intended outputs: Yorktown II -> `32` PV and Yorktown V -> `80` PV. 
- Served the app locally with `python -m http.server` and captured a Playwright screenshot to verify the moved PV controls and UI rendered correctly; the smoke test completed without errors. 
- All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f23ac4b08332af49a3f74d411d1d)