### PR TITLE
Refactor weapon/range weighting and scoring in PV calculator

### DIFF
--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -7,26 +7,61 @@ function sum(values) {
   return values.reduce((total, value) => total + num(value), 0);
 }
 
-function bandSpan(rawBand) {
+function rangeTypeWeight(type) {
+  if (type === 'green') {
+    return 1.1;
+  }
+  if (type === 'black') {
+    return 1;
+  }
+  if (type === 'blue') {
+    return 0.9;
+  }
+  // Keep support for legacy color tags.
+  if (type === 'red') {
+    return 1.05;
+  }
+  if (type === 'yellow') {
+    return 1.02;
+  }
+  return 1;
+}
+
+function diceColorWeight(symbol) {
+  const normalized = String(symbol || '').trim().toUpperCase();
+  if (normalized === 'R') {
+    return 1.45;
+  }
+  if (normalized === 'Y') {
+    return 1.22;
+  }
+  if (normalized === 'G') {
+    return 1;
+  }
+  if (normalized === 'B') {
+    return 0.78;
+  }
+  return 1;
+}
+
+function bandMax(rawBand) {
   const [start, end] = String(rawBand || '')
     .split('-')
     .map((part) => Number(part.trim()));
 
-  if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
-    return Math.max(1, end - start + 1);
+  if (Number.isFinite(start) && Number.isFinite(end)) {
+    return Math.max(start, end);
   }
 
-  return 1;
-}
+  if (Number.isFinite(start)) {
+    return start;
+  }
 
-function rangeTypeWeight(type) {
-  if (type === 'green') {
-    return 1.15;
+  if (Number.isFinite(end)) {
+    return end;
   }
-  if (type === 'red') {
-    return 0.9;
-  }
-  return 1;
+
+  return 8;
 }
 
 function normalizeWeapons(weapons) {
@@ -54,47 +89,29 @@ function normalizeArcValues(weapon) {
 }
 
 function arcFacingWeight(arc) {
-  if (arc === 1) {
-    return 1.6; // forward
+  if (arc === 1 || arc === 2) {
+    return 1.35; // strongest firing arcs
   }
-  if (arc === 2 || arc === 8) {
-    return 1.35; // forward flanks
+  if (arc === 3) {
+    return 1.18;
   }
-  if (arc === 3 || arc === 7) {
-    return 1.05; // side-forward quarters
+  if (arc === 4 || arc === 8) {
+    return 1.0;
   }
-  if (arc === 4 || arc === 6) {
-    return 0.82; // side-rear quarters
+  if (arc === 5) {
+    return 0.9;
   }
-  return 0.6; // arc 5 rear
+  if (arc === 6 || arc === 7) {
+    return 0.7; // weakest firing arcs
+  }
+  return 1;
 }
 
 function mountFacingScore(weapon) {
   const arcs = [...new Set(normalizeArcValues(weapon))];
   const summedFacing = sum(arcs.map((arc) => arcFacingWeight(arc)));
-  const averagedFacing = summedFacing / Math.max(1, arcs.length);
-  const arcCoverageBonus = Math.sqrt(Math.max(1, arcs.length));
-  return averagedFacing * arcCoverageBonus;
+  return summedFacing / Math.max(1, arcs.length);
 }
-
-function normalizeTrait(trait) {
-  return String(trait || '').trim().toUpperCase();
-}
-
-const TRAIT_BONUS_BY_PREFIX = [
-  { match: 'HOMING', bonus: 1.2 },
-  { match: 'HVY', bonus: 1.4 },
-  { match: 'PREC', bonus: 1.4 },
-  { match: 'PIERCE', bonus: 1.4 },
-  { match: 'PIRCE', bonus: 1.4 },
-  { match: 'PARICAL', bonus: 1.1 },
-  { match: 'PARTIAL', bonus: 1.1 },
-  { match: 'LEAK', bonus: 1.1 },
-  { match: 'PD MODE', bonus: 1.1 },
-  { match: 'ATMO', bonus: 0.8 },
-  { match: 'NOBAT', bonus: 0.6 },
-  { match: 'FTL', bonus: 1.0 }
-];
 
 const SECTION_MULTIPLIERS = {
   identity: 0.4,
@@ -106,22 +123,6 @@ const SECTION_MULTIPLIERS = {
   functions: 1.7,
   weapons: 1.35
 };
-
-function traitBonusScore(traits) {
-  if (!Array.isArray(traits) || traits.length === 0) {
-    return 0;
-  }
-
-  return traits.reduce((score, trait) => {
-    const normalized = normalizeTrait(trait);
-    if (!normalized) {
-      return score;
-    }
-
-    const weighted = TRAIT_BONUS_BY_PREFIX.find((entry) => normalized.startsWith(entry.match));
-    return score + (weighted ? weighted.bonus : 0.9);
-  }, 0);
-}
 
 function positivePart(value, fallback = 0) {
   const parsed = num(value);
@@ -310,23 +311,21 @@ function scoreWeaponQuality(weapon, build) {
   const ranges = Array.isArray(weapon?.ranges) ? weapon.ranges : [];
 
   const rangeScore = ranges.reduce((rangeTotal, range) => {
-    const span = bandSpan(range?.band);
-    const dice = Array.isArray(range?.dice) ? range.dice.length : 0;
-    const bonus = positivePart(range?.bonus) * 0.45;
-    const color = rangeTypeWeight(String(range?.type || 'black').toLowerCase());
-    return rangeTotal + ((dice + bonus) * span * color * 0.62);
+    const diceScore = sum((Array.isArray(range?.dice) ? range.dice : []).map((die) => diceColorWeight(die)));
+    const bonus = positivePart(range?.bonus);
+    const rangeType = rangeTypeWeight(String(range?.type || 'black').toLowerCase());
+    const maxDistance = bandMax(range?.band);
+    const distanceFactor = Math.max(0.45, maxDistance / 8);
+    return rangeTotal + ((diceScore + bonus) * rangeType * distanceFactor);
   }, 0);
 
-  const powerScore = positivePart(weapon?.powerCircles) * 0.85;
-  const stopScore = (Array.isArray(weapon?.powerStops) ? weapon.powerStops.length : 0) * 0.45;
-  const structureScore = positivePart(weapon?.structure) * 0.95;
-  const traitScore = traitBonusScore(weapon?.traits) * 1.0;
-  const specialScore = String(weapon?.special || '').trim() ? 1.3 : 0;
+  const powerDiscount = (positivePart(weapon?.powerCircles) * 0.32)
+    + ((Array.isArray(weapon?.powerStops) ? weapon.powerStops.length : 0) * 0.72);
+  const structureScore = positivePart(weapon?.structure) * 0.35;
 
-  return (rangeScore * rank(build, 'rankWeaponsRange'))
-    + ((powerScore + stopScore) * rank(build, 'rankWeaponsPower'))
-    + (structureScore * rank(build, 'rankWeaponsStructure'))
-    + ((traitScore + specialScore) * rank(build, 'rankWeaponsTraitsSpecial'));
+  return (rangeScore * 1.35 * rank(build, 'rankWeaponsRange'))
+    - (powerDiscount * rank(build, 'rankWeaponsPower'))
+    + (structureScore * rank(build, 'rankWeaponsStructure'));
 }
 
 
@@ -339,32 +338,13 @@ function effectiveMountCount(weapon) {
 
 function scoreWeapons(build) {
   const weapons = normalizeWeapons(build?.weapons);
-  const perWeaponScores = weapons.map((weapon) => {
+  return weapons.reduce((total, weapon) => {
     const mountCount = effectiveMountCount(weapon);
-    const arcCount = new Set(normalizeArcValues(weapon)).size;
-    const facingScore = mountFacingScore(weapon);
-    const weaponQuality = Math.pow(Math.max(0.1, scoreWeaponQuality(weapon, build)), 0.82);
-
-    // Better weapons scale super-linearly when mounted more times.
-    const mountScale = 0.82 + (Math.pow(mountCount, 1.2) * 0.3) + (mountCount >= 4 ? (Math.sqrt(mountCount) * 0.12) : 0);
-
-    // Arc quality matters: forward-biased facings scale value harder than poor arcs.
-    const arcQualityScale = (0.82 + (Math.pow(facingScore, 1.12) * 0.55)) * rank(build, 'rankWeaponsMountArc');
-
-    // Coverage breadth gives a smaller additive multiplier for tactical flexibility.
-    const coverageScale = 0.9 + (Math.log2(Math.max(1, arcCount) + 1) * 0.22);
-
-    return (weaponQuality * mountScale * arcQualityScale * coverageScale)
-      + (mountCount * 0.28 * rank(build, 'rankWeaponsMountArc'));
-  });
-
-  // Multiple weapon lines are powerful, but stacking has diminishing returns in battle tempo.
-  return perWeaponScores
-    .sort((a, b) => b - a)
-    .reduce((total, score, index) => {
-      const stackingMultiplier = index === 0 ? 1 : Math.max(0.5, 1 - (index * 0.18));
-      return total + (score * stackingMultiplier);
-    }, 0);
+    const arcWeight = 0.12 + (mountFacingScore(weapon) * rank(build, 'rankWeaponsMountArc'));
+    const weaponQuality = Math.max(0, scoreWeaponQuality(weapon, build));
+    const singleMountValue = weaponQuality * arcWeight;
+    return total + (singleMountValue * mountCount);
+  }, 0);
 }
 
 


### PR DESCRIPTION
### Motivation
- Improve accuracy and consistency of weapon and range scoring by replacing brittle band parsing and legacy trait heuristics with clearer weights and distance factors.
- Simplify arc/mount scoring and make per-weapon contributions more predictable for multi-mount weapons.
- Restore support for legacy color tags while standardizing dice and range type weightings.

### Description
- Introduced `rangeTypeWeight`, `diceColorWeight`, and `bandMax` to replace `bandSpan` and legacy trait lookups, and to normalize range/dice weight calculations.
- Reworked `arcFacingWeight` and simplified `mountFacingScore` to return the averaged facing weight without an additional coverage bonus.
- Removed the old `TRAIT_BONUS_BY_PREFIX` and `traitBonusScore` logic and eliminated `special` trait scoring from weapon quality.
- Rewrote `scoreWeaponQuality` to compute `diceScore`, `bonus`, `rangeType`, and a `distanceFactor`, changed power and structure contributions, and adjusted multipliers and rank usage.
- Simplified `scoreWeapons` to aggregate weapon contributions as `singleMountValue * mountCount` using a computed `arcWeight` instead of the previous multi-step scaling, stacking, and sorting logic.
- Adjusted a number of numeric weights and fallbacks to tighten scoring ranges and provide sane defaults.

### Testing
- Ran the project's linting and unit test suite against the modified file and observed all existing automated tests passed. 
- Performed a quick smoke test of the PV calculation in the application UI to ensure values remain stable and no runtime errors occur.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1125a3914833288638f0a61bda712)