### PR TITLE
Normalize Utopia data layer: schema, migrations, backfill, and DAL

### DIFF
--- a/Frontiers/Utopia/.gitignore
+++ b/Frontiers/Utopia/.gitignore
@@ -1,0 +1,3 @@
+db/*.sqlite
+db/*.sqlite.bak.*
+**/__pycache__/

--- a/Frontiers/Utopia/README.md
+++ b/Frontiers/Utopia/README.md
@@ -1,0 +1,15 @@
+# Utopia Phase 1: Data Layer Refactor
+
+This folder contains the normalized schema, migration/backfill scripts, and repository/service data access layer for Utopia.
+
+## Quick start
+
+```bash
+# Build schema + backfill from legacy data
+Frontiers/Utopia/migrate_utopia_data --rebuild
+
+# Verify migrated integrity and counts
+python3 Frontiers/Utopia/scripts/verify_utopia_data.py --db-path Frontiers/Utopia/db/utopia.sqlite
+```
+
+See `schema.md` for ERD, normalization rationale, indexing strategy, and migration notes.

--- a/Frontiers/Utopia/db/migrations/001_create_utopia_v2_down.sql
+++ b/Frontiers/Utopia/db/migrations/001_create_utopia_v2_down.sql
@@ -1,0 +1,12 @@
+PRAGMA foreign_keys = OFF;
+DROP TABLE IF EXISTS activities;
+DROP TABLE IF EXISTS saved_views;
+DROP TABLE IF EXISTS card_links;
+DROP TABLE IF EXISTS card_tags;
+DROP TABLE IF EXISTS tags;
+DROP TABLE IF EXISTS cards;
+DROP TABLE IF EXISTS columns;
+DROP TABLE IF EXISTS boards;
+DROP TABLE IF EXISTS workspaces;
+DROP TABLE IF EXISTS users;
+PRAGMA foreign_keys = ON;

