### PR TITLE
Add PV class curve and refactor point-value scoring into section-based model

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -12,99 +12,68 @@ let shipArtDataUrl = '';
 const STANDARD_DEFAULT_LOADOUT = {
   identity: {
     name: 'SHIP NAME / ID',
-    classType: 'YORKTOWN II - Class Heavy Cruiser',
-    faction: 'COMMON',
-    era: '3655',
-    pointValue: 29
+    classType: 'Class Name - Class ship type',
+    faction: '/',
+    era: '/',
+    pointValue: 2
   },
-  engineering: { move: 5, vector: 2, turn: 4, special: 4 },
-  shields: { forward: 16, aft: 15, port: 15, starboard: 15 },
+  engineering: { move: 0, vector: 0, turn: 0, special: 0 },
+  shields: { forward: 0, aft: 0, port: 0, starboard: 0 },
   armor: { forward: 0, aft: 0, port: 0, starboard: 0 },
-  shieldGen: 3,
+  shieldGen: 0,
   textBlocks: { powerSystem: '' },
   functionsConfig: {
-    accDec: { values: ['1', '2', '3', '4'], free: 1 },
-    sifIdf: { values: ['1', '2', '3'], free: 0, emer: true },
-    batRech: { values: ['1'], free: 0 },
-    ftl: { empty: 3 },
-    cloak: { enabled: false, empty: 3 },
-    sensor: { values: ['2', '4', '6'], free: 1 },
-    genSys: { values: ['NRM', 'MAX'], free: 1 },
+    accDec: { values: [], free: 0 },
+    sifIdf: { values: [], free: 0, emer: false },
+    batRech: { values: [], free: 0 },
+    ftl: { empty: 0 },
+    cloak: { enabled: false, empty: 0 },
+    sensor: { values: [], free: 0 },
+    genSys: { values: [], free: 0 },
     weapons: [
-      { label: 'A/MAT TORP', enabled: true, free: 1, values: ['1', '4'] },
-      { label: 'PHASER', enabled: true, free: 1, values: ['1', '4', '6', '8'] },
+      { label: 'WPN A', enabled: false, free: 0, values: [] },
+      { label: 'WPN B', enabled: false, free: 0, values: [] },
       { label: 'WPN C', enabled: false, free: 0, values: [] },
       { label: 'WPN D', enabled: false, free: 0, values: [] }
     ]
   },
   powerSystem: {
     tracks: [
-      { key: 'lMain', label: 'L MAIN', points: 3, boxesPerPoint: 2, boxPattern: [], hasDot: true },
-      { key: 'rMain', label: 'R MAIN', points: 3, boxesPerPoint: 2, boxPattern: [], hasDot: true },
-      { key: 'cMain', label: 'C MAIN', points: 0, boxesPerPoint: 2, boxPattern: [], hasDot: true },
-      { key: 'slReac', label: 'SL REAC', points: 1, boxesPerPoint: 2, boxPattern: [], hasDot: true },
-      { key: 'auxPwr', label: 'AUX PWR', points: 1, boxesPerPoint: 2, boxPattern: [], hasDot: true },
-      { key: 'battery', label: 'BATTERY', points: 1, boxesPerPoint: 1, boxPattern: [], hasDot: true },
-      { key: 'ftlDrive', label: 'FTL DRIVE', points: 1, boxesPerPoint: 2, boxPattern: [], hasDot: false }
+      { key: 'lMain', label: 'L MAIN', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
+      { key: 'rMain', label: 'R MAIN', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
+      { key: 'cMain', label: 'C MAIN', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
+      { key: 'slReac', label: 'SL REAC', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
+      { key: 'auxPwr', label: 'AUX PWR', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
+      { key: 'battery', label: 'BATTERY', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
+      { key: 'ftlDrive', label: 'FTL DRIVE', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: false }
     ]
   },
   sublight: {
-    maxAccPhs: 2,
-    greenCircles: 2,
-    redCircles: 2,
+    maxAccPhs: 0,
+    greenCircles: 0,
+    redCircles: 0,
     spd: [6, 5, 4, 3, 2, 1, 0],
     turns: [0, 20, 30, 30, 35, 35, 40],
-    dmgStops: [true, true, true, false, true, true, true]
+    dmgStops: [false, false, false, false, false, false, false]
   },
-  structure: { repairable: 3, permanent: 10 },
+  structure: { repairable: 0, permanent: 0 },
   shipArtDataUrl: '',
   weapons: [
-    {
-      name: 'MK-4 A\\MAT TORPEDO',
-      mountArcs: ['1', '2|1', '2|1', '2|1', '2'],
-      mountFacings: [[1, 2], [1, 2], [1, 2], [1, 2]],
-      powerCircles: 2,
-      powerStops: [1],
-      structure: 1,
-      ranges: [
-        { band: '0-4', type: 'green', bonus: 0, dice: ['R'] },
-        { band: '5-10', type: 'black', bonus: 0, dice: ['R'] },
-        { band: '11-14', type: 'red', bonus: 0, dice: ['R'] },
-        { band: '15-20', type: 'red', bonus: 0, dice: ['Y'] }
-      ],
-      traits: ['HVY', 'FTL', 'NoBAT'],
-      special: 'H(4+1), STR 1'
-    },
-    {
-      name: 'LNC-447 PHASER',
-      mountArcs: ['1', '6', '7', '8|8', '1', '2', '3|4', '5', '6', '7|2', '3', '4', '5'],
-      mountFacings: [[1, 6, 7, 8], [8, 1, 2, 3], [4, 5, 6, 7], [2, 3, 4, 5]],
-      powerCircles: 2,
-      powerStops: [],
-      structure: 2,
-      ranges: [
-        { band: '0-2', type: 'green', bonus: 0, dice: ['G', 'G'] },
-        { band: '3-5', type: 'green', bonus: 0, dice: ['G', 'B'] },
-        { band: '6-8', type: 'black', bonus: 0, dice: ['G', 'B'] },
-        { band: '9-10', type: 'black', bonus: 0, dice: ['B', 'B'] },
-        { band: '11-12', type: 'red', bonus: 0, dice: ['B'] }
-      ],
-      traits: ['PREC 1', 'PD MODE'],
-      special: ''
-    },
-    { name: '', mountArcs: [], mountFacings: [], powerCircles: 2, powerStops: [], structure: 2, ranges: [], traits: [], special: '' },
-    { name: '', mountArcs: [], mountFacings: [], powerCircles: 2, powerStops: [], structure: 2, ranges: [], traits: [], special: '' }
+    { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
+    { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
+    { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
+    { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' }
   ],
   systems: [
-    { key: 'SCNC', value: '4' },
-    { key: 'SENS', value: '3' },
-    { key: 'TRAC', value: '2' },
-    { key: 'TRAN', value: '2' },
-    { key: 'SHTL', value: '2' },
-    { key: 'QTRS', value: '4' },
-    { key: 'CRGO', value: '2' }
+    { key: 'SCNC', value: '0' },
+    { key: 'SENS', value: '0' },
+    { key: 'TRAC', value: '0' },
+    { key: 'TRAN', value: '0' },
+    { key: 'SHTL', value: '0' },
+    { key: 'QTRS', value: '0' },
+    { key: 'CRGO', value: '0' }
   ],
-  crew: { shuttleCraft: 4, marinesStationed: 11 }
+  crew: { shuttleCraft: 0, marinesStationed: 0 }
 };
 
 const POWER_TRACK_CONFIG = [
@@ -741,9 +710,9 @@ function circleRun(containerId, count) {
 
 function renderManeuvering(sublight) {
   const data = sublight || {
-    maxAccPhs: 2,
-    greenCircles: 3,
-    redCircles: 3,
+    maxAccPhs: 0,
+    greenCircles: 0,
+    redCircles: 0,
     spd: [6, 5, 4, 3, 2, 1, 0],
     turns: [20, 20, 20, 20, 20, 20, 20],
     dmgStops: [false, false, false, false, false, false, false]
@@ -1134,10 +1103,10 @@ function restoreDraft(draft) {
   setValue('faction', draft.identity?.faction ?? '');
   setValue('era', draft.identity?.era ?? '');
 
-  setValue('move', draft.engineering?.move ?? 3);
-  setValue('vector', draft.engineering?.vector ?? 2);
-  setValue('turn', draft.engineering?.turn ?? 2);
-  setValue('special', draft.engineering?.special ?? 3);
+  setValue('move', draft.engineering?.move ?? 0);
+  setValue('vector', draft.engineering?.vector ?? 0);
+  setValue('turn', draft.engineering?.turn ?? 0);
+  setValue('special', draft.engineering?.special ?? 0);
 
   setValue('shieldFwd', draft.shields?.forward ?? 0);
   setValue('shieldAft', draft.shields?.aft ?? 0);
@@ -1152,31 +1121,31 @@ function restoreDraft(draft) {
   setValue('shieldGen', draft.shieldGen ?? 0);
 
   const fn = draft.functionsConfig || {};
-  setValue('fnAccDecValues', (fn.accDec?.values ?? ['1', '2', '3', '4', '5', '6']).join(','));
-  setChecked('fnAccDecFree', fn.accDec?.free ?? 1);
-  setValue('fnSifIdfValues', (fn.sifIdf?.values ?? ['1', '2', '3']).join(','));
+  setValue('fnAccDecValues', (fn.accDec?.values ?? []).join(','));
+  setChecked('fnAccDecFree', fn.accDec?.free ?? 0);
+  setValue('fnSifIdfValues', (fn.sifIdf?.values ?? []).join(','));
   setChecked('fnSifIdfFree', fn.sifIdf?.free ?? 0);
-  setChecked('fnSifIdfEmer', fn.sifIdf?.emer ?? true);
-  setValue('fnFtlEmpty', fn.ftl?.empty ?? 2);
+  setChecked('fnSifIdfEmer', fn.sifIdf?.emer ?? false);
+  setValue('fnFtlEmpty', fn.ftl?.empty ?? 0);
   setChecked('fnCloakEnabled', fn.cloak?.enabled ?? false);
-  setValue('fnCloakEmpty', fn.cloak?.empty ?? 3);
-  setValue('fnSensorValues', (fn.sensor?.values ?? ['2', '4', '6']).join(','));
-  setChecked('fnSensorFree', fn.sensor?.free ?? 1);
-  setValue('fnGenSysValues', (fn.genSys?.values ?? ['NRM', 'MAX']).join(','));
-  setChecked('fnGenSysFree', fn.genSys?.free ?? 1);
+  setValue('fnCloakEmpty', fn.cloak?.empty ?? 0);
+  setValue('fnSensorValues', (fn.sensor?.values ?? []).join(','));
+  setChecked('fnSensorFree', fn.sensor?.free ?? 0);
+  setValue('fnGenSysValues', (fn.genSys?.values ?? []).join(','));
+  setChecked('fnGenSysFree', fn.genSys?.free ?? 0);
 
   const fnWpn = fn.weapons ?? [];
-  setValue('fnWpnALabel', fnWpn[0]?.label ?? 'A/MAT TRP');
-  setChecked('fnWpnAFree', fnWpn[0]?.free ?? 1);
-  setChecked('fnWpnAEnabled', fnWpn[0]?.enabled ?? true);
-  setValue('fnWpnAValues', (fnWpn[0]?.values ?? ['2']).join(','));
-  setValue('fnWpnBLabel', fnWpn[1]?.label ?? 'PHASER');
-  setChecked('fnWpnBFree', fnWpn[1]?.free ?? 1);
-  setChecked('fnWpnBEnabled', fnWpn[1]?.enabled ?? true);
-  setValue('fnWpnBValues', (fnWpn[1]?.values ?? ['4']).join(','));
+  setValue('fnWpnALabel', fnWpn[0]?.label ?? 'WPN A');
+  setChecked('fnWpnAFree', fnWpn[0]?.free ?? 0);
+  setChecked('fnWpnAEnabled', fnWpn[0]?.enabled ?? false);
+  setValue('fnWpnAValues', (fnWpn[0]?.values ?? []).join(','));
+  setValue('fnWpnBLabel', fnWpn[1]?.label ?? 'WPN B');
+  setChecked('fnWpnBFree', fnWpn[1]?.free ?? 0);
+  setChecked('fnWpnBEnabled', fnWpn[1]?.enabled ?? false);
+  setValue('fnWpnBValues', (fnWpn[1]?.values ?? []).join(','));
   setValue('fnWpnCLabel', fnWpn[2]?.label ?? 'WPN C');
-  setChecked('fnWpnCFree', fnWpn[2]?.free ?? 1);
-  setChecked('fnWpnCEnabled', fnWpn[2]?.enabled ?? true);
+  setChecked('fnWpnCFree', fnWpn[2]?.free ?? 0);
+  setChecked('fnWpnCEnabled', fnWpn[2]?.enabled ?? false);
   setValue('fnWpnCValues', (fnWpn[2]?.values ?? []).join(','));
   setValue('fnWpnDLabel', fnWpn[3]?.label ?? 'WPN D');
   setChecked('fnWpnDFree', fnWpn[3]?.free ?? 0);
@@ -1196,32 +1165,32 @@ function restoreDraft(draft) {
     const hasDotField = getField(track.hasDotField);
 
     if (pointsField) {
-      pointsField.value = Math.max(0, Number(trackData?.points ?? pointsField.value ?? 0));
+      pointsField.value = Math.max(0, Number(trackData?.points ?? 0));
     }
     if (boxesField) {
-      boxesField.value = clamp(Number(trackData?.boxesPerPoint ?? boxesField.value ?? 2), 1, 3);
+      boxesField.value = clamp(Number(trackData?.boxesPerPoint ?? 1), 1, 3);
     }
     if (patternField) {
       patternField.value = (trackData?.boxPattern ?? []).join(',');
     }
     if (hasDotField) {
-      hasDotField.checked = Boolean(trackData?.hasDot ?? hasDotField.checked);
+      hasDotField.checked = Boolean(trackData?.hasDot ?? (track.key !== 'ftlDrive'));
     }
   });
 
   const sublight = draft.sublight ?? {
-    maxAccPhs: 2,
-    greenCircles: 3,
-    redCircles: 3,
+    maxAccPhs: 0,
+    greenCircles: 0,
+    redCircles: 0,
     spd: [6, 5, 4, 3, 2, 1, 0],
     turns: [20, 20, 20, 20, 20, 20, 20],
     dmgStops: [false, false, false, false, false, false, false]
   };
-  setValue('sublightMaxAcc', sublight.maxAccPhs ?? 2);
-  setValue('sublightGreen', sublight.greenCircles ?? 3);
-  setValue('sublightRed', sublight.redCircles ?? 3);
+  setValue('sublightMaxAcc', sublight.maxAccPhs ?? 0);
+  setValue('sublightGreen', sublight.greenCircles ?? 0);
+  setValue('sublightRed', sublight.redCircles ?? 0);
   [6, 5, 4, 3, 2, 1, 0].forEach((speed, index) => {
-    setValue(`sublightTurn${speed}`, normalizeTurnOption(sublight.turns?.[index] ?? 20));
+    setValue(`sublightTurn${speed}`, normalizeTurnOption(sublight.turns?.[index] ?? TURN_OPTIONS[index] ?? 0));
     setChecked(`sublightDmg${speed}`, sublight.dmgStops?.[index]);
   });
 
@@ -1235,9 +1204,9 @@ function restoreDraft(draft) {
     setValue(`wpn${index}Name`, weapon.name || '');
     setValue(`wpn${index}Traits`, (weapon.traits || []).join(', '));
     setValue(`wpn${index}MountArcs`, (weapon.mountFacings || []).map((mount) => mount.join(',')).join('|'));
-    setValue(`wpn${index}PowerCircles`, weapon.powerCircles || 1);
+    setValue(`wpn${index}PowerCircles`, weapon.powerCircles ?? 1);
     setValue(`wpn${index}PowerStops`, (weapon.powerStops || []).join(', '));
-    setValue(`wpn${index}Structure`, weapon.structure || 1);
+    setValue(`wpn${index}Structure`, weapon.structure ?? 1);
     setValue(`wpn${index}Ranges`, (weapon.ranges || []).map((range) => `${range.band}:${range.type}`).join(','));
     setValue(`wpn${index}Dice`, (weapon.ranges || []).map((range) => {
       const dice = (range.dice || []).join(',');
@@ -1247,8 +1216,8 @@ function restoreDraft(draft) {
   });
 
   setValue('systems', (draft.systems ?? []).map((item) => `${item.key}:${item.value ?? ''}`).join('\n'));
-  setValue('shuttleCraft', draft.crew?.shuttleCraft ?? 4);
-  setValue('marinesStationed', draft.crew?.marinesStationed ?? 10);
+  setValue('shuttleCraft', draft.crew?.shuttleCraft ?? 0);
+  setValue('marinesStationed', draft.crew?.marinesStationed ?? 0);
 
   render();
 }

--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -33,6 +33,50 @@ function normalizeWeapons(weapons) {
   return Array.isArray(weapons) ? weapons.filter((weapon) => weapon && weapon.name) : [];
 }
 
+function normalizeArcValues(weapon) {
+  const fromFacings = Array.isArray(weapon?.mountFacings)
+    ? weapon.mountFacings.flatMap((mount) => (Array.isArray(mount) ? mount : []))
+    : [];
+
+  const fromArcs = Array.isArray(weapon?.mountArcs)
+    ? weapon.mountArcs
+      .flatMap((entry) => String(entry || '').split('|'))
+      .flatMap((group) => group.split(','))
+      .map((value) => Number(value.trim()))
+      .filter((value) => Number.isFinite(value))
+    : [];
+
+  const merged = [...fromFacings, ...fromArcs]
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value) && value >= 1 && value <= 8);
+
+  return merged.length > 0 ? merged : [1];
+}
+
+function arcFacingWeight(arc) {
+  if (arc === 1) {
+    return 1.6; // forward
+  }
+  if (arc === 2 || arc === 8) {
+    return 1.35; // forward flanks
+  }
+  if (arc === 3 || arc === 7) {
+    return 1.05; // side-forward quarters
+  }
+  if (arc === 4 || arc === 6) {
+    return 0.82; // side-rear quarters
+  }
+  return 0.6; // arc 5 rear
+}
+
+function mountFacingScore(weapon) {
+  const arcs = normalizeArcValues(weapon);
+  const summedFacing = sum(arcs.map((arc) => arcFacingWeight(arc)));
+  const averagedFacing = summedFacing / Math.max(1, arcs.length);
+  const arcCoverageBonus = Math.sqrt(Math.max(1, arcs.length));
+  return averagedFacing * arcCoverageBonus;
+}
+
 function normalizeTrait(trait) {
   return String(trait || '').trim().toUpperCase();
 }
@@ -52,6 +96,17 @@ const TRAIT_BONUS_BY_PREFIX = [
   { match: 'FTL', bonus: 1.0 }
 ];
 
+const SECTION_MULTIPLIERS = {
+  identity: 0.4,
+  engineering: 1.2,
+  defense: 1.9,
+  maneuvering: 1.4,
+  systemsCrew: 1.0,
+  powerTracks: 1.9,
+  functions: 1.7,
+  weapons: 2.6
+};
+
 function traitBonusScore(traits) {
   if (!Array.isArray(traits) || traits.length === 0) {
     return 0;
@@ -68,229 +123,250 @@ function traitBonusScore(traits) {
   }, 0);
 }
 
-function normalizeArcValues(weapon) {
-  const fromFacings = Array.isArray(weapon.mountFacings)
-    ? weapon.mountFacings.flatMap((mount) => (Array.isArray(mount) ? mount : []))
-    : [];
-
-  const fromArcs = Array.isArray(weapon.mountArcs)
-    ? weapon.mountArcs
-      .flatMap((entry) => String(entry || '').split('|'))
-      .flatMap((group) => group.split(','))
-      .map((value) => Number(value.trim()))
-      .filter((value) => Number.isFinite(value))
-    : [];
-
-  const merged = [...fromFacings, ...fromArcs]
-    .map((value) => Number(value))
-    .filter((value) => Number.isFinite(value) && value >= 1 && value <= 8);
-
-  return merged.length ? merged : [1];
-}
-
-function arcValueWeight(arc) {
-  if (arc === 1) {
-    return 1.35;
+function positivePart(value, fallback = 0) {
+  const parsed = num(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
   }
-  if (arc === 2 || arc === 8) {
-    return 1.15;
+  return Math.max(0, parsed);
+}
+
+function safeRun(scorer, fallback = 0) {
+  try {
+    return positivePart(scorer(), fallback);
+  } catch {
+    return fallback;
   }
-  if (arc === 3 || arc === 7) {
-    return 1.0;
-  }
-  if (arc === 4 || arc === 6) {
-    return 0.86;
-  }
-  return 0.72; // arc 5 (rear)
 }
 
-function mountFacingWeight(weapon) {
-  const arcs = normalizeArcValues(weapon);
-  return sum(arcs.map((arc) => arcValueWeight(arc))) / Math.max(1, arcs.length);
+function scoreIdentity(build) {
+  const identity = build?.identity || {};
+  return [identity.name, identity.classType, identity.faction, identity.era]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean)
+    .length * 0.15;
 }
 
-function rangeProfileScore(ranges = []) {
-  const weighted = ranges.map((range) => {
-    const span = bandSpan(range.band);
-    const maxRange = (() => {
-      const [, end] = String(range.band || '').split('-').map((part) => Number(part.trim()));
-      return Number.isFinite(end) ? end : span;
-    })();
-
-    const dice = Array.isArray(range.dice) ? range.dice.length : 0;
-    const bonus = Math.max(0, num(range.bonus));
-    const baseDamage = (dice + (bonus * 0.35));
-    const colorWeight = rangeTypeWeight(String(range.type || 'black').toLowerCase());
-    const overallRangeWeight = 1 + (Math.max(0, maxRange) * 0.012);
-    const greenRangeBonus = String(range.type || '').toLowerCase() === 'green'
-      ? 1 + (Math.max(0, maxRange) * 0.022)
-      : 1;
-
-    return baseDamage * span * colorWeight * overallRangeWeight * greenRangeBonus;
-  });
-
-  return sum(weighted);
+function scoreEngineering(build) {
+  const engineering = build?.engineering || {};
+  return (positivePart(engineering.move) * 1.4)
+    + (positivePart(engineering.vector) * 1.5)
+    + (positivePart(engineering.turn) * 1.2)
+    + (positivePart(engineering.special) * 1.1);
 }
 
-function weaponCostScore(weapon) {
-  const ranges = Array.isArray(weapon.ranges) ? weapon.ranges : [];
-  const mountCount = Math.max(1, weapon.mountArcs?.length || weapon.mountFacings?.length || 1);
-  const structure = Math.max(1, num(weapon.structure));
-  const facingWeight = mountFacingWeight(weapon);
+function scoreDefense(build) {
+  const shields = build?.shields || {};
+  const armor = build?.armor || {};
+  const structure = build?.structure || {};
 
-  const damageCoverage = rangeProfileScore(ranges);
-  const mountAndStructure = mountCount * (1 + (structure * 0.55));
-  const powerDraw = num(weapon.powerCircles) * 0.45;
-  const powerStops = (Array.isArray(weapon.powerStops) ? weapon.powerStops.length : 0) * 0.18;
-  const traitBonus = traitBonusScore(weapon.traits);
-  const specialBonus = String(weapon.special || '').trim() ? 0.5 : 0;
+  const repairable = positivePart(structure.repairable);
+  const permanent = positivePart(structure.permanent);
+  const totalStructure = repairable + permanent;
 
-  return (damageCoverage * mountAndStructure * facingWeight * 0.17)
-    + powerDraw
-    + powerStops
-    + traitBonus
-    + specialBonus;
+  // Survival is non-linear: each extra hull box is worth more in staying power.
+  // This especially rewards high-total ships versus low-total ships.
+  const structureBase = totalStructure * 1.4;
+  const structureScaling = Math.pow(totalStructure, 1.45) * 0.62;
+
+  // Damage control has outsized value because it extends effective lifespan in combat.
+  const damageControlScore = Math.pow(repairable, 1.55) * 1.9;
+
+  // Permanent structure converts directly to scenario/VP durability and kill threshold.
+  const permanentHullScore = Math.pow(permanent, 1.35) * 1.2;
+
+  // Larger structure pools amplify value from shields/armor and vice versa.
+  const durabilitySynergy = (Math.sqrt(totalStructure) * 0.35)
+    * (sum([shields.forward, shields.aft, shields.port, shields.starboard]) * 0.05);
+
+  const shieldScore = sum([shields.forward, shields.aft, shields.port, shields.starboard]) * 0.58;
+  const armorScore = sum([armor.forward, armor.aft, armor.port, armor.starboard]) * 0.82;
+  const structureScore = structureBase
+    + structureScaling
+    + damageControlScore
+    + permanentHullScore
+    + durabilitySynergy;
+  const generatorScore = positivePart(build?.shieldGen) * 1.3;
+
+  return shieldScore + armorScore + structureScore + generatorScore;
 }
 
-function offenseScore(build) {
-  const weapons = normalizeWeapons(build.weapons);
-  const totalWeaponCost = sum(weapons.map((weapon) => weaponCostScore(weapon)));
-
-  // Battery coordination has value, but individual weapon quality drives most offense cost.
-  const coordinatedBatteryBonus = Math.max(0, weapons.length - 1) * 1.5;
-  return totalWeaponCost + coordinatedBatteryBonus;
+function scoreManeuvering(build) {
+  const sublight = build?.sublight || {};
+  const turnScore = sum(Array.isArray(sublight.turns) ? sublight.turns : []) * 0.03;
+  const spdScore = sum(Array.isArray(sublight.spd) ? sublight.spd : []) * 0.09;
+  const dmgStopScore = sum((Array.isArray(sublight.dmgStops) ? sublight.dmgStops : []).map((stop) => (stop ? 1 : 0))) * 0.5;
+  return (positivePart(sublight.maxAccPhs) * 1.15)
+    + (positivePart(sublight.greenCircles) * 0.62)
+    + (positivePart(sublight.redCircles) * 0.58)
+    + turnScore
+    + spdScore
+    + dmgStopScore;
 }
 
+function scoreSystemsAndCrew(build) {
+  const systems = Array.isArray(build?.systems) ? build.systems : [];
+  const crew = build?.crew || {};
 
-function weaponPowerDemandScore(build) {
-  const weapons = normalizeWeapons(build.weapons);
-  return weapons.reduce((total, weapon) => {
-    const mountCount = Math.max(1, weapon.mountArcs?.length || weapon.mountFacings?.length || 1);
-    const circleDemand = num(weapon.powerCircles) * mountCount;
-    const stopDemand = (Array.isArray(weapon.powerStops) ? weapon.powerStops.length : 0) * 0.5;
-    return total + circleDemand + stopDemand;
-  }, 0);
+  const systemsValue = systems.reduce((total, entry) => total + positivePart(entry?.value), 0);
+  const systemsBreadth = systems.length * 0.45;
+  const crewScore = (positivePart(crew.shuttleCraft) * 0.42) + (positivePart(crew.marinesStationed) * 0.22);
+
+  return systemsValue + systemsBreadth + crewScore;
 }
 
-function availableCombatPowerScore(build) {
-  const tracks = Array.isArray(build.powerSystem?.tracks) ? build.powerSystem.tracks : [];
+function scorePowerTracks(build) {
+  const tracks = Array.isArray(build?.powerSystem?.tracks) ? build.powerSystem.tracks : [];
   return tracks.reduce((total, track) => {
     const key = String(track?.key || '').toLowerCase();
-    const points = num(track?.points);
+    const points = positivePart(track?.points);
+    const boxesPerPoint = Math.max(1, positivePart(track?.boxesPerPoint, 1));
+    const patternCount = (Array.isArray(track?.boxPattern) ? track.boxPattern : []).length;
 
-    if (key === 'ftldrive' || key === 'ftl') {
+    const isBattery = key === 'battery';
+    const isFtl = key === 'ftldrive' || key === 'ftl';
+    const isMainOrReactor = key.includes('main') || key.includes('reac');
+    const isAux = key.includes('aux');
+
+    // More usable/free energy means more combat capability.
+    const basePointValue = isBattery
+      ? 2.5
+      : isMainOrReactor
+        ? 1.55
+        : isAux
+          ? 1.35
+          : isFtl
+            ? 0.65
+            : 1.1;
+
+    const freePowerFromBoxes = (boxesPerPoint - 1) * (isBattery ? 1.05 : 0.55);
+    const reserveFlexibility = isBattery ? (1.0 + (points * 0.35)) : 0;
+    const patternBonus = patternCount * (isBattery ? 0.2 : 0.12);
+    const freeDotBonus = track?.hasDot === false ? 0 : (isBattery ? 0.35 : 0.18);
+
+    return total
+      + (points * (basePointValue + freePowerFromBoxes))
+      + reserveFlexibility
+      + patternBonus
+      + freeDotBonus;
+  }, 0);
+}
+
+
+function parseFunctionMagnitude(values = []) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return 0;
+  }
+
+  return values.reduce((total, value) => {
+    const raw = String(value || '').trim();
+    if (!raw) {
       return total;
     }
-    if (key === 'battery') {
-      return total + (points * 0.5);
+
+    const numeric = Number(raw);
+    if (Number.isFinite(numeric)) {
+      return total + Math.max(0, numeric);
     }
 
-    return total + points;
+    // Named function steps still have non-zero tactical value.
+    return total + 0.75;
   }, 0);
 }
 
-function powerConstraintMultiplier(build) {
-  const demand = weaponPowerDemandScore(build);
-  if (demand <= 0) {
-    return 1;
-  }
-
-  const available = availableCombatPowerScore(build);
-  const coverage = available / demand;
-
-  if (coverage >= 1) {
-    const utilization = demand / Math.max(1, available);
-    // Even when fully powered, weapon energy tax reduces effective offensive value somewhat.
-    return Math.max(0.82, 1 - (utilization * 0.18));
-  }
-
-  // Underpowered ships cannot realize full weapon card value in battle.
-  return Math.max(0.45, 0.58 + (coverage * 0.3));
-}
-
-function durabilityScore(build) {
-  const structure = build.structure || {};
-  const shields = build.shields || {};
-  const armor = build.armor || {};
-
-  const structureTotal = num(structure.repairable) + num(structure.permanent);
-  const shieldTotal = sum([shields.forward, shields.aft, shields.port, shields.starboard]);
-  const armorTotal = sum([armor.forward, armor.aft, armor.port, armor.starboard]);
-
-  return (structureTotal * 1.1) + (shieldTotal * 0.22) + (armorTotal * 0.3) + (num(build.shieldGen) * 0.9);
-}
-
-function mobilityScore(build) {
-  const engineering = build.engineering || {};
-  const sublight = build.sublight || {};
-
-  const baseMobility = (num(engineering.move) * 1.1)
-    + (num(engineering.vector) * 1.3)
-    + (num(engineering.turn) * 0.8)
-    + (num(engineering.special) * 0.75);
-
-  const maxAcc = num(sublight.maxAccPhs) * 0.9;
-  const circles = (num(sublight.greenCircles) * 0.4) + (num(sublight.redCircles) * 0.35);
-  const turnFlexibility = sum(Array.isArray(sublight.turns) ? sublight.turns : []) * 0.02;
-  const dmgStopControl = sum((Array.isArray(sublight.dmgStops) ? sublight.dmgStops : []).map((stop) => (stop ? 1 : 0))) * 0.35;
-
-  return baseMobility + maxAcc + circles + turnFlexibility + dmgStopControl;
-}
-
-function systemsAndCrewScore(build) {
-  const systems = Array.isArray(build.systems) ? build.systems : [];
-  const crew = build.crew || {};
-
-  const systemsValue = systems.reduce((total, entry) => total + num(entry?.value), 0);
-  const systemsBreadth = systems.length * 0.5;
-  const crewSupport = (num(crew.shuttleCraft) * 0.25) + (num(crew.marinesStationed) * 0.12);
-
-  return systemsValue + systemsBreadth + crewSupport;
-}
-
-function powerAndFunctionsScore(build) {
-  const tracks = Array.isArray(build.powerSystem?.tracks) ? build.powerSystem.tracks : [];
-  const trackPower = tracks.reduce((total, track) => {
-    const points = num(track?.points);
-    const boxesPerPoint = Math.max(1, num(track?.boxesPerPoint));
-    const patternBonus = (Array.isArray(track?.boxPattern) ? track.boxPattern : []).length * 0.08;
-    const dotBonus = track?.hasDot === false ? 0 : 0.1;
-    return total + (points * (0.7 + (boxesPerPoint * 0.12))) + patternBonus + dotBonus;
-  }, 0);
-
-  const cfg = build.functionsConfig || {};
+function scoreFunctions(build) {
+  const cfg = build?.functionsConfig || {};
   const rows = [cfg.accDec, cfg.sifIdf, cfg.batRech, cfg.sensor, cfg.genSys, ...(Array.isArray(cfg.weapons) ? cfg.weapons : [])];
 
-  const functionsValue = rows.reduce((total, row) => {
+  const rowScore = rows.reduce((total, row) => {
     if (!row || row.enabled === false) {
       return total;
     }
-    const valueCount = Array.isArray(row.values) ? row.values.length : 0;
-    const free = num(row.free);
-    const emergency = row.emer ? 0.35 : 0;
-    return total + (valueCount * 0.55) + (free * 0.4) + emergency;
-  }, 0)
-    + (num(cfg.ftl?.empty) * 0.2)
-    + (num(cfg.cloak?.empty) * 0.2)
-    + (cfg.cloak?.enabled ? 1.2 : 0);
 
-  return trackPower + functionsValue;
+    const valueCount = Array.isArray(row.values) ? row.values.length : 0;
+    const valueMagnitude = parseFunctionMagnitude(row.values);
+    const free = positivePart(row.free);
+    const emergency = row.emer ? 0.45 : 0;
+    const enabledBonus = row.enabled === true ? 0.35 : 0;
+
+    return total
+      + (valueCount * 0.95)
+      + (valueMagnitude * 0.32)
+      + (free * 0.65)
+      + emergency
+      + enabledBonus;
+  }, 0);
+
+  const trackSupport = (positivePart(cfg?.ftl?.empty) * 0.5)
+    + (positivePart(cfg?.cloak?.empty) * 0.5)
+    + (cfg?.cloak?.enabled ? 1.8 : 0);
+
+  return rowScore + trackSupport;
+}
+
+function scoreWeapons(build) {
+  const weapons = normalizeWeapons(build?.weapons);
+  return weapons.reduce((total, weapon) => {
+    const ranges = Array.isArray(weapon?.ranges) ? weapon.ranges : [];
+
+    const rangeScore = ranges.reduce((rangeTotal, range) => {
+      const span = bandSpan(range?.band);
+      const dice = Array.isArray(range?.dice) ? range.dice.length : 0;
+      const bonus = positivePart(range?.bonus) * 0.45;
+      const color = rangeTypeWeight(String(range?.type || 'black').toLowerCase());
+      return rangeTotal + ((dice + bonus) * span * color * 0.6);
+    }, 0);
+
+    const mountCount = Math.max(1, weapon?.mountArcs?.length || weapon?.mountFacings?.length || 1);
+    const facingScore = mountFacingScore(weapon);
+    const powerScore = positivePart(weapon?.powerCircles) * 0.85;
+    const stopScore = (Array.isArray(weapon?.powerStops) ? weapon.powerStops.length : 0) * 0.45;
+    const structureScore = positivePart(weapon?.structure) * 0.95;
+    const traitScore = traitBonusScore(weapon?.traits) * 1.0;
+    const specialScore = String(weapon?.special || '').trim() ? 1.3 : 0;
+
+    return total
+      + rangeScore
+      + (mountCount * 1.1)
+      + (facingScore * 2.8)
+      + powerScore
+      + stopScore
+      + structureScore
+      + traitScore
+      + specialScore;
+  }, 0);
+}
+
+
+function applyPointValueCurve(totalScore) {
+  const base = positivePart(totalScore) * 0.082;
+
+  // Keep modest/smaller ships from inflating too quickly.
+  const lowEndCompression = base <= 30
+    ? Math.pow((30 - base) / 30, 1.25) * 2.8
+    : 0;
+
+  // Push high-end capability into a higher class band.
+  const classSeparationBonus = base > 40
+    ? Math.pow(base - 40, 1.22) * 0.24
+    : 0;
+
+  return Math.max(2, base - lowEndCompression + classSeparationBonus);
 }
 
 export function calculatePointValue(build) {
-  const offense = offenseScore(build);
-  const powerLimitedOffense = offense * powerConstraintMultiplier(build);
-  const durability = durabilityScore(build);
-  const mobility = mobilityScore(build);
-  const systems = systemsAndCrewScore(build);
-  const power = powerAndFunctionsScore(build);
+  const contributions = {
+    identity: safeRun(() => scoreIdentity(build)) * SECTION_MULTIPLIERS.identity,
+    engineering: safeRun(() => scoreEngineering(build)) * SECTION_MULTIPLIERS.engineering,
+    defense: safeRun(() => scoreDefense(build)) * SECTION_MULTIPLIERS.defense,
+    maneuvering: safeRun(() => scoreManeuvering(build)) * SECTION_MULTIPLIERS.maneuvering,
+    systemsCrew: safeRun(() => scoreSystemsAndCrew(build)) * SECTION_MULTIPLIERS.systemsCrew,
+    powerTracks: safeRun(() => scorePowerTracks(build)) * SECTION_MULTIPLIERS.powerTracks,
+    functions: safeRun(() => scoreFunctions(build)) * SECTION_MULTIPLIERS.functions,
+    weapons: safeRun(() => scoreWeapons(build)) * SECTION_MULTIPLIERS.weapons
+  };
 
-  // Balanced model: every major ship section contributes to cost.
-  const total = (powerLimitedOffense * 0.9)
-    + (durability * 0.95)
-    + (mobility * 0.85)
-    + (systems * 0.75)
-    + (power * 0.8);
-
-  return Math.max(1, Math.round(Math.max(total, survivabilityFloor)));
+  const total = sum(Object.values(contributions));
+  const curvedTotal = applyPointValueCurve(total);
+  return Math.max(2, Math.round(curvedTotal));
 }


### PR DESCRIPTION
### Motivation
- Prevent modest/older/smaller ships from inflating in point value while ensuring advanced ships separate into a clearly higher PV class. 
- Move away from near-linear final PV scaling so generational improvements (e.g., York II -> York V) produce larger, class-level gaps. 
- Clean up and modularize the PV calculation so individual subsystems can be tuned independently and robustly.

### Description
- Add `applyPointValueCurve(totalScore)` to shape the final PV distribution with `lowEndCompression` to contain small ships and `classSeparationBonus` to push high-end ships into a distinct band, and wire it into `calculatePointValue` so the curve replaces the prior flat normalization. 
- Refactor and split scoring into section-based functions (`scoreIdentity`, `scoreEngineering`, `scoreDefense`, `scoreManeuvering`, `scoreSystemsAndCrew`, `scorePowerTracks`, `scoreFunctions`, `scoreWeapons`) and a `SECTION_MULTIPLIERS` map to weight each section before the final curve. 
- Implement robustness and helper utilities: `positivePart`, `safeRun`, improved weapon arc/facing normalization (`normalizeArcValues`, `arcFacingWeight`, `mountFacingScore`), trait weighting, and improved power/track scoring logic. 
- Update `app.js` defaults and form/restore behavior to use minimal/zeroed defaults and make form fields consistent with the new scoring expectations.

### Testing
- Ran a syntax check with `node --check starforce-commander-ship-designer/pv-calculator.js` which completed successfully. 
- Executed representative PV sanity checks via `node --input-type=module` using `calculatePointValue` and observed expected curve behavior with results: `smallOld 7`, `york2Like 30`, `york5Like 69`, `delta 39`, and `blank 2`. 
- Performed a power/battery regression spot-check using the same harness with results: `noBattery 17`, `base 17`, `moreBattery 19`, confirming no major regressions in power handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a58488f7c8332830ecd362f6e9d11)