### PR TITLE
Embed ship art in SSD JSON, add import UI, and adjust PV floor

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -205,6 +205,54 @@ function buildRangeProfile(ranges, diceByRange, structure = 1) {
   }));
 }
 
+function splitDataUrl(dataUrl) {
+  const match = String(dataUrl || '').match(/^data:([^;]+);base64,(.+)$/i);
+  if (!match) {
+    return null;
+  }
+  return {
+    mimeType: match[1],
+    base64: match[2]
+  };
+}
+
+function buildDataUrlFromEmbedded(embeddedAsset) {
+  if (!embeddedAsset || typeof embeddedAsset !== 'object') {
+    return '';
+  }
+  const mimeType = String(embeddedAsset.mimeType || '').trim();
+  const base64 = String(embeddedAsset.base64 || '').trim();
+  if (!mimeType || !base64) {
+    return '';
+  }
+  return `data:${mimeType};base64,${base64}`;
+}
+
+function withEmbeddedShipArt(build) {
+  const normalizedDataUrl = typeof build?.shipArtDataUrl === 'string' ? build.shipArtDataUrl : '';
+  const split = splitDataUrl(normalizedDataUrl);
+  return {
+    ...build,
+    embeddedAssets: split
+      ? {
+        ...(build.embeddedAssets && typeof build.embeddedAssets === 'object' ? build.embeddedAssets : {}),
+        shipArt: split
+      }
+      : (build.embeddedAssets && typeof build.embeddedAssets === 'object' ? build.embeddedAssets : undefined)
+  };
+}
+
+function resolveImportedShipArt(importedDraft = {}) {
+  if (typeof importedDraft.shipArtDataUrl === 'string' && importedDraft.shipArtDataUrl.trim()) {
+    return importedDraft.shipArtDataUrl;
+  }
+  const embeddedDataUrl = buildDataUrlFromEmbedded(importedDraft.embeddedAssets?.shipArt);
+  if (embeddedDataUrl) {
+    return embeddedDataUrl;
+  }
+  return shipArtDataUrl;
+}
+
 function readWeaponsFromForm() {
   return [1, 2, 3, 4].map((index) => {
     const name = form.elements[`wpn${index}Name`]?.value?.trim() || '';
@@ -998,13 +1046,23 @@ function renderPowerSystem(powerSystem) {
 }
 
 function getJsonPreview(build) {
-  if (!build.shipArtDataUrl) {
-    return JSON.stringify(build, null, 2);
+  const previewBuild = { ...build };
+
+  if (previewBuild.shipArtDataUrl) {
+    previewBuild.shipArtDataUrl = `[image data url omitted: ${previewBuild.shipArtDataUrl.length} chars]`;
   }
-  const previewBuild = {
-    ...build,
-    shipArtDataUrl: `[image data url omitted: ${build.shipArtDataUrl.length} chars]`
-  };
+
+  const embeddedBase64 = previewBuild.embeddedAssets?.shipArt?.base64;
+  if (typeof embeddedBase64 === 'string' && embeddedBase64.length > 0) {
+    previewBuild.embeddedAssets = {
+      ...(previewBuild.embeddedAssets || {}),
+      shipArt: {
+        ...(previewBuild.embeddedAssets?.shipArt || {}),
+        base64: `[image base64 omitted: ${embeddedBase64.length} chars]`
+      }
+    };
+  }
+
   return JSON.stringify(previewBuild, null, 2);
 }
 
@@ -1018,7 +1076,7 @@ function pulseLiveBadge() {
 function render(options = {}) {
   const { recalculatePointValue = true } = options;
   syncDerivedFunctionInputs();
-  const build = getBuild();
+  const build = withEmbeddedShipArt(getBuild());
   renderPreview(build, { recalculatePointValue });
   jsonPreview.textContent = getJsonPreview(build);
   pulseLiveBadge();
@@ -1227,8 +1285,34 @@ function downloadBlob(blob, filename) {
 
 function exportCurrent() {
   const name = slugifyFileName(form.elements.name.value);
-  const blob = new Blob([JSON.stringify(getBuild(), null, 2)], { type: 'application/json' });
+  const shareableBuild = withEmbeddedShipArt(getBuild());
+  const blob = new Blob([JSON.stringify(shareableBuild, null, 2)], { type: 'application/json' });
   downloadBlob(blob, `${name}.json`);
+}
+
+function importJsonFile(file) {
+  if (!file) {
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const importedDraft = JSON.parse(String(reader.result || '{}'));
+      if (!importedDraft || typeof importedDraft !== 'object') {
+        throw new Error('Invalid JSON');
+      }
+
+      const mergedDraft = {
+        ...importedDraft,
+        shipArtDataUrl: resolveImportedShipArt(importedDraft)
+      };
+      restoreDraft(mergedDraft);
+    } catch {
+      window.alert('Could not import JSON. Please choose a valid SSD export file.');
+    }
+  };
+  reader.readAsText(file);
 }
 
 form.addEventListener('input', () => render({ recalculatePointValue: false }));
@@ -1236,6 +1320,21 @@ form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+document.getElementById('importBtn').addEventListener('click', () => {
+  const picker = document.createElement('input');
+  picker.type = 'file';
+  picker.accept = 'application/json,.json';
+  picker.addEventListener('change', (event) => {
+    const [file] = event.target.files || [];
+    importJsonFile(file);
+  }, { once: true });
+
+  if (typeof picker.showPicker === 'function') {
+    picker.showPicker();
+  } else {
+    picker.click();
+  }
+});
 document.getElementById('printBtn').addEventListener('click', () => window.print());
 document.getElementById('updatePvBtn').addEventListener('click', () => render({ recalculatePointValue: true }));
 

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -268,6 +268,7 @@
         <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="importBtn">Import JSON</button>
           <button type="button" id="printBtn">Print to Paper</button>
           <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>
         </div>

--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -139,11 +139,11 @@ export function calculatePointValue(build) {
   // A ship that keeps firing while absorbing return fire scales faster than linearly.
   const sustainedCombatPressure = offense * (1 + (durability / 50));
 
-  // Calibrated targets:
-  // - Yorktown II baseline remains around 30 PV.
-  // - V-7D Raider counterpart lands near Yorktown II (~29-31 PV).
-  // - Yorktown V advanced fit lands in the low-mid 50s PV band.
+  // Main combat calibration path.
   const total = -50 + sustainedCombatPressure + (utility * 0.2);
 
-  return Math.max(1, Math.round(total));
+  // Survivability/utility floor prevents valid low-offense escorts from collapsing to 1 PV.
+  const survivabilityFloor = (durability * 0.5) + (utility * 0.8) - 8;
+
+  return Math.max(1, Math.round(Math.max(total, survivabilityFloor)));
 }


### PR DESCRIPTION
### Motivation
- Allow SSD exports to carry the ship artwork inline so builds can be shared without a separate PNG attachment and imports can restore in-memory art from the JSON.
- Keep on-page JSON previews human-readable by redacting large data URLs and embedded base64 payloads.
- Prevent valid low-offense ships (for example escorts) from being forced to the hard minimum of `1` PV by adding a survivability/utility-based floor to the PV formula.

### Description
- Added helpers `splitDataUrl`, `buildDataUrlFromEmbedded`, `withEmbeddedShipArt`, and `resolveImportedShipArt` to normalize and convert between inline data URLs and `embeddedAssets.shipArt` objects.
- Updated rendering and export to call `withEmbeddedShipArt(getBuild())` so exported JSON includes `embeddedAssets.shipArt` when a `shipArtDataUrl` exists, and added `importJsonFile(file)` plus a wired `#importBtn` file picker to reconstruct `shipArtDataUrl` from embedded assets when importing.
- Improved `getJsonPreview` to redact both inline `shipArtDataUrl` and embedded base64 payloads for readability.
- Adjusted `calculatePointValue` in `pv-calculator.js` to compute a `survivabilityFloor = (durability * 0.5) + (utility * 0.8) - 8` and return `Math.max(total, survivabilityFloor)` before rounding and clamping to the minimum of `1`.

### Testing
- Ran `node --check starforce-commander-ship-designer/pv-calculator.js` which completed successfully.
- Executed a Node reproduction script using the provided ship profile and confirmed the PV changed from `1` to `10` under the updated calculation.
- Ran the PV calculation trace script to inspect intermediate `offense`, `durability`, and `utility` values and confirmed the new floor produces a higher, reasonable PV for the sample escort.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1ce333d48332b02c5dc317c5bb1e)