### PR TITLE
Rebalance PV weighting to emphasize weapons, defense, power, and maneuvering

### DIFF
--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -52,6 +52,17 @@ const TRAIT_BONUS_BY_PREFIX = [
   { match: 'FTL', bonus: 1.0 }
 ];
 
+const SECTION_MULTIPLIERS = {
+  identity: 0.4,
+  engineering: 1.2,
+  defense: 1.9,
+  maneuvering: 1.4,
+  systemsCrew: 1.0,
+  powerTracks: 1.35,
+  functions: 1.2,
+  weapons: 2.6
+};
+
 function traitBonusScore(traits) {
   if (!Array.isArray(traits) || traits.length === 0) {
     return 0;
@@ -68,229 +79,144 @@ function traitBonusScore(traits) {
   }, 0);
 }
 
-function normalizeArcValues(weapon) {
-  const fromFacings = Array.isArray(weapon.mountFacings)
-    ? weapon.mountFacings.flatMap((mount) => (Array.isArray(mount) ? mount : []))
-    : [];
-
-  const fromArcs = Array.isArray(weapon.mountArcs)
-    ? weapon.mountArcs
-      .flatMap((entry) => String(entry || '').split('|'))
-      .flatMap((group) => group.split(','))
-      .map((value) => Number(value.trim()))
-      .filter((value) => Number.isFinite(value))
-    : [];
-
-  const merged = [...fromFacings, ...fromArcs]
-    .map((value) => Number(value))
-    .filter((value) => Number.isFinite(value) && value >= 1 && value <= 8);
-
-  return merged.length ? merged : [1];
-}
-
-function arcValueWeight(arc) {
-  if (arc === 1) {
-    return 1.35;
+function positivePart(value, fallback = 0) {
+  const parsed = num(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
   }
-  if (arc === 2 || arc === 8) {
-    return 1.15;
+  return Math.max(0, parsed);
+}
+
+function safeRun(scorer, fallback = 0) {
+  try {
+    return positivePart(scorer(), fallback);
+  } catch {
+    return fallback;
   }
-  if (arc === 3 || arc === 7) {
-    return 1.0;
-  }
-  if (arc === 4 || arc === 6) {
-    return 0.86;
-  }
-  return 0.72; // arc 5 (rear)
 }
 
-function mountFacingWeight(weapon) {
-  const arcs = normalizeArcValues(weapon);
-  return sum(arcs.map((arc) => arcValueWeight(arc))) / Math.max(1, arcs.length);
+function scoreIdentity(build) {
+  const identity = build?.identity || {};
+  return [identity.name, identity.classType, identity.faction, identity.era]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean)
+    .length * 0.15;
 }
 
-function rangeProfileScore(ranges = []) {
-  const weighted = ranges.map((range) => {
-    const span = bandSpan(range.band);
-    const maxRange = (() => {
-      const [, end] = String(range.band || '').split('-').map((part) => Number(part.trim()));
-      return Number.isFinite(end) ? end : span;
-    })();
-
-    const dice = Array.isArray(range.dice) ? range.dice.length : 0;
-    const bonus = Math.max(0, num(range.bonus));
-    const baseDamage = (dice + (bonus * 0.35));
-    const colorWeight = rangeTypeWeight(String(range.type || 'black').toLowerCase());
-    const overallRangeWeight = 1 + (Math.max(0, maxRange) * 0.012);
-    const greenRangeBonus = String(range.type || '').toLowerCase() === 'green'
-      ? 1 + (Math.max(0, maxRange) * 0.022)
-      : 1;
-
-    return baseDamage * span * colorWeight * overallRangeWeight * greenRangeBonus;
-  });
-
-  return sum(weighted);
+function scoreEngineering(build) {
+  const engineering = build?.engineering || {};
+  return (positivePart(engineering.move) * 1.4)
+    + (positivePart(engineering.vector) * 1.5)
+    + (positivePart(engineering.turn) * 1.2)
+    + (positivePart(engineering.special) * 1.1);
 }
 
-function weaponCostScore(weapon) {
-  const ranges = Array.isArray(weapon.ranges) ? weapon.ranges : [];
-  const mountCount = Math.max(1, weapon.mountArcs?.length || weapon.mountFacings?.length || 1);
-  const structure = Math.max(1, num(weapon.structure));
-  const facingWeight = mountFacingWeight(weapon);
+function scoreDefense(build) {
+  const shields = build?.shields || {};
+  const armor = build?.armor || {};
+  const structure = build?.structure || {};
 
-  const damageCoverage = rangeProfileScore(ranges);
-  const mountAndStructure = mountCount * (1 + (structure * 0.55));
-  const powerDraw = num(weapon.powerCircles) * 0.45;
-  const powerStops = (Array.isArray(weapon.powerStops) ? weapon.powerStops.length : 0) * 0.18;
-  const traitBonus = traitBonusScore(weapon.traits);
-  const specialBonus = String(weapon.special || '').trim() ? 0.5 : 0;
+  const shieldScore = sum([shields.forward, shields.aft, shields.port, shields.starboard]) * 0.58;
+  const armorScore = sum([armor.forward, armor.aft, armor.port, armor.starboard]) * 0.82;
+  const structureScore = (positivePart(structure.repairable) * 1.8) + (positivePart(structure.permanent) * 1.55);
+  const generatorScore = positivePart(build?.shieldGen) * 1.3;
 
-  return (damageCoverage * mountAndStructure * facingWeight * 0.17)
-    + powerDraw
-    + powerStops
-    + traitBonus
-    + specialBonus;
+  return shieldScore + armorScore + structureScore + generatorScore;
 }
 
-function offenseScore(build) {
-  const weapons = normalizeWeapons(build.weapons);
-  const totalWeaponCost = sum(weapons.map((weapon) => weaponCostScore(weapon)));
-
-  // Battery coordination has value, but individual weapon quality drives most offense cost.
-  const coordinatedBatteryBonus = Math.max(0, weapons.length - 1) * 1.5;
-  return totalWeaponCost + coordinatedBatteryBonus;
+function scoreManeuvering(build) {
+  const sublight = build?.sublight || {};
+  const turnScore = sum(Array.isArray(sublight.turns) ? sublight.turns : []) * 0.03;
+  const spdScore = sum(Array.isArray(sublight.spd) ? sublight.spd : []) * 0.09;
+  const dmgStopScore = sum((Array.isArray(sublight.dmgStops) ? sublight.dmgStops : []).map((stop) => (stop ? 1 : 0))) * 0.5;
+  return (positivePart(sublight.maxAccPhs) * 1.15)
+    + (positivePart(sublight.greenCircles) * 0.62)
+    + (positivePart(sublight.redCircles) * 0.58)
+    + turnScore
+    + spdScore
+    + dmgStopScore;
 }
 
+function scoreSystemsAndCrew(build) {
+  const systems = Array.isArray(build?.systems) ? build.systems : [];
+  const crew = build?.crew || {};
 
-function weaponPowerDemandScore(build) {
-  const weapons = normalizeWeapons(build.weapons);
-  return weapons.reduce((total, weapon) => {
-    const mountCount = Math.max(1, weapon.mountArcs?.length || weapon.mountFacings?.length || 1);
-    const circleDemand = num(weapon.powerCircles) * mountCount;
-    const stopDemand = (Array.isArray(weapon.powerStops) ? weapon.powerStops.length : 0) * 0.5;
-    return total + circleDemand + stopDemand;
-  }, 0);
+  const systemsValue = systems.reduce((total, entry) => total + positivePart(entry?.value), 0);
+  const systemsBreadth = systems.length * 0.45;
+  const crewScore = (positivePart(crew.shuttleCraft) * 0.42) + (positivePart(crew.marinesStationed) * 0.22);
+
+  return systemsValue + systemsBreadth + crewScore;
 }
 
-function availableCombatPowerScore(build) {
-  const tracks = Array.isArray(build.powerSystem?.tracks) ? build.powerSystem.tracks : [];
+function scorePowerTracks(build) {
+  const tracks = Array.isArray(build?.powerSystem?.tracks) ? build.powerSystem.tracks : [];
   return tracks.reduce((total, track) => {
-    const key = String(track?.key || '').toLowerCase();
-    const points = num(track?.points);
-
-    if (key === 'ftldrive' || key === 'ftl') {
-      return total;
-    }
-    if (key === 'battery') {
-      return total + (points * 0.5);
-    }
-
-    return total + points;
+    const points = positivePart(track?.points);
+    const boxesPerPoint = Math.max(1, positivePart(track?.boxesPerPoint, 1));
+    const patternBonus = (Array.isArray(track?.boxPattern) ? track.boxPattern : []).length * 0.1;
+    const dotBonus = track?.hasDot === false ? 0 : 0.12;
+    return total + (points * (0.95 + (boxesPerPoint * 0.18))) + patternBonus + dotBonus;
   }, 0);
 }
 
-function powerConstraintMultiplier(build) {
-  const demand = weaponPowerDemandScore(build);
-  if (demand <= 0) {
-    return 1;
-  }
-
-  const available = availableCombatPowerScore(build);
-  const coverage = available / demand;
-
-  if (coverage >= 1) {
-    const utilization = demand / Math.max(1, available);
-    // Even when fully powered, weapon energy tax reduces effective offensive value somewhat.
-    return Math.max(0.82, 1 - (utilization * 0.18));
-  }
-
-  // Underpowered ships cannot realize full weapon card value in battle.
-  return Math.max(0.45, 0.58 + (coverage * 0.3));
-}
-
-function durabilityScore(build) {
-  const structure = build.structure || {};
-  const shields = build.shields || {};
-  const armor = build.armor || {};
-
-  const structureTotal = num(structure.repairable) + num(structure.permanent);
-  const shieldTotal = sum([shields.forward, shields.aft, shields.port, shields.starboard]);
-  const armorTotal = sum([armor.forward, armor.aft, armor.port, armor.starboard]);
-
-  return (structureTotal * 1.1) + (shieldTotal * 0.22) + (armorTotal * 0.3) + (num(build.shieldGen) * 0.9);
-}
-
-function mobilityScore(build) {
-  const engineering = build.engineering || {};
-  const sublight = build.sublight || {};
-
-  const baseMobility = (num(engineering.move) * 1.1)
-    + (num(engineering.vector) * 1.3)
-    + (num(engineering.turn) * 0.8)
-    + (num(engineering.special) * 0.75);
-
-  const maxAcc = num(sublight.maxAccPhs) * 0.9;
-  const circles = (num(sublight.greenCircles) * 0.4) + (num(sublight.redCircles) * 0.35);
-  const turnFlexibility = sum(Array.isArray(sublight.turns) ? sublight.turns : []) * 0.02;
-  const dmgStopControl = sum((Array.isArray(sublight.dmgStops) ? sublight.dmgStops : []).map((stop) => (stop ? 1 : 0))) * 0.35;
-
-  return baseMobility + maxAcc + circles + turnFlexibility + dmgStopControl;
-}
-
-function systemsAndCrewScore(build) {
-  const systems = Array.isArray(build.systems) ? build.systems : [];
-  const crew = build.crew || {};
-
-  const systemsValue = systems.reduce((total, entry) => total + num(entry?.value), 0);
-  const systemsBreadth = systems.length * 0.5;
-  const crewSupport = (num(crew.shuttleCraft) * 0.25) + (num(crew.marinesStationed) * 0.12);
-
-  return systemsValue + systemsBreadth + crewSupport;
-}
-
-function powerAndFunctionsScore(build) {
-  const tracks = Array.isArray(build.powerSystem?.tracks) ? build.powerSystem.tracks : [];
-  const trackPower = tracks.reduce((total, track) => {
-    const points = num(track?.points);
-    const boxesPerPoint = Math.max(1, num(track?.boxesPerPoint));
-    const patternBonus = (Array.isArray(track?.boxPattern) ? track.boxPattern : []).length * 0.08;
-    const dotBonus = track?.hasDot === false ? 0 : 0.1;
-    return total + (points * (0.7 + (boxesPerPoint * 0.12))) + patternBonus + dotBonus;
-  }, 0);
-
-  const cfg = build.functionsConfig || {};
+function scoreFunctions(build) {
+  const cfg = build?.functionsConfig || {};
   const rows = [cfg.accDec, cfg.sifIdf, cfg.batRech, cfg.sensor, cfg.genSys, ...(Array.isArray(cfg.weapons) ? cfg.weapons : [])];
 
-  const functionsValue = rows.reduce((total, row) => {
+  const rowScore = rows.reduce((total, row) => {
     if (!row || row.enabled === false) {
       return total;
     }
-    const valueCount = Array.isArray(row.values) ? row.values.length : 0;
-    const free = num(row.free);
-    const emergency = row.emer ? 0.35 : 0;
-    return total + (valueCount * 0.55) + (free * 0.4) + emergency;
-  }, 0)
-    + (num(cfg.ftl?.empty) * 0.2)
-    + (num(cfg.cloak?.empty) * 0.2)
-    + (cfg.cloak?.enabled ? 1.2 : 0);
 
-  return trackPower + functionsValue;
+    const valueCount = Array.isArray(row.values) ? row.values.length : 0;
+    const free = positivePart(row.free);
+    const emergency = row.emer ? 0.45 : 0;
+    return total + (valueCount * 0.75) + (free * 0.55) + emergency;
+  }, 0);
+
+  return rowScore
+    + (positivePart(cfg?.ftl?.empty) * 0.35)
+    + (positivePart(cfg?.cloak?.empty) * 0.35)
+    + (cfg?.cloak?.enabled ? 1.5 : 0);
+}
+
+function scoreWeapons(build) {
+  const weapons = normalizeWeapons(build?.weapons);
+  return weapons.reduce((total, weapon) => {
+    const ranges = Array.isArray(weapon?.ranges) ? weapon.ranges : [];
+
+    const rangeScore = ranges.reduce((rangeTotal, range) => {
+      const span = bandSpan(range?.band);
+      const dice = Array.isArray(range?.dice) ? range.dice.length : 0;
+      const bonus = positivePart(range?.bonus) * 0.45;
+      const color = rangeTypeWeight(String(range?.type || 'black').toLowerCase());
+      return rangeTotal + ((dice + bonus) * span * color * 0.6);
+    }, 0);
+
+    const mountCount = Math.max(1, weapon?.mountArcs?.length || weapon?.mountFacings?.length || 1);
+    const powerScore = positivePart(weapon?.powerCircles) * 0.85;
+    const stopScore = (Array.isArray(weapon?.powerStops) ? weapon.powerStops.length : 0) * 0.45;
+    const structureScore = positivePart(weapon?.structure) * 0.95;
+    const traitScore = traitBonusScore(weapon?.traits) * 1.0;
+    const specialScore = String(weapon?.special || '').trim() ? 1.3 : 0;
+
+    return total + rangeScore + (mountCount * 1.35) + powerScore + stopScore + structureScore + traitScore + specialScore;
+  }, 0);
 }
 
 export function calculatePointValue(build) {
-  const offense = offenseScore(build);
-  const powerLimitedOffense = offense * powerConstraintMultiplier(build);
-  const durability = durabilityScore(build);
-  const mobility = mobilityScore(build);
-  const systems = systemsAndCrewScore(build);
-  const power = powerAndFunctionsScore(build);
+  const contributions = {
+    identity: safeRun(() => scoreIdentity(build)) * SECTION_MULTIPLIERS.identity,
+    engineering: safeRun(() => scoreEngineering(build)) * SECTION_MULTIPLIERS.engineering,
+    defense: safeRun(() => scoreDefense(build)) * SECTION_MULTIPLIERS.defense,
+    maneuvering: safeRun(() => scoreManeuvering(build)) * SECTION_MULTIPLIERS.maneuvering,
+    systemsCrew: safeRun(() => scoreSystemsAndCrew(build)) * SECTION_MULTIPLIERS.systemsCrew,
+    powerTracks: safeRun(() => scorePowerTracks(build)) * SECTION_MULTIPLIERS.powerTracks,
+    functions: safeRun(() => scoreFunctions(build)) * SECTION_MULTIPLIERS.functions,
+    weapons: safeRun(() => scoreWeapons(build)) * SECTION_MULTIPLIERS.weapons
+  };
 
-  // Balanced model: every major ship section contributes to cost.
-  const total = (powerLimitedOffense * 0.9)
-    + (durability * 0.95)
-    + (mobility * 0.85)
-    + (systems * 0.75)
-    + (power * 0.8);
-
-  return Math.max(1, Math.round(Math.max(total, survivabilityFloor)));
+  const total = sum(Object.values(contributions));
+  const normalizedTotal = total * 0.1;
+  return Math.max(1, Math.round(normalizedTotal));
 }


### PR DESCRIPTION
### Motivation
- The PV funnel undervalued major combat and ship-function inputs relative to minor metadata, so the scoring should make weapons, defense, power, and mobility move the final PV more noticeably.
- The goal is to keep the robust per-section, fail-soft model while increasing the practical influence of core design decisions on final cost.

### Description
- Introduced `SECTION_MULTIPLIERS` and converted the calculator to explicit per-section scorers (`scoreIdentity`, `scoreEngineering`, `scoreDefense`, `scoreManeuvering`, `scoreSystemsAndCrew`, `scorePowerTracks`, `scoreFunctions`, `scoreWeapons`) which are aggregated and normalized to produce PV.
- Increased coefficients inside defense, maneuvering, power tracks, functions, and weapons scorers and amplified weapons-related weights for range output, mounts, power demand, structure, traits, and specials so those fields have greater impact on total PV.
- Removed several legacy weapon/arc/power-constraint helper functions and replaced them with simpler, resilient scoring pieces that keep each input isolated and non-negative via `safeRun` and `positivePart`.
- Preserved safety behavior so malformed or missing sections return zero contribution rather than breaking the calculation.

### Testing
- Ran a representative Node check with a baseline build and three targeted variants using `node --input-type=module` to confirm deltas, and the script completed without exceptions.
- Observed PV outputs from the automated run as `base 30`, `no weapons 23`, `low defense 23`, `low mobility 26`, and `empty 1`, demonstrating stronger movement from major inputs while preserving the safe floor.
- No automated test failures occurred during these runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a58488f7c8332830ecd362f6e9d11)