### PR TITLE
Embed ship art PNG in exported SSD JSON and preserve on import

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -205,6 +205,54 @@ function buildRangeProfile(ranges, diceByRange, structure = 1) {
   }));
 }
 
+function splitDataUrl(dataUrl) {
+  const match = String(dataUrl || '').match(/^data:([^;]+);base64,(.+)$/i);
+  if (!match) {
+    return null;
+  }
+  return {
+    mimeType: match[1],
+    base64: match[2]
+  };
+}
+
+function buildDataUrlFromEmbedded(embeddedAsset) {
+  if (!embeddedAsset || typeof embeddedAsset !== 'object') {
+    return '';
+  }
+  const mimeType = String(embeddedAsset.mimeType || '').trim();
+  const base64 = String(embeddedAsset.base64 || '').trim();
+  if (!mimeType || !base64) {
+    return '';
+  }
+  return `data:${mimeType};base64,${base64}`;
+}
+
+function withEmbeddedShipArt(build) {
+  const normalizedDataUrl = typeof build?.shipArtDataUrl === 'string' ? build.shipArtDataUrl : '';
+  const split = splitDataUrl(normalizedDataUrl);
+  return {
+    ...build,
+    embeddedAssets: split
+      ? {
+        ...(build.embeddedAssets && typeof build.embeddedAssets === 'object' ? build.embeddedAssets : {}),
+        shipArt: split
+      }
+      : (build.embeddedAssets && typeof build.embeddedAssets === 'object' ? build.embeddedAssets : undefined)
+  };
+}
+
+function resolveImportedShipArt(importedDraft = {}) {
+  if (typeof importedDraft.shipArtDataUrl === 'string' && importedDraft.shipArtDataUrl.trim()) {
+    return importedDraft.shipArtDataUrl;
+  }
+  const embeddedDataUrl = buildDataUrlFromEmbedded(importedDraft.embeddedAssets?.shipArt);
+  if (embeddedDataUrl) {
+    return embeddedDataUrl;
+  }
+  return shipArtDataUrl;
+}
+
 function readWeaponsFromForm() {
   return [1, 2, 3, 4].map((index) => {
     const name = form.elements[`wpn${index}Name`]?.value?.trim() || '';
@@ -998,13 +1046,23 @@ function renderPowerSystem(powerSystem) {
 }
 
 function getJsonPreview(build) {
-  if (!build.shipArtDataUrl) {
-    return JSON.stringify(build, null, 2);
+  const previewBuild = { ...build };
+
+  if (previewBuild.shipArtDataUrl) {
+    previewBuild.shipArtDataUrl = `[image data url omitted: ${previewBuild.shipArtDataUrl.length} chars]`;
   }
-  const previewBuild = {
-    ...build,
-    shipArtDataUrl: `[image data url omitted: ${build.shipArtDataUrl.length} chars]`
-  };
+
+  const embeddedBase64 = previewBuild.embeddedAssets?.shipArt?.base64;
+  if (typeof embeddedBase64 === 'string' && embeddedBase64.length > 0) {
+    previewBuild.embeddedAssets = {
+      ...(previewBuild.embeddedAssets || {}),
+      shipArt: {
+        ...(previewBuild.embeddedAssets?.shipArt || {}),
+        base64: `[image base64 omitted: ${embeddedBase64.length} chars]`
+      }
+    };
+  }
+
   return JSON.stringify(previewBuild, null, 2);
 }
 
@@ -1018,7 +1076,7 @@ function pulseLiveBadge() {
 function render(options = {}) {
   const { recalculatePointValue = true } = options;
   syncDerivedFunctionInputs();
-  const build = getBuild();
+  const build = withEmbeddedShipArt(getBuild());
   renderPreview(build, { recalculatePointValue });
   jsonPreview.textContent = getJsonPreview(build);
   pulseLiveBadge();
@@ -1227,8 +1285,34 @@ function downloadBlob(blob, filename) {
 
 function exportCurrent() {
   const name = slugifyFileName(form.elements.name.value);
-  const blob = new Blob([JSON.stringify(getBuild(), null, 2)], { type: 'application/json' });
+  const shareableBuild = withEmbeddedShipArt(getBuild());
+  const blob = new Blob([JSON.stringify(shareableBuild, null, 2)], { type: 'application/json' });
   downloadBlob(blob, `${name}.json`);
+}
+
+function importJsonFile(file) {
+  if (!file) {
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const importedDraft = JSON.parse(String(reader.result || '{}'));
+      if (!importedDraft || typeof importedDraft !== 'object') {
+        throw new Error('Invalid JSON');
+      }
+
+      const mergedDraft = {
+        ...importedDraft,
+        shipArtDataUrl: resolveImportedShipArt(importedDraft)
+      };
+      restoreDraft(mergedDraft);
+    } catch {
+      window.alert('Could not import JSON. Please choose a valid SSD export file.');
+    }
+  };
+  reader.readAsText(file);
 }
 
 form.addEventListener('input', () => render({ recalculatePointValue: false }));
@@ -1236,6 +1320,21 @@ form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+document.getElementById('importBtn').addEventListener('click', () => {
+  const picker = document.createElement('input');
+  picker.type = 'file';
+  picker.accept = 'application/json,.json';
+  picker.addEventListener('change', (event) => {
+    const [file] = event.target.files || [];
+    importJsonFile(file);
+  }, { once: true });
+
+  if (typeof picker.showPicker === 'function') {
+    picker.showPicker();
+  } else {
+    picker.click();
+  }
+});
 document.getElementById('printBtn').addEventListener('click', () => window.print());
 document.getElementById('updatePvBtn').addEventListener('click', () => render({ recalculatePointValue: true }));
 

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -268,6 +268,7 @@
         <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="importBtn">Import JSON</button>
           <button type="button" id="printBtn">Print to Paper</button>
           <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>
         </div>


### PR DESCRIPTION
### Motivation
- Allow users to share SSD exports that include the ship image when they cannot separately attach the PNG by embedding a normalized image payload into the JSON file. 
- Preserve existing `shipArtDataUrl` behavior while adding a structured `embeddedAssets.shipArt` representation (`mimeType` + `base64`) for easier downstream transforms. 
- Ensure imports still restore in-memory art by rebuilding `shipArtDataUrl` from `embeddedAssets.shipArt` if a data URL is not present. 

### Description
- Added helpers `splitDataUrl`, `buildDataUrlFromEmbedded`, `withEmbeddedShipArt`, and `resolveImportedShipArt` to normalize and convert between inline data URLs and embedded asset objects. 
- Changed rendering and export paths to use `withEmbeddedShipArt(getBuild())` so exported JSON includes `embeddedAssets.shipArt` when `shipArtDataUrl` is present, and updated `exportCurrent` accordingly. 
- Updated import flow with `importJsonFile(file)` to reconstruct `shipArtDataUrl` from `embeddedAssets.shipArt` using `resolveImportedShipArt` and then call `restoreDraft`. 
- Improved `getJsonPreview` to redact both inline data URLs and embedded base64 in the on-page preview for readability, and kept the dynamic JSON file picker behavior for `#importBtn`. 

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` which completed successfully. 
- Launched a local server with `python3 -m http.server 4173` and exercised the UI with a Playwright script that uploaded a PNG, clicked `#exportBtn`, saved the exported JSON, and asserted the JSON contains both `shipArtDataUrl` and `embeddedAssets.shipArt.base64`. 
- The Playwright validation and the served UI run completed successfully and produced an exported sample artifact with embedded image data.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1ce333d48332b02c5dc317c5bb1e)