### PR TITLE
Add JSON import support to Starforce Commander SSD builder

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -1231,11 +1231,47 @@ function exportCurrent() {
   downloadBlob(blob, `${name}.json`);
 }
 
+function importJsonFile(file) {
+  if (!file) {
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const importedDraft = JSON.parse(String(reader.result || '{}'));
+      if (!importedDraft || typeof importedDraft !== 'object') {
+        throw new Error('Invalid JSON');
+      }
+
+      const mergedDraft = {
+        ...importedDraft,
+        shipArtDataUrl: typeof importedDraft.shipArtDataUrl === 'string'
+          ? importedDraft.shipArtDataUrl
+          : shipArtDataUrl
+      };
+      restoreDraft(mergedDraft);
+    } catch {
+      window.alert('Could not import JSON. Please choose a valid SSD export file.');
+    }
+  };
+  reader.readAsText(file);
+}
+
 form.addEventListener('input', () => render({ recalculatePointValue: false }));
 form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+const importJsonInput = document.getElementById('importJsonInput');
+document.getElementById('importBtn').addEventListener('click', () => {
+  importJsonInput.click();
+});
+importJsonInput.addEventListener('change', (event) => {
+  const [file] = event.target.files || [];
+  importJsonFile(file);
+  importJsonInput.value = '';
+});
 document.getElementById('printBtn').addEventListener('click', () => window.print());
 document.getElementById('updatePvBtn').addEventListener('click', () => render({ recalculatePointValue: true }));
 

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -268,6 +268,8 @@
         <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="importBtn">Import JSON</button>
+          <input id="importJsonInput" type="file" accept="application/json,.json" hidden />
           <button type="button" id="printBtn">Print to Paper</button>
           <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>
         </div>


### PR DESCRIPTION
### Motivation
- Provide a way for users to import shared SSDs as JSON so custom ships can be exchanged and restored in the builder.
- Avoid unintentionally losing the currently-uploaded ship art when an imported JSON omits embedded image data.

### Description
- Added an `Import JSON` button and a hidden file input (`id="importJsonInput"`) to the action row in `index.html` to open a JSON file picker.
- Implemented `importJsonFile(file)` in `app.js` to read and parse the selected file, validate the payload, and call `restoreDraft` with the imported data.
- When `shipArtDataUrl` is missing or not a string in the imported file, the current `shipArtDataUrl` is preserved to avoid losing the ship graphic.
- Wired the importer UI: clicking the new button triggers the file input, the chosen file is imported, and the input value is cleared so the same file can be re-selected.

### Testing
- `node --check starforce-commander-ship-designer/app.js` executed successfully with no syntax errors.
- Launched a local server via `python3 -m http.server 4173` and performed a browser validation (Playwright screenshot) to confirm the `Import JSON` UI appears and the flow is reachable, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1ce333d48332b02c5dc317c5bb1e)