### PR TITLE
Harden PV cost calculation pipeline

### DIFF
--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -278,12 +278,22 @@ function powerAndFunctionsScore(build) {
 }
 
 export function calculatePointValue(build) {
-  const offense = offenseScore(build);
-  const powerLimitedOffense = offense * powerConstraintMultiplier(build);
-  const durability = durabilityScore(build);
-  const mobility = mobilityScore(build);
-  const systems = systemsAndCrewScore(build);
-  const power = powerAndFunctionsScore(build);
+  const scorePart = (scorer, fallback = 0) => {
+    try {
+      const value = scorer();
+      return Number.isFinite(value) ? value : fallback;
+    } catch {
+      return fallback;
+    }
+  };
+
+  const offense = scorePart(() => offenseScore(build));
+  const powerLimitedOffense = scorePart(() => offense * powerConstraintMultiplier(build));
+  const durability = scorePart(() => durabilityScore(build));
+  const mobility = scorePart(() => mobilityScore(build));
+  const systems = scorePart(() => systemsAndCrewScore(build));
+  const power = scorePart(() => powerAndFunctionsScore(build));
+  const survivabilityFloor = scorePart(() => Math.max(1, Math.round((durability * 0.65) + 1)), 1);
 
   // Balanced model: every major ship section contributes to cost.
   const total = (powerLimitedOffense * 0.9)


### PR DESCRIPTION
### Motivation
- The point-value (`PV`) calculation pipeline can fail when a single sub-calculation throws or returns non-finite values, causing the UI to lose the displayed cost.
- The code relied on an undefined/brittle survivability floor in some cases, which prevented reliable fallbacks for minimal or malformed builds.

### Description
- Added a `scorePart` wrapper inside `starforce-commander-ship-designer/pv-calculator.js` that runs each sub-scorer (offense, power-limited offense, durability, mobility, systems, power) inside a `try`/`catch` and enforces a numeric fallback so one broken segment cannot break the whole calculation.
- Replaced the previous survivability floor dependency with a guarded computed `survivabilityFloor` derived from `durability` and a safe fallback value to guarantee a finite final result.
- Kept the existing weighting math and final aggregation in `calculatePointValue` so overall behavior is preserved while making intermediate steps resilient to exceptions or invalid inputs.

### Testing
- Ran a Node module check that imports `calculatePointValue` from `starforce-commander-ship-designer/pv-calculator.js` and executed it against `starforce-commander-ship-designer/data.json` for a few builds, which completed without exceptions and produced finite values.
- Executed `calculatePointValue({})` (a minimal/empty build) and confirmed it returns a finite fallback value (`1`) and does not throw an error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a58488f7c8332830ecd362f6e9d11)