--- a/Frontiers/Utopia/db/migrations/001_create_utopia_v2_up.sql
+++ b/Frontiers/Utopia/db/migrations/001_create_utopia_v2_up.sql
@@ -1,0 +1,124 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  email TEXT UNIQUE,
+  display_name TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS workspaces (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  owner_user_id TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS boards (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  archived_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  UNIQUE(workspace_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS columns (
+  id TEXT PRIMARY KEY,
+  board_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  position REAL NOT NULL,
+  archived_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE,
+  UNIQUE(board_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS cards (
+  id TEXT PRIMARY KEY,
+  board_id TEXT NOT NULL,
+  column_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  card_type TEXT,
+  external_id TEXT,
+  position REAL NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  archived_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE,
+  FOREIGN KEY (column_id) REFERENCES columns(id) ON DELETE CASCADE,
+  UNIQUE(board_id, card_type, external_id)
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  color TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  UNIQUE(workspace_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS card_tags (
+  card_id TEXT NOT NULL,
+  tag_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (card_id, tag_id),
+  FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE CASCADE,
+  FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS card_links (
+  id TEXT PRIMARY KEY,
+  card_id TEXT NOT NULL,
+  label TEXT NOT NULL,
+  url TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS saved_views (
+  id TEXT PRIMARY KEY,
+  board_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  filter_json TEXT NOT NULL DEFAULT '{}',
+  sort_json TEXT NOT NULL DEFAULT '{}',
+  created_by_user_id TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE,
+  FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE SET NULL,
+  UNIQUE(board_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS activities (
+  id TEXT PRIMARY KEY,
+  board_id TEXT NOT NULL,
+  card_id TEXT,
+  actor_user_id TEXT,
+  activity_type TEXT NOT NULL,
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE,
+  FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE SET NULL,
+  FOREIGN KEY (actor_user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_boards_workspace_id ON boards(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_columns_board_position ON columns(board_id, position);
+CREATE INDEX IF NOT EXISTS idx_cards_board_column_position ON cards(board_id, column_id, position);
+CREATE INDEX IF NOT EXISTS idx_cards_updated_at ON cards(updated_at);
+CREATE INDEX IF NOT EXISTS idx_cards_type_external ON cards(card_type, external_id);
+CREATE INDEX IF NOT EXISTS idx_tags_workspace ON tags(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_activities_board_created ON activities(board_id, created_at DESC);

--- a/Frontiers/Utopia/db/seeds/seed_sample_data.sql
+++ b/Frontiers/Utopia/db/seeds/seed_sample_data.sql
@@ -1,0 +1,19 @@
+INSERT INTO users (id, email, display_name)
+VALUES ('usr_demo', 'demo@utopia.local', 'Demo User');
+
+INSERT INTO workspaces (id, name, owner_user_id)
+VALUES ('wsp_demo', 'Demo Workspace', 'usr_demo');
+
+INSERT INTO boards (id, workspace_id, name, description)
+VALUES ('brd_demo', 'wsp_demo', 'Getting Started', 'Sample board for local development');
+
+INSERT INTO columns (id, board_id, name, position)
+VALUES
+  ('col_demo_backlog', 'brd_demo', 'Backlog', 1000),
+  ('col_demo_doing', 'brd_demo', 'Doing', 2000),
+  ('col_demo_done', 'brd_demo', 'Done', 3000);
+
+INSERT INTO cards (id, board_id, column_id, title, description, card_type, external_id, position, metadata_json)
+VALUES
+  ('crd_demo_1', 'brd_demo', 'col_demo_backlog', 'Import legacy fleet data', 'Run migrate_utopia_data.', 'task', 'demo-1', 1000, '{"priority":"high"}'),
+  ('crd_demo_2', 'brd_demo', 'col_demo_doing', 'Refactor repository layer', 'Adopt repositories for all reads/writes.', 'task', 'demo-2', 1000, '{"priority":"medium"}');

--- a/Frontiers/Utopia/migrate_utopia_data
+++ b/Frontiers/Utopia/migrate_utopia_data
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$SCRIPT_DIR/scripts/migrate_utopia_data.py" "$@"

--- a/Frontiers/Utopia/schema.md
+++ b/Frontiers/Utopia/schema.md
@@ -1,0 +1,102 @@
+# Utopia Data Layer (Phase 1)
+
+## Repo Recon (Current State)
+
+### Where schema/data lives today
+- Utopia currently loads a single denormalized JSON payload from `data/data.json` via Angular `$http` in `utopia-card-loader`. There is no relational DB/ORM layer yet.
+- Source records are authored in category-specific JS modules (`ships`, `captains`, `upgrades`, etc.) and merged into one payload by `src/data/index.js`.
+- User state is mostly browser-local (`localStorage.defaults`) and fleet serialization in URL hash.
+
+### Where data is accessed
+- `src/js/common/utopia-card-loader.js` performs direct category iteration, duplicate checks, enrichment, and merges all cards into one in-memory array.
+- `src/js/utopia-fleet-builder.js` mutates nested fleet objects directly in controllers/directives.
+
+### Current pain points
+1. **No persistence boundary**: UI code and data-transform logic are tightly coupled.
+2. **Denormalized payload**: all card categories are loaded as large arrays; query/index constraints are not enforceable.
+3. **Inconsistent ownership/lifecycle**: rules, data loading, and mutation are interwoven.
+4. **Stringly-typed identifiers and category buckets**: category keys drive behavior implicitly.
+5. **No referential integrity or migration safety**: duplicates are runtime-checked only.
+
+---
+
+## Proposed Schema (ERD style)
+
+- **users** (optional actor identity)
+- **workspaces** (root ownership boundary)
+- **boards** (list-building spaces inside a workspace)
+- **columns** (ordered lanes/list buckets per board)
+- **cards** (ordered items in a column; typed; extensible metadata)
+- **tags** + **card_tags** (many-to-many labels)
+- **card_links** (external reference URLs)
+- **saved_views** (persisted filters/sorts)
+- **activities** (audit/event stream)
+
+Relationships:
+- `workspace 1..n boards`
+- `board 1..n columns`
+- `board 1..n cards`
+- `column 1..n cards`
+- `cards n..m tags` via `card_tags`
+- `card 1..n card_links`
+- `board 1..n saved_views`
+- `board 1..n activities` and optionally `card 0..n activities`
+
+### Normalized vs embedded JSON
+- **Normalized**: workspace/board/column/card/tag/link/view/activity relations, because these are queried/joined frequently and need integrity guarantees.
+- **Embedded JSON**: `cards.metadata_json`, `saved_views.filter_json`, `saved_views.sort_json`, `activities.payload_json` for flexible, evolving payloads without schema churn.
+
+### Ordering strategy
+- Uses **fractional/numeric positions with gaps** (`REAL`, seeded with `1000, 2000, ...`).
+- Rationale: simple drag/drop insertions without full reindex in common operations; easy to rebalance later.
+
+### Integrity and indexing
+- FK cascades on board/column/card ownership.
+- Unique constraints for:
+  - `boards(workspace_id, name)`
+  - `columns(board_id, name)`
+  - `tags(workspace_id, name)`
+  - `cards(board_id, card_type, external_id)`
+- Indexes for board/column ordering, tags, card lookup, and activity feed recency.
+
+---
+
+## Migration + Backfill Plan
+
+1. Apply `001_create_utopia_v2_up.sql`.
+2. Back up existing sqlite DB file (if any).
+3. Import legacy `src/data/backup/data.json` into:
+   - one workspace (`Legacy Utopia Import`)
+   - one board (`Imported Card Catalog`)
+   - columns by legacy bucket (`Ships`, `Captains`, ...)
+   - one card row per legacy record with raw data in `metadata_json`
+   - tags for source bucket and factions
+4. Run verification script to confirm row counts + no orphan join rows.
+
+Rollback:
+- `--rebuild` option runs down migration before rebuilding.
+- DB file backup is written before mutation for recovery.
+
+---
+
+## Developer Ergonomics
+
+### Migration command
+```bash
+Frontiers/Utopia/migrate_utopia_data --rebuild
+```
+
+### Validation command
+```bash
+python3 Frontiers/Utopia/scripts/verify_utopia_data.py --db-path Frontiers/Utopia/db/utopia.sqlite
+```
+
+### Data access boundary
+Use `utopia_data/repositories.py` + `utopia_data/services.py` for read/write paths instead of direct SQL from app/business logic.
+
+---
+
+## Assumptions
+- This repo currently has no running server-side DB integration for Utopia; Phase 1 therefore introduces a DB layer in parallel without forcing immediate UI rewrites.
+- Legacy source-of-truth for migration is `src/data/backup/data.json` (JSON-safe and deterministic).
+- Soft-delete behavior is retained as optional fields (`archived_at`) only where list/card archival semantics are expected.

--- a/Frontiers/Utopia/scripts/migrate_utopia_data.py
+++ b/Frontiers/Utopia/scripts/migrate_utopia_data.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utopia_data import (
+    BoardRepository,
+    CardRepository,
+    ColumnRepository,
+    TagRepository,
+    UtopiaBoardService,
+    WorkspaceRepository,
+    connect,
+    migrate_down,
+    migrate_up,
+)
+
+DEFAULT_DB_PATH = ROOT / "db" / "utopia.sqlite"
+DEFAULT_LEGACY_PATH = ROOT.parent / "src" / "data" / "backup" / "data.json"
+
+
+def backup_db(db_path: Path) -> Path | None:
+    if not db_path.exists():
+        return None
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    backup_path = db_path.with_suffix(f".sqlite.bak.{ts}")
+    shutil.copy2(db_path, backup_path)
+    return backup_path
+
+
+def load_legacy_data(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def source_buckets() -> list[str]:
+    return ["ships", "captains", "admirals", "ambassadors", "upgrades", "resources", "others"]
+
+
+def migrate(args: argparse.Namespace) -> None:
+    db_path = Path(args.db_path)
+    legacy_path = Path(args.legacy_path)
+
+    if not legacy_path.exists():
+        raise FileNotFoundError(f"Legacy source does not exist: {legacy_path}")
+
+    backup_path = backup_db(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = connect(db_path)
+    try:
+        if args.rebuild:
+            migrate_down(conn)
+        migrate_up(conn)
+
+        service = UtopiaBoardService(
+            WorkspaceRepository(conn),
+            BoardRepository(conn),
+            ColumnRepository(conn),
+            CardRepository(conn),
+            TagRepository(conn),
+        )
+        card_repo = CardRepository(conn)
+        legacy = load_legacy_data(legacy_path)
+
+        workspace_id, board_id, columns = service.create_workspace_with_board(
+            workspace_name="Legacy Utopia Import",
+            board_name="Imported Card Catalog",
+            column_names=[bucket.capitalize() for bucket in source_buckets()],
+        )
+
+        seen_keys: dict[tuple[str, str | None], int] = {}
+
+        for bucket in source_buckets():
+            position = 1000.0
+            for item in legacy.get(bucket, []):
+                metadata = {
+                    "legacy_source": bucket,
+                    "set": item.get("set"),
+                    "factions": item.get("factions", []),
+                    "cost": item.get("cost"),
+                    "raw": item,
+                }
+                tags = [(bucket[:-1] if bucket.endswith("s") else bucket, "#64748b")]
+                for faction in item.get("factions", []) or []:
+                    tags.append((f"faction:{faction}", None))
+
+                card_type = item.get("type", bucket[:-1])
+                base_external_id = str(item.get("id")) if item.get("id") is not None else None
+                key = (card_type, base_external_id)
+                dedupe_count = seen_keys.get(key, 0)
+                seen_keys[key] = dedupe_count + 1
+                external_id = base_external_id if dedupe_count == 0 else f"{base_external_id}::dup{dedupe_count}"
+
+                service.create_card(
+                    board_id=board_id,
+                    column_id=columns[bucket.capitalize()],
+                    title=item.get("name") or f"{bucket}:{item.get('id', 'unknown')}",
+                    card_type=card_type,
+                    external_id=external_id,
+                    metadata=metadata,
+                    tags=tags,
+                    workspace_id=workspace_id,
+                    position=position,
+                )
+                position += 1000.0
+
+        conn.commit()
+        print(f"Migration completed: {db_path}")
+        print(f"Imported {card_repo.count()} cards from {legacy_path}")
+        if backup_path:
+            print(f"Backup: {backup_path}")
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Migrate legacy Utopia data to normalized schema.")
+    parser.add_argument("--db-path", default=str(DEFAULT_DB_PATH), help="Target sqlite database path")
+    parser.add_argument("--legacy-path", default=str(DEFAULT_LEGACY_PATH), help="Legacy data.json path")
+    parser.add_argument("--rebuild", action="store_true", help="Drop v2 tables before migrating")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    migrate(parse_args())

--- a/Frontiers/Utopia/scripts/verify_utopia_data.py
+++ b/Frontiers/Utopia/scripts/verify_utopia_data.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+
+
+def fetch_int(conn: sqlite3.Connection, sql: str) -> int:
+    return int(conn.execute(sql).fetchone()[0])
+
+
+def verify(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+
+        cards = fetch_int(conn, "SELECT COUNT(*) FROM cards")
+        columns = fetch_int(conn, "SELECT COUNT(*) FROM columns")
+        boards = fetch_int(conn, "SELECT COUNT(*) FROM boards")
+        orphan_tags = fetch_int(
+            conn,
+            """
+            SELECT COUNT(*) FROM card_tags ct
+            LEFT JOIN cards c ON c.id = ct.card_id
+            LEFT JOIN tags t ON t.id = ct.tag_id
+            WHERE c.id IS NULL OR t.id IS NULL
+            """,
+        )
+
+        if cards <= 0:
+            raise AssertionError("No cards found after migration")
+        if columns <= 0 or boards <= 0:
+            raise AssertionError("Missing core entities (boards/columns)")
+        if orphan_tags != 0:
+            raise AssertionError(f"Found {orphan_tags} orphan card_tags")
+
+        print(f"OK: boards={boards}, columns={columns}, cards={cards}, orphan_card_tags={orphan_tags}")
+    finally:
+        conn.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate migrated Utopia data")
+    parser.add_argument("--db-path", default="Frontiers/Utopia/db/utopia.sqlite")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    verify(Path(args.db_path))

--- a/Frontiers/Utopia/utopia_data/__init__.py
+++ b/Frontiers/Utopia/utopia_data/__init__.py
@@ -1,0 +1,15 @@
+from .db import connect, migrate_down, migrate_up
+from .repositories import BoardRepository, CardRepository, ColumnRepository, TagRepository, WorkspaceRepository
+from .services import UtopiaBoardService
+
+__all__ = [
+    "connect",
+    "migrate_up",
+    "migrate_down",
+    "WorkspaceRepository",
+    "BoardRepository",
+    "ColumnRepository",
+    "CardRepository",
+    "TagRepository",
+    "UtopiaBoardService",
+]

--- a/Frontiers/Utopia/utopia_data/db.py
+++ b/Frontiers/Utopia/utopia_data/db.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = ROOT / "db" / "migrations"
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def apply_sql_file(conn: sqlite3.Connection, sql_path: Path) -> None:
+    conn.executescript(sql_path.read_text(encoding="utf-8"))
+
+
+def migrate_up(conn: sqlite3.Connection) -> None:
+    apply_sql_file(conn, MIGRATIONS_DIR / "001_create_utopia_v2_up.sql")
+
+
+def migrate_down(conn: sqlite3.Connection) -> None:
+    apply_sql_file(conn, MIGRATIONS_DIR / "001_create_utopia_v2_down.sql")

--- a/Frontiers/Utopia/utopia_data/models.py
+++ b/Frontiers/Utopia/utopia_data/models.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Workspace:
+    id: str
+    name: str
+    owner_user_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Board:
+    id: str
+    workspace_id: str
+    name: str
+    description: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Column:
+    id: str
+    board_id: str
+    name: str
+    position: float
+
+
+@dataclass(frozen=True)
+class Card:
+    id: str
+    board_id: str
+    column_id: str
+    title: str
+    description: Optional[str]
+    card_type: Optional[str]
+    external_id: Optional[str]
+    position: float
+    metadata_json: str
+
+
+@dataclass(frozen=True)
+class Tag:
+    id: str
+    workspace_id: str
+    name: str
+    color: Optional[str] = None

--- a/Frontiers/Utopia/utopia_data/repositories.py
+++ b/Frontiers/Utopia/utopia_data/repositories.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import asdict
+from typing import Iterable
+
+from .models import Board, Card, Column, Tag, Workspace
+
+
+class WorkspaceRepository:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def create(self, workspace: Workspace) -> None:
+        self.conn.execute(
+            "INSERT INTO workspaces (id, name, owner_user_id) VALUES (:id, :name, :owner_user_id)",
+            asdict(workspace),
+        )
+
+
+class BoardRepository:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def create(self, board: Board) -> None:
+        self.conn.execute(
+            "INSERT INTO boards (id, workspace_id, name, description) VALUES (:id, :workspace_id, :name, :description)",
+            asdict(board),
+        )
+
+
+class ColumnRepository:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def create_many(self, columns: Iterable[Column]) -> None:
+        self.conn.executemany(
+            "INSERT INTO columns (id, board_id, name, position) VALUES (:id, :board_id, :name, :position)",
+            [asdict(col) for col in columns],
+        )
+
+
+class TagRepository:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def get_or_create(self, tag: Tag) -> Tag:
+        row = self.conn.execute(
+            "SELECT id, workspace_id, name, color FROM tags WHERE workspace_id = ? AND name = ?",
+            (tag.workspace_id, tag.name),
+        ).fetchone()
+        if row:
+            return Tag(**dict(row))
+        self.conn.execute(
+            "INSERT INTO tags (id, workspace_id, name, color) VALUES (:id, :workspace_id, :name, :color)",
+            asdict(tag),
+        )
+        return tag
+
+
+class CardRepository:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def create(self, card: Card, tag_ids: list[str] | None = None) -> None:
+        payload = asdict(card)
+        payload["metadata_json"] = card.metadata_json if isinstance(card.metadata_json, str) else json.dumps(card.metadata_json)
+        self.conn.execute(
+            """
+            INSERT INTO cards
+              (id, board_id, column_id, title, description, card_type, external_id, position, metadata_json)
+            VALUES
+              (:id, :board_id, :column_id, :title, :description, :card_type, :external_id, :position, :metadata_json)
+            """,
+            payload,
+        )
+        if tag_ids:
+            self.conn.executemany(
+                "INSERT INTO card_tags (card_id, tag_id) VALUES (?, ?)",
+                [(card.id, tag_id) for tag_id in tag_ids],
+            )
+
+    def count(self) -> int:
+        return int(self.conn.execute("SELECT COUNT(*) FROM cards").fetchone()[0])
+
+    def list_for_board(self, board_id: str) -> list[sqlite3.Row]:
+        return list(
+            self.conn.execute(
+                """
+                SELECT c.*, col.name AS column_name
+                FROM cards c
+                JOIN columns col ON col.id = c.column_id
+                WHERE c.board_id = ? AND c.archived_at IS NULL
+                ORDER BY col.position, c.position
+                """,
+                (board_id,),
+            ).fetchall()
+        )

--- a/Frontiers/Utopia/utopia_data/services.py
+++ b/Frontiers/Utopia/utopia_data/services.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from .models import Board, Card, Column, Tag, Workspace
+from .repositories import BoardRepository, CardRepository, ColumnRepository, TagRepository, WorkspaceRepository
+
+
+class UtopiaBoardService:
+    """Service boundary so UI/business code doesn't query raw tables directly."""
+
+    def __init__(self, workspace_repo: WorkspaceRepository, board_repo: BoardRepository, column_repo: ColumnRepository, card_repo: CardRepository, tag_repo: TagRepository):
+        self.workspace_repo = workspace_repo
+        self.board_repo = board_repo
+        self.column_repo = column_repo
+        self.card_repo = card_repo
+        self.tag_repo = tag_repo
+
+    def create_workspace_with_board(self, workspace_name: str, board_name: str, column_names: list[str]) -> tuple[str, str, dict[str, str]]:
+        workspace_id = f"wsp_{uuid.uuid4().hex[:10]}"
+        board_id = f"brd_{uuid.uuid4().hex[:10]}"
+        self.workspace_repo.create(Workspace(id=workspace_id, name=workspace_name))
+        self.board_repo.create(Board(id=board_id, workspace_id=workspace_id, name=board_name))
+
+        columns = []
+        column_ids: dict[str, str] = {}
+        position = 1000.0
+        for name in column_names:
+            col_id = f"col_{uuid.uuid4().hex[:10]}"
+            column_ids[name] = col_id
+            columns.append(Column(id=col_id, board_id=board_id, name=name, position=position))
+            position += 1000.0
+        self.column_repo.create_many(columns)
+        return workspace_id, board_id, column_ids
+
+    def create_card(self, board_id: str, column_id: str, title: str, card_type: str, external_id: str | None, metadata: dict[str, Any], tags: list[tuple[str, str | None]], workspace_id: str, position: float) -> str:
+        card_id = f"crd_{uuid.uuid4().hex[:12]}"
+        tag_ids: list[str] = []
+        for tag_name, color in tags:
+            tag_id = f"tag_{uuid.uuid4().hex[:10]}"
+            tag = self.tag_repo.get_or_create(Tag(id=tag_id, workspace_id=workspace_id, name=tag_name, color=color))
+            tag_ids.append(tag.id)
+
+        self.card_repo.create(
+            Card(
+                id=card_id,
+                board_id=board_id,
+                column_id=column_id,
+                title=title,
+                description=None,
+                card_type=card_type,
+                external_id=external_id,
+                position=position,
+                metadata_json=json.dumps(metadata, separators=(",", ":")),
+            ),
+            tag_ids=tag_ids,
+        )
+        return card_id


### PR DESCRIPTION
### Motivation
- Provide a clean, normalized, and evolvable persistence layer for the Utopia card/list builder while leaving the UI unchanged for Phase 1. 
- Replace the current single denormalized JSON payload approach with explicit entities and referential integrity to remove stringly-typed buckets and couple data access to a small, testable API. 
- Use the existing legacy JSON (`src/data/backup/data.json`) as the safe backfill source and add tooling to migrate and verify the data with rollback and backup safeguards. 

### Description
- Introduced a normalized SQLite schema (migrations) for `users`, `workspaces`, `boards`, `columns`, `cards`, `tags`, `card_tags`, `card_links`, `saved_views`, and `activities` with FK constraints, uniqueness rules, and indexes in `Frontiers/Utopia/db/migrations/001_create_utopia_v2_up.sql` (and a down script). 
- Added a simple DB helper and migration runner in `utopia_data/db.py`, typed dataclass models in `utopia_data/models.py`, and a repository layer in `utopia_data/repositories.py` plus a service boundary `utopia_data/services.py` so UI/business code can stop querying raw tables directly. 
- Implemented a safe backfill/migration tool `Frontiers/Utopia/migrate_utopia_data` (Python script) that optionally rebuilds the schema, creates DB backups, imports legacy buckets into columns, stores legacy payload in `metadata_json`, tags by source/faction, and deduplicates `external_id` collisions to preserve the uniqueness constraint. 
- Added seed/sample SQL (`db/seeds/seed_sample_data.sql`), a lightweight verification script (`scripts/verify_utopia_data.py`), documentation (`schema.md`, `README.md`), and a small `.gitignore` for DB and pycache. 

### Testing
- Ran the migration end-to-end with `Frontiers/Utopia/migrate_utopia_data --rebuild` which completed and reported a successful import. 
- Verified the migrated DB with `python3 Frontiers/Utopia/scripts/verify_utopia_data.py --db-path Frontiers/Utopia/db/utopia.sqlite` which printed `OK: boards=1, columns=7, cards=1334, orphan_card_tags=0`. 
- Performed static sanity checks by compiling Python sources with `python3 -m py_compile` and confirmed no syntax errors in the migration and module files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f35bdf8448332b5be3c816c7bea50)