### PR TITLE
Stabilize PV update & export, add import/embedded art, and refine PV scoring

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -205,6 +205,54 @@ function buildRangeProfile(ranges, diceByRange, structure = 1) {
   }));
 }
 
+function splitDataUrl(dataUrl) {
+  const match = String(dataUrl || '').match(/^data:([^;]+);base64,(.+)$/i);
+  if (!match) {
+    return null;
+  }
+  return {
+    mimeType: match[1],
+    base64: match[2]
+  };
+}
+
+function buildDataUrlFromEmbedded(embeddedAsset) {
+  if (!embeddedAsset || typeof embeddedAsset !== 'object') {
+    return '';
+  }
+  const mimeType = String(embeddedAsset.mimeType || '').trim();
+  const base64 = String(embeddedAsset.base64 || '').trim();
+  if (!mimeType || !base64) {
+    return '';
+  }
+  return `data:${mimeType};base64,${base64}`;
+}
+
+function withEmbeddedShipArt(build) {
+  const normalizedDataUrl = typeof build?.shipArtDataUrl === 'string' ? build.shipArtDataUrl : '';
+  const split = splitDataUrl(normalizedDataUrl);
+  return {
+    ...build,
+    embeddedAssets: split
+      ? {
+        ...(build.embeddedAssets && typeof build.embeddedAssets === 'object' ? build.embeddedAssets : {}),
+        shipArt: split
+      }
+      : (build.embeddedAssets && typeof build.embeddedAssets === 'object' ? build.embeddedAssets : undefined)
+  };
+}
+
+function resolveImportedShipArt(importedDraft = {}) {
+  if (typeof importedDraft.shipArtDataUrl === 'string' && importedDraft.shipArtDataUrl.trim()) {
+    return importedDraft.shipArtDataUrl;
+  }
+  const embeddedDataUrl = buildDataUrlFromEmbedded(importedDraft.embeddedAssets?.shipArt);
+  if (embeddedDataUrl) {
+    return embeddedDataUrl;
+  }
+  return shipArtDataUrl;
+}
+
 function readWeaponsFromForm() {
   return [1, 2, 3, 4].map((index) => {
     const name = form.elements[`wpn${index}Name`]?.value?.trim() || '';
@@ -481,7 +529,7 @@ function getBuild() {
       classType: form.elements.classType.value,
       faction: form.elements.faction.value,
       era: form.elements.era.value,
-      pointValue: num('pointValue')
+      pointValue: num('pointValueCalculated')
     },
     engineering: {
       move: num('move'),
@@ -721,9 +769,9 @@ function renderManeuvering(sublight) {
 function safeCalculatePointValue(build) {
   try {
     const pointValue = calculatePointValue(build);
-    return Number.isFinite(pointValue) ? pointValue : 29;
+    return Number.isFinite(pointValue) ? pointValue : 1;
   } catch {
-    return 29;
+    return 1;
   }
 }
 
@@ -998,13 +1046,23 @@ function renderPowerSystem(powerSystem) {
 }
 
 function getJsonPreview(build) {
-  if (!build.shipArtDataUrl) {
-    return JSON.stringify(build, null, 2);
+  const previewBuild = { ...build };
+
+  if (previewBuild.shipArtDataUrl) {
+    previewBuild.shipArtDataUrl = `[image data url omitted: ${previewBuild.shipArtDataUrl.length} chars]`;
   }
-  const previewBuild = {
-    ...build,
-    shipArtDataUrl: `[image data url omitted: ${build.shipArtDataUrl.length} chars]`
-  };
+
+  const embeddedBase64 = previewBuild.embeddedAssets?.shipArt?.base64;
+  if (typeof embeddedBase64 === 'string' && embeddedBase64.length > 0) {
+    previewBuild.embeddedAssets = {
+      ...(previewBuild.embeddedAssets || {}),
+      shipArt: {
+        ...(previewBuild.embeddedAssets?.shipArt || {}),
+        base64: `[image base64 omitted: ${embeddedBase64.length} chars]`
+      }
+    };
+  }
+
   return JSON.stringify(previewBuild, null, 2);
 }
 
@@ -1018,7 +1076,7 @@ function pulseLiveBadge() {
 function render(options = {}) {
   const { recalculatePointValue = true } = options;
   syncDerivedFunctionInputs();
-  const build = getBuild();
+  const build = withEmbeddedShipArt(getBuild());
   renderPreview(build, { recalculatePointValue });
   jsonPreview.textContent = getJsonPreview(build);
   pulseLiveBadge();
@@ -1227,8 +1285,34 @@ function downloadBlob(blob, filename) {
 
 function exportCurrent() {
   const name = slugifyFileName(form.elements.name.value);
-  const blob = new Blob([JSON.stringify(getBuild(), null, 2)], { type: 'application/json' });
+  const shareableBuild = withEmbeddedShipArt(getBuild());
+  const blob = new Blob([JSON.stringify(shareableBuild, null, 2)], { type: 'application/json' });
   downloadBlob(blob, `${name}.json`);
+}
+
+function importJsonFile(file) {
+  if (!file) {
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const importedDraft = JSON.parse(String(reader.result || '{}'));
+      if (!importedDraft || typeof importedDraft !== 'object') {
+        throw new Error('Invalid JSON');
+      }
+
+      const mergedDraft = {
+        ...importedDraft,
+        shipArtDataUrl: resolveImportedShipArt(importedDraft)
+      };
+      restoreDraft(mergedDraft);
+    } catch {
+      window.alert('Could not import JSON. Please choose a valid SSD export file.');
+    }
+  };
+  reader.readAsText(file);
 }
 
 form.addEventListener('input', () => render({ recalculatePointValue: false }));
@@ -1236,8 +1320,25 @@ form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+document.getElementById('importBtn').addEventListener('click', () => {
+  const picker = document.createElement('input');
+  picker.type = 'file';
+  picker.accept = 'application/json,.json';
+  picker.addEventListener('change', (event) => {
+    const [file] = event.target.files || [];
+    importJsonFile(file);
+  }, { once: true });
+
+  if (typeof picker.showPicker === 'function') {
+    picker.showPicker();
+  } else {
+    picker.click();
+  }
+});
 document.getElementById('printBtn').addEventListener('click', () => window.print());
-document.getElementById('updatePvBtn').addEventListener('click', () => render({ recalculatePointValue: true }));
+document.querySelectorAll('.update-pv-btn').forEach((button) => {
+  button.addEventListener('click', () => render({ recalculatePointValue: true }));
+});
 
 const shipArtInput = document.getElementById('shipArt');
 document.getElementById('clearArtBtn').addEventListener('click', () => {

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -19,8 +19,6 @@
         <div class="grid2">
           <label>Faction <input name="faction" value="COMMON" /></label>
           <label>Era <input name="era" value="ERA" /></label>
-          <label>Point Value (Auto) <input name="pointValueCalculated" id="pointValueCalculated" value="29" readonly /></label>
-          <button type="button" id="updatePvBtn">Update</button>
         </div>
 
         <h2>Engineering</h2>
@@ -261,13 +259,14 @@
         </div>
 
         <div class="row row-pv-controls">
-          <label>Point Value (Auto) <input name="pointValueCalculated" id="pointValueCalculated" value="29" readonly /></label>
-          <button type="button" id="updatePvBtn">Update PV</button>
+          <label>Point Value (Auto) <input name="pointValueCalculated" value="29" readonly /></label>
+          <button type="button" class="update-pv-btn">Update PV</button>
         </div>
 
         <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="importBtn">Import JSON</button>
           <button type="button" id="printBtn">Print to Paper</button>
           <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>
         </div>

--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -42,8 +42,8 @@ const TRAIT_BONUS_BY_PREFIX = [
   { match: 'HVY', bonus: 1.4 },
   { match: 'PREC', bonus: 1.4 },
   { match: 'PIERCE', bonus: 1.4 },
-  { match: 'PIRCE', bonus: 1.4 }, // common typo support
-  { match: 'PARICAL', bonus: 1.1 }, // custom rules typo support
+  { match: 'PIRCE', bonus: 1.4 },
+  { match: 'PARICAL', bonus: 1.1 },
   { match: 'PARTIAL', bonus: 1.1 },
   { match: 'LEAK', bonus: 1.1 },
   { match: 'PD MODE', bonus: 1.1 },
@@ -64,42 +64,148 @@ function traitBonusScore(traits) {
     }
 
     const weighted = TRAIT_BONUS_BY_PREFIX.find((entry) => normalized.startsWith(entry.match));
-    // Default keeps unknown custom traits meaningful without overpricing flavor tags.
     return score + (weighted ? weighted.bonus : 0.9);
   }, 0);
 }
 
+function normalizeArcValues(weapon) {
+  const fromFacings = Array.isArray(weapon.mountFacings)
+    ? weapon.mountFacings.flatMap((mount) => (Array.isArray(mount) ? mount : []))
+    : [];
+
+  const fromArcs = Array.isArray(weapon.mountArcs)
+    ? weapon.mountArcs
+      .flatMap((entry) => String(entry || '').split('|'))
+      .flatMap((group) => group.split(','))
+      .map((value) => Number(value.trim()))
+      .filter((value) => Number.isFinite(value))
+    : [];
+
+  const merged = [...fromFacings, ...fromArcs]
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value) && value >= 1 && value <= 8);
+
+  return merged.length ? merged : [1];
+}
+
+function arcValueWeight(arc) {
+  if (arc === 1) {
+    return 1.35;
+  }
+  if (arc === 2 || arc === 8) {
+    return 1.15;
+  }
+  if (arc === 3 || arc === 7) {
+    return 1.0;
+  }
+  if (arc === 4 || arc === 6) {
+    return 0.86;
+  }
+  return 0.72; // arc 5 (rear)
+}
+
+function mountFacingWeight(weapon) {
+  const arcs = normalizeArcValues(weapon);
+  return sum(arcs.map((arc) => arcValueWeight(arc))) / Math.max(1, arcs.length);
+}
+
+function rangeProfileScore(ranges = []) {
+  const weighted = ranges.map((range) => {
+    const span = bandSpan(range.band);
+    const maxRange = (() => {
+      const [, end] = String(range.band || '').split('-').map((part) => Number(part.trim()));
+      return Number.isFinite(end) ? end : span;
+    })();
+
+    const dice = Array.isArray(range.dice) ? range.dice.length : 0;
+    const bonus = Math.max(0, num(range.bonus));
+    const baseDamage = (dice + (bonus * 0.35));
+    const colorWeight = rangeTypeWeight(String(range.type || 'black').toLowerCase());
+    const overallRangeWeight = 1 + (Math.max(0, maxRange) * 0.012);
+    const greenRangeBonus = String(range.type || '').toLowerCase() === 'green'
+      ? 1 + (Math.max(0, maxRange) * 0.022)
+      : 1;
+
+    return baseDamage * span * colorWeight * overallRangeWeight * greenRangeBonus;
+  });
+
+  return sum(weighted);
+}
+
+function weaponCostScore(weapon) {
+  const ranges = Array.isArray(weapon.ranges) ? weapon.ranges : [];
+  const mountCount = Math.max(1, weapon.mountArcs?.length || weapon.mountFacings?.length || 1);
+  const structure = Math.max(1, num(weapon.structure));
+  const facingWeight = mountFacingWeight(weapon);
+
+  const damageCoverage = rangeProfileScore(ranges);
+  const mountAndStructure = mountCount * (1 + (structure * 0.55));
+  const powerDraw = num(weapon.powerCircles) * 0.45;
+  const powerStops = (Array.isArray(weapon.powerStops) ? weapon.powerStops.length : 0) * 0.18;
+  const traitBonus = traitBonusScore(weapon.traits);
+  const specialBonus = String(weapon.special || '').trim() ? 0.5 : 0;
+
+  return (damageCoverage * mountAndStructure * facingWeight * 0.17)
+    + powerDraw
+    + powerStops
+    + traitBonus
+    + specialBonus;
+}
+
 function offenseScore(build) {
   const weapons = normalizeWeapons(build.weapons);
+  const totalWeaponCost = sum(weapons.map((weapon) => weaponCostScore(weapon)));
 
-  const weaponScore = weapons.reduce((score, weapon) => {
+  // Battery coordination has value, but individual weapon quality drives most offense cost.
+  const coordinatedBatteryBonus = Math.max(0, weapons.length - 1) * 1.5;
+  return totalWeaponCost + coordinatedBatteryBonus;
+}
+
+
+function weaponPowerDemandScore(build) {
+  const weapons = normalizeWeapons(build.weapons);
+  return weapons.reduce((total, weapon) => {
     const mountCount = Math.max(1, weapon.mountArcs?.length || weapon.mountFacings?.length || 1);
-    const structure = Math.max(1, num(weapon.structure));
-    const ranges = Array.isArray(weapon.ranges) ? weapon.ranges : [];
-
-    const rangeWeights = ranges.map((range) => {
-      const dice = Array.isArray(range.dice) ? range.dice.length : 0;
-      const bonus = Math.max(0, num(range.bonus));
-      const rawPower = (dice + (bonus * 0.3)) * rangeTypeWeight(String(range.type || 'black').toLowerCase());
-      return {
-        span: bandSpan(range.band),
-        power: rawPower
-      };
-    });
-
-    const spanTotal = sum(rangeWeights.map((entry) => entry.span)) || 1;
-    const weightedRangePower = sum(rangeWeights.map((entry) => entry.power * entry.span)) / spanTotal;
-
-    const traitBonus = traitBonusScore(weapon.traits);
-    const specialBonus = String(weapon.special || '').trim() ? 0.3 : 0;
-    const powerReqBonus = num(weapon.powerCircles) * 0.08;
-
-    return score + ((mountCount * structure * weightedRangePower * 0.62) + traitBonus + specialBonus + powerReqBonus);
+    const circleDemand = num(weapon.powerCircles) * mountCount;
+    const stopDemand = (Array.isArray(weapon.powerStops) ? weapon.powerStops.length : 0) * 0.5;
+    return total + circleDemand + stopDemand;
   }, 0);
+}
 
-  // Multiple active weapon systems improve pressure/coverage in sustained engagements.
-  const coordinatedBatteryBonus = Math.max(0, weapons.length - 1) * 6;
-  return weaponScore + coordinatedBatteryBonus;
+function availableCombatPowerScore(build) {
+  const tracks = Array.isArray(build.powerSystem?.tracks) ? build.powerSystem.tracks : [];
+  return tracks.reduce((total, track) => {
+    const key = String(track?.key || '').toLowerCase();
+    const points = num(track?.points);
+
+    if (key === 'ftldrive' || key === 'ftl') {
+      return total;
+    }
+    if (key === 'battery') {
+      return total + (points * 0.5);
+    }
+
+    return total + points;
+  }, 0);
+}
+
+function powerConstraintMultiplier(build) {
+  const demand = weaponPowerDemandScore(build);
+  if (demand <= 0) {
+    return 1;
+  }
+
+  const available = availableCombatPowerScore(build);
+  const coverage = available / demand;
+
+  if (coverage >= 1) {
+    const utilization = demand / Math.max(1, available);
+    // Even when fully powered, weapon energy tax reduces effective offensive value somewhat.
+    return Math.max(0.82, 1 - (utilization * 0.18));
+  }
+
+  // Underpowered ships cannot realize full weapon card value in battle.
+  return Math.max(0.45, 0.58 + (coverage * 0.3));
 }
 
 function durabilityScore(build) {
@@ -111,39 +217,80 @@ function durabilityScore(build) {
   const shieldTotal = sum([shields.forward, shields.aft, shields.port, shields.starboard]);
   const armorTotal = sum([armor.forward, armor.aft, armor.port, armor.starboard]);
 
-  return (structureTotal * 1.4) + (shieldTotal * 0.18) + (armorTotal * 0.24) + (num(build.shieldGen) * 1.1);
+  return (structureTotal * 1.1) + (shieldTotal * 0.22) + (armorTotal * 0.3) + (num(build.shieldGen) * 0.9);
 }
 
-function mobilityAndSystemsScore(build) {
+function mobilityScore(build) {
   const engineering = build.engineering || {};
+  const sublight = build.sublight || {};
+
+  const baseMobility = (num(engineering.move) * 1.1)
+    + (num(engineering.vector) * 1.3)
+    + (num(engineering.turn) * 0.8)
+    + (num(engineering.special) * 0.75);
+
+  const maxAcc = num(sublight.maxAccPhs) * 0.9;
+  const circles = (num(sublight.greenCircles) * 0.4) + (num(sublight.redCircles) * 0.35);
+  const turnFlexibility = sum(Array.isArray(sublight.turns) ? sublight.turns : []) * 0.02;
+  const dmgStopControl = sum((Array.isArray(sublight.dmgStops) ? sublight.dmgStops : []).map((stop) => (stop ? 1 : 0))) * 0.35;
+
+  return baseMobility + maxAcc + circles + turnFlexibility + dmgStopControl;
+}
+
+function systemsAndCrewScore(build) {
   const systems = Array.isArray(build.systems) ? build.systems : [];
   const crew = build.crew || {};
 
-  const mobility = (num(engineering.move) * 0.7)
-    + (num(engineering.vector) * 0.9)
-    + (num(engineering.turn) * 0.45)
-    + (num(engineering.special) * 0.4);
+  const systemsValue = systems.reduce((total, entry) => total + num(entry?.value), 0);
+  const systemsBreadth = systems.length * 0.5;
+  const crewSupport = (num(crew.shuttleCraft) * 0.25) + (num(crew.marinesStationed) * 0.12);
 
-  const systemDepth = systems.length * 0.35;
-  const crewSupport = (num(crew.shuttleCraft) * 0.08) + (num(crew.marinesStationed) * 0.04);
+  return systemsValue + systemsBreadth + crewSupport;
+}
 
-  return mobility + systemDepth + crewSupport;
+function powerAndFunctionsScore(build) {
+  const tracks = Array.isArray(build.powerSystem?.tracks) ? build.powerSystem.tracks : [];
+  const trackPower = tracks.reduce((total, track) => {
+    const points = num(track?.points);
+    const boxesPerPoint = Math.max(1, num(track?.boxesPerPoint));
+    const patternBonus = (Array.isArray(track?.boxPattern) ? track.boxPattern : []).length * 0.08;
+    const dotBonus = track?.hasDot === false ? 0 : 0.1;
+    return total + (points * (0.7 + (boxesPerPoint * 0.12))) + patternBonus + dotBonus;
+  }, 0);
+
+  const cfg = build.functionsConfig || {};
+  const rows = [cfg.accDec, cfg.sifIdf, cfg.batRech, cfg.sensor, cfg.genSys, ...(Array.isArray(cfg.weapons) ? cfg.weapons : [])];
+
+  const functionsValue = rows.reduce((total, row) => {
+    if (!row || row.enabled === false) {
+      return total;
+    }
+    const valueCount = Array.isArray(row.values) ? row.values.length : 0;
+    const free = num(row.free);
+    const emergency = row.emer ? 0.35 : 0;
+    return total + (valueCount * 0.55) + (free * 0.4) + emergency;
+  }, 0)
+    + (num(cfg.ftl?.empty) * 0.2)
+    + (num(cfg.cloak?.empty) * 0.2)
+    + (cfg.cloak?.enabled ? 1.2 : 0);
+
+  return trackPower + functionsValue;
 }
 
 export function calculatePointValue(build) {
   const offense = offenseScore(build);
+  const powerLimitedOffense = offense * powerConstraintMultiplier(build);
   const durability = durabilityScore(build);
-  const utility = mobilityAndSystemsScore(build);
+  const mobility = mobilityScore(build);
+  const systems = systemsAndCrewScore(build);
+  const power = powerAndFunctionsScore(build);
 
-  // Core philosophy: value sustained combat pressure over burst.
-  // A ship that keeps firing while absorbing return fire scales faster than linearly.
-  const sustainedCombatPressure = offense * (1 + (durability / 50));
-
-  // Calibrated targets:
-  // - Yorktown II baseline remains around 30 PV.
-  // - V-7D Raider counterpart lands near Yorktown II (~29-31 PV).
-  // - Yorktown V advanced fit lands in the low-mid 50s PV band.
-  const total = -50 + sustainedCombatPressure + (utility * 0.2);
+  // Balanced model: every major ship section contributes to cost.
+  const total = (powerLimitedOffense * 0.9)
+    + (durability * 0.95)
+    + (mobility * 0.85)
+    + (systems * 0.75)
+    + (power * 0.8);
 
   return Math.max(1, Math.round(total));
 }


### PR DESCRIPTION
### Motivation
- Ensure the Point Value (PV) UI reliably triggers recalculation and that exported builds persist the correct `pointValue` instead of defaulting to `0` due to a form mismatch.
- Decouple fallback PV behavior from the demo ship baseline so tuning changes don't silently anchor to an example value.
- Improve import/export and embedded ship art handling so large image data is preserved or elided safely and imports restore art where present.
- Refine PV scoring to better model weapon power demand, available power, and balance offense against mobility, systems, and power/fn configuration.

### Description
- Removed duplicate PV control `id` in `index.html`, consolidated to a single control row, changed the update button to use a class `.update-pv-btn`, and wired event listeners with `document.querySelectorAll('.update-pv-btn')` in `app.js` to stabilize recalculation triggers. 
- Fixed `getBuild()` to read `pointValue` from the actual form field `pointValueCalculated` so exported JSON contains the correct PV. 
- Relaxed `safeCalculatePointValue` fallback from `29` to `1` by updating `app.js` so the demo ship no longer anchors fallback behavior. 
- Added embedded-asset helpers (`splitDataUrl`, `buildDataUrlFromEmbedded`, `withEmbeddedShipArt`, `resolveImportedShipArt`) and integrated them into `render()`, `exportCurrent()`, and import flow so ship art is preserved on export/import and long base64 strings are elided in `getJsonPreview()`. 
- Added an `Import JSON` button and file-picker import handler that merges imported art via `resolveImportedShipArt`. 
- Reworked PV scoring in `pv-calculator.js` with many new/adjusted components: weapon normalization, `mountFacingWeight`, `rangeProfileScore`, `weaponCostScore`, `offenseScore`, `weaponPowerDemandScore`, `availableCombatPowerScore`, `powerConstraintMultiplier`, plus refactored `durability`, `mobility`, `systems`, and `power/functions` scoring pieces, and applied a `powerLimitedOffense` multiplier when computing final PV. 
- Improved `getJsonPreview()` to omit or shorten inline image data for readability and safety. 

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` which completed successfully. 
- Ran `node --check starforce-commander-ship-designer/pv-calculator.js` which completed successfully. 
- Performed browser automation against a local test server (`python3 -m http.server 4173`) using Playwright to change weapon inputs, trigger `.update-pv-btn`, assert `#pvPointValue` and `input[name="pointValueCalculated"]` update to numeric values, and assert the JSON preview no longer contains `"pointValue": 0`; the script passed and produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1ce333d48332b02c5dc317c5bb1e)