### PR TITLE
Lock PV ranking baseline and remove editable PV weights; reorder SSD builder panels

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -78,7 +78,7 @@ const STANDARD_DEFAULT_LOADOUT = {
 
 
 const PV_RANKING_DEFAULTS = {
-  rankIdentityFields: 0.6,
+  rankIdentityFields: 0,
   rankEngineeringMove: 0.65,
   rankEngineeringVector: 0.7,
   rankEngineeringTurn: 0.6,
@@ -110,7 +110,7 @@ const PV_RANKING_DEFAULTS = {
   rankWeaponsStructure: 0.45,
   rankWeaponsTraitsSpecial: 0.6,
   rankWeaponsMountArc: 0.4,
-  rankGlobalScale: 0.25
+  rankGlobalScale: 0.2
 };
 
 const POWER_TRACK_CONFIG = [
@@ -530,13 +530,7 @@ function syncDerivedFunctionInputs() {
 
 
 function readPvRankings() {
-  return Object.fromEntries(
-    Object.entries(PV_RANKING_DEFAULTS).map(([key, defaultValue]) => {
-      const raw = num(key);
-      const value = Number.isFinite(raw) && raw >= 0 ? raw : defaultValue;
-      return [key, value];
-    })
-  );
+  return { ...PV_RANKING_DEFAULTS };
 }
 
 function getBuild() {
@@ -1267,10 +1261,6 @@ function restoreDraft(draft) {
   setValue('systems', (draft.systems ?? []).map((item) => `${item.key}:${item.value ?? ''}`).join('\n'));
   setValue('shuttleCraft', draft.crew?.shuttleCraft ?? 0);
   setValue('marinesStationed', draft.crew?.marinesStationed ?? 0);
-
-  Object.entries(PV_RANKING_DEFAULTS).forEach(([key, defaultValue]) => {
-    setValue(key, draft.pvRankings?.[key] ?? defaultValue);
-  });
 
   render();
 }

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -29,113 +29,10 @@
           <label>Damage Control <input name="special" type="number" min="0" value="3" /></label>
         </div>
 
-        <h2>Shields</h2>
-        <div class="shield-stat-grid">
-          <fieldset class="shield-stat-card">
-            <legend>Forward</legend>
-            <label>Shield <input name="shieldFwd" type="number" min="0" value="0" /></label>
-            <label>Armor <input name="armorFwd" type="number" min="0" value="0" /></label>
-          </fieldset>
-          <fieldset class="shield-stat-card">
-            <legend>Aft</legend>
-            <label>Shield <input name="shieldAft" type="number" min="0" value="0" /></label>
-            <label>Armor <input name="armorAft" type="number" min="0" value="0" /></label>
-          </fieldset>
-          <fieldset class="shield-stat-card">
-            <legend>Port</legend>
-            <label>Shield <input name="shieldPort" type="number" min="0" value="0" /></label>
-            <label>Armor <input name="armorPort" type="number" min="0" value="0" /></label>
-          </fieldset>
-          <fieldset class="shield-stat-card">
-            <legend>Starboard</legend>
-            <label>Shield <input name="shieldStbd" type="number" min="0" value="0" /></label>
-            <label>Armor <input name="armorStbd" type="number" min="0" value="0" /></label>
-          </fieldset>
-        </div>
-        <label>Shield Generators (single value for all facings) <input name="shieldGen" type="number" min="0" value="0" /></label>
-        <label>Ship Art (for shield center)
-          <input name="shipArt" id="shipArt" type="file" accept="image/*" />
-        </label>
-        <button type="button" id="clearArtBtn" class="ghost">Clear Ship Art</button>
-
-        <h2>Weapons (up to 4)</h2>
-        <p class="muted">Each weapon supports up to 8 mounts, power circles/stops, structure, per-range dice colors, HOMING band boxes, and optional SPECIAL text (enabled by the HVY trait).</p>
-        <div class="weapon-editor-list">
-          <fieldset class="weapon-editor-card">
-            <legend>Weapon A</legend>
-            <div class="grid2">
-              <label>Name <input name="wpn1Name" value="WPN NAME" /></label>
-              <label>Traits (comma separated) <input name="wpn1Traits" value="HVY, FTL, NoBAT" /></label>
-            </div>
-            <label>Mount arcs (per mount as wedge values, e.g. <code>1,2|5,6</code>)
-              <input name="wpn1MountArcs" value="1,2|5,6" />
-            </label>
-            <div class="grid3">
-              <label>Power circles (1-6) <input name="wpn1PowerCircles" type="number" min="1" max="6" value="3" /></label>
-              <label>Power stop positions (comma) <input name="wpn1PowerStops" value="2" placeholder="2,4" /></label>
-              <label>Structure per mount (1-4) <input name="wpn1Structure" type="number" min="1" max="4" value="2" /></label>
-            </div>
-            <label>Range bands (format <code>0-4:green,5-9:black</code> or <code>0-4,green,5-9,black</code>)
-              <input name="wpn1Ranges" value="0-4:green,5-9:black,10-13:red,14-16:red" />
-            </label>
-            <label>Dice per band (optional bonus first: <code>8,R,R|4,R,R</code>)
-              <input name="wpn1Dice" value="8,R,R|4,R,R|4,R,R|2,R,R" />
-            </label>
-            <label>Special (shown only when HVY trait is present)
-              <input name="wpn1Special" value="H(4+1), STR 2" />
-            </label>
-          </fieldset>
-
-          <fieldset class="weapon-editor-card">
-            <legend>Weapon B</legend>
-            <div class="grid2">
-              <label>Name <input name="wpn2Name" value="" placeholder="Optional" /></label>
-              <label>Traits (comma separated) <input name="wpn2Traits" value="" /></label>
-            </div>
-            <label>Mount arcs <input name="wpn2MountArcs" value="" placeholder="1,2|5,6" /></label>
-            <div class="grid3">
-              <label>Power circles (1-6) <input name="wpn2PowerCircles" type="number" min="1" max="6" value="2" /></label>
-              <label>Power stop positions (comma) <input name="wpn2PowerStops" value="" /></label>
-              <label>Structure per mount (1-4) <input name="wpn2Structure" type="number" min="1" max="4" value="2" /></label>
-            </div>
-            <label>Range bands <input name="wpn2Ranges" value="" placeholder="0-6:green,7-12:black" /></label>
-            <label>Dice per band <input name="wpn2Dice" value="" placeholder="R,R|Y,Y" /></label>
-            <label>Special <input name="wpn2Special" value="" /></label>
-          </fieldset>
-
-          <fieldset class="weapon-editor-card">
-            <legend>Weapon C</legend>
-            <div class="grid2">
-              <label>Name <input name="wpn3Name" value="" placeholder="Optional" /></label>
-              <label>Traits (comma separated) <input name="wpn3Traits" value="" /></label>
-            </div>
-            <label>Mount arcs <input name="wpn3MountArcs" value="" /></label>
-            <div class="grid3">
-              <label>Power circles (1-6) <input name="wpn3PowerCircles" type="number" min="1" max="6" value="2" /></label>
-              <label>Power stop positions (comma) <input name="wpn3PowerStops" value="" /></label>
-              <label>Structure per mount (1-4) <input name="wpn3Structure" type="number" min="1" max="4" value="2" /></label>
-            </div>
-            <label>Range bands <input name="wpn3Ranges" value="" /></label>
-            <label>Dice per band <input name="wpn3Dice" value="" /></label>
-            <label>Special <input name="wpn3Special" value="" /></label>
-          </fieldset>
-
-          <fieldset class="weapon-editor-card">
-            <legend>Weapon D</legend>
-            <div class="grid2">
-              <label>Name <input name="wpn4Name" value="" placeholder="Optional" /></label>
-              <label>Traits (comma separated) <input name="wpn4Traits" value="" /></label>
-            </div>
-            <label>Mount arcs <input name="wpn4MountArcs" value="" /></label>
-            <div class="grid3">
-              <label>Power circles (1-6) <input name="wpn4PowerCircles" type="number" min="1" max="6" value="2" /></label>
-              <label>Power stop positions (comma) <input name="wpn4PowerStops" value="" /></label>
-              <label>Structure per mount (1-4) <input name="wpn4Structure" type="number" min="1" max="4" value="2" /></label>
-            </div>
-            <label>Range bands <input name="wpn4Ranges" value="" /></label>
-            <label>Dice per band <input name="wpn4Dice" value="" /></label>
-            <label>Special <input name="wpn4Special" value="" /></label>
-          </fieldset>
+        <h2>Structure</h2>
+        <div class="grid2">
+          <label>Repairable Structure Boxes <input name="structureBlack" type="number" min="0" value="3" /></label>
+          <label>Permanent Structure Boxes <input name="structureRed" type="number" min="0" value="12" /></label>
         </div>
 
         <h2>Functions / Power / Maneuvering</h2>
@@ -245,64 +142,121 @@
           </div>
         </div>
 
+        <h2>Weapons (up to 4)</h2>
+        <p class="muted">Each weapon supports up to 8 mounts, power circles/stops, structure, per-range dice colors, HOMING band boxes, and optional SPECIAL text (enabled by the HVY trait).</p>
+        <div class="weapon-editor-list">
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon A</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn1Name" value="WPN NAME" /></label>
+              <label>Traits (comma separated) <input name="wpn1Traits" value="HVY, FTL, NoBAT" /></label>
+            </div>
+            <label>Mount arcs (per mount as wedge values, e.g. <code>1,2|5,6</code>)
+              <input name="wpn1MountArcs" value="1,2|5,6" />
+            </label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn1PowerCircles" type="number" min="1" max="6" value="3" /></label>
+              <label>Power stop positions (comma) <input name="wpn1PowerStops" value="2" placeholder="2,4" /></label>
+              <label>Structure per mount (1-4) <input name="wpn1Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands (format <code>0-4:green,5-9:black</code> or <code>0-4,green,5-9,black</code>)
+              <input name="wpn1Ranges" value="0-4:green,5-9:black,10-13:red,14-16:red" />
+            </label>
+            <label>Dice per band (optional bonus first: <code>8,R,R|4,R,R</code>)
+              <input name="wpn1Dice" value="8,R,R|4,R,R|4,R,R|2,R,R" />
+            </label>
+            <label>Special (shown only when HVY trait is present)
+              <input name="wpn1Special" value="H(4+1), STR 2" />
+            </label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon B</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn2Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn2Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn2MountArcs" value="" placeholder="1,2|5,6" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn2PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn2PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn2Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn2Ranges" value="" placeholder="0-6:green,7-12:black" /></label>
+            <label>Dice per band <input name="wpn2Dice" value="" placeholder="R,R|Y,Y" /></label>
+            <label>Special <input name="wpn2Special" value="" /></label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon C</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn3Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn3Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn3MountArcs" value="" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn3PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn3PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn3Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn3Ranges" value="" /></label>
+            <label>Dice per band <input name="wpn3Dice" value="" /></label>
+            <label>Special <input name="wpn3Special" value="" /></label>
+          </fieldset>
+
+          <fieldset class="weapon-editor-card">
+            <legend>Weapon D</legend>
+            <div class="grid2">
+              <label>Name <input name="wpn4Name" value="" placeholder="Optional" /></label>
+              <label>Traits (comma separated) <input name="wpn4Traits" value="" /></label>
+            </div>
+            <label>Mount arcs <input name="wpn4MountArcs" value="" /></label>
+            <div class="grid3">
+              <label>Power circles (1-6) <input name="wpn4PowerCircles" type="number" min="1" max="6" value="2" /></label>
+              <label>Power stop positions (comma) <input name="wpn4PowerStops" value="" /></label>
+              <label>Structure per mount (1-4) <input name="wpn4Structure" type="number" min="1" max="4" value="2" /></label>
+            </div>
+            <label>Range bands <input name="wpn4Ranges" value="" /></label>
+            <label>Dice per band <input name="wpn4Dice" value="" /></label>
+            <label>Special <input name="wpn4Special" value="" /></label>
+          </fieldset>
+        </div>
+
+        <h2>Shields</h2>
+        <div class="shield-stat-grid">
+          <fieldset class="shield-stat-card">
+            <legend>Forward</legend>
+            <label>Shield <input name="shieldFwd" type="number" min="0" value="0" /></label>
+            <label>Armor <input name="armorFwd" type="number" min="0" value="0" /></label>
+          </fieldset>
+          <fieldset class="shield-stat-card">
+            <legend>Aft</legend>
+            <label>Shield <input name="shieldAft" type="number" min="0" value="0" /></label>
+            <label>Armor <input name="armorAft" type="number" min="0" value="0" /></label>
+          </fieldset>
+          <fieldset class="shield-stat-card">
+            <legend>Port</legend>
+            <label>Shield <input name="shieldPort" type="number" min="0" value="0" /></label>
+            <label>Armor <input name="armorPort" type="number" min="0" value="0" /></label>
+          </fieldset>
+          <fieldset class="shield-stat-card">
+            <legend>Starboard</legend>
+            <label>Shield <input name="shieldStbd" type="number" min="0" value="0" /></label>
+            <label>Armor <input name="armorStbd" type="number" min="0" value="0" /></label>
+          </fieldset>
+        </div>
+        <label>Shield Generators (single value for all facings) <input name="shieldGen" type="number" min="0" value="0" /></label>
+        <label>Ship Art (for shield center)
+          <input name="shipArt" id="shipArt" type="file" accept="image/*" />
+        </label>
+        <button type="button" id="clearArtBtn" class="ghost">Clear Ship Art</button>
+
         <h2>Systems (one per line)</h2>
         <label><textarea name="systems" rows="4" placeholder="SCNC:3\nSENS:4\nQTRS:2"></textarea></label>
         <div class="grid2">
           <label>Shuttle Craft <input name="shuttleCraft" type="number" min="0" value="4" /></label>
           <label>Marines Stationed <input name="marinesStationed" type="number" min="0" value="10" /></label>
         </div>
-
-        <h2>Structure</h2>
-        <div class="grid2">
-          <label>Repairable Structure Boxes <input name="structureBlack" type="number" min="0" value="3" /></label>
-          <label>Permanent Structure Boxes <input name="structureRed" type="number" min="0" value="12" /></label>
-        </div>
-
-
-
-        <h2>PV Rank Weights</h2>
-        <p class="muted">Adjust each weighting factor (tuned defaults shown) to tune how strongly each input affects PV.</p>
-        <div class="pv-rank-table-wrap">
-          <table class="pv-rank-table">
-            <thead><tr><th>Section</th><th>Input</th><th>Rank</th></tr></thead>
-            <tbody>
-              <tr><td>Identity</td><td>Identity fields</td><td><input name="rankIdentityFields" type="number" min="0" step="0.1" value="0.6" /></td></tr>
-              <tr><td>Engineering</td><td>Size Class</td><td><input name="rankEngineeringMove" type="number" min="0" step="0.1" value="0.65" /></td></tr>
-              <tr><td>Engineering</td><td>Acceleration</td><td><input name="rankEngineeringVector" type="number" min="0" step="0.1" value="0.7" /></td></tr>
-              <tr><td>Engineering</td><td>Stress Damage</td><td><input name="rankEngineeringTurn" type="number" min="0" step="0.1" value="0.6" /></td></tr>
-              <tr><td>Engineering</td><td>Damage Control</td><td><input name="rankEngineeringSpecial" type="number" min="0" step="0.1" value="0.75" /></td></tr>
-              <tr><td>Defense</td><td>Shield values</td><td><input name="rankDefenseShields" type="number" min="0" step="0.1" value="0.42" /></td></tr>
-              <tr><td>Defense</td><td>Armor values</td><td><input name="rankDefenseArmor" type="number" min="0" step="0.1" value="0.4" /></td></tr>
-              <tr><td>Defense</td><td>Repairable structure</td><td><input name="rankDefenseRepairable" type="number" min="0" step="0.1" value="0.3" /></td></tr>
-              <tr><td>Defense</td><td>Permanent structure</td><td><input name="rankDefensePermanent" type="number" min="0" step="0.1" value="0.28" /></td></tr>
-              <tr><td>Defense</td><td>Shield generator</td><td><input name="rankDefenseShieldGen" type="number" min="0" step="0.1" value="0.45" /></td></tr>
-              <tr><td>Maneuver</td><td>MAX ACC / PHS</td><td><input name="rankManeuverMaxAcc" type="number" min="0" step="0.1" value="0.65" /></td></tr>
-              <tr><td>Maneuver</td><td>Green RND circles</td><td><input name="rankManeuverGreen" type="number" min="0" step="0.1" value="0.5" /></td></tr>
-              <tr><td>Maneuver</td><td>Red RND circles</td><td><input name="rankManeuverRed" type="number" min="0" step="0.1" value="0.45" /></td></tr>
-              <tr><td>Maneuver</td><td>TURN profile</td><td><input name="rankManeuverTurnProfile" type="number" min="0" step="0.1" value="0.35" /></td></tr>
-              <tr><td>Maneuver</td><td>DMG stop profile</td><td><input name="rankManeuverDmgStops" type="number" min="0" step="0.1" value="0.55" /></td></tr>
-              <tr><td>Systems/Crew</td><td>Systems values</td><td><input name="rankSystemsValues" type="number" min="0" step="0.1" value="0.55" /></td></tr>
-              <tr><td>Systems/Crew</td><td>System breadth</td><td><input name="rankSystemsBreadth" type="number" min="0" step="0.1" value="0.45" /></td></tr>
-              <tr><td>Systems/Crew</td><td>Shuttle craft</td><td><input name="rankCrewShuttle" type="number" min="0" step="0.1" value="0.6" /></td></tr>
-              <tr><td>Systems/Crew</td><td>Marines stationed</td><td><input name="rankCrewMarines" type="number" min="0" step="0.1" value="0.45" /></td></tr>
-              <tr><td>Power</td><td>Track points</td><td><input name="rankPowerPoints" type="number" min="0" step="0.1" value="0.5" /></td></tr>
-              <tr><td>Power</td><td>Boxes per point</td><td><input name="rankPowerBoxes" type="number" min="0" step="0.1" value="0.45" /></td></tr>
-              <tr><td>Power</td><td>Reserve flexibility</td><td><input name="rankPowerReserve" type="number" min="0" step="0.1" value="0.5" /></td></tr>
-              <tr><td>Power</td><td>Track pattern</td><td><input name="rankPowerPattern" type="number" min="0" step="0.1" value="0.4" /></td></tr>
-              <tr><td>Functions</td><td>Function values</td><td><input name="rankFunctionsValues" type="number" min="0" step="0.1" value="0.65" /></td></tr>
-              <tr><td>Functions</td><td>Free functions</td><td><input name="rankFunctionsFree" type="number" min="0" step="0.1" value="0.6" /></td></tr>
-              <tr><td>Functions</td><td>Emergency/Enabled bonus</td><td><input name="rankFunctionsState" type="number" min="0" step="0.1" value="0.6" /></td></tr>
-              <tr><td>Functions</td><td>FTL/Cloak support</td><td><input name="rankFunctionsTrackSupport" type="number" min="0" step="0.1" value="0.7" /></td></tr>
-              <tr><td>Weapons</td><td>Range bands & dice</td><td><input name="rankWeaponsRange" type="number" min="0" step="0.1" value="0.42" /></td></tr>
-              <tr><td>Weapons</td><td>Power circles/stops</td><td><input name="rankWeaponsPower" type="number" min="0" step="0.1" value="0.5" /></td></tr>
-              <tr><td>Weapons</td><td>Structure</td><td><input name="rankWeaponsStructure" type="number" min="0" step="0.1" value="0.45" /></td></tr>
-              <tr><td>Weapons</td><td>Traits/Special</td><td><input name="rankWeaponsTraitsSpecial" type="number" min="0" step="0.1" value="0.6" /></td></tr>
-              <tr><td>Weapons</td><td>Mount scaling & arcs</td><td><input name="rankWeaponsMountArc" type="number" min="0" step="0.1" value="0.4" /></td></tr>
-              <tr><td>Final</td><td>Global PV scale</td><td><input name="rankGlobalScale" type="number" min="0" step="0.1" value="0.25" /></td></tr>
-            </tbody>
-          </table>
-        </div>
-
         <div class="row row-pv-controls">
           <label>Point Value (Auto) <input name="pointValueCalculated" value="29" readonly /></label>
           <button type="button" class="update-pv-btn">Update PV</button>


### PR DESCRIPTION
### Motivation
- Prevent runtime changes to PV weighting by locking the Point Value (PV) ranking baseline so costing always uses the agreed constants. 
- Remove the developer-only PV Rank Weights editor from the builder UI to avoid accidental edits. 
- Reorder the builder panels so the form follows the finalized layout sequence for easier use and consistency.

### Description
- Set the baseline `PV_RANKING_DEFAULTS` in `starforce-commander-ship-designer/app.js` (notably `rankIdentityFields: 0` and `rankGlobalScale: 0.2`) so those values are fixed. 
- Changed `readPvRankings()` to return the constant baseline (`{ ...PV_RANKING_DEFAULTS }`) instead of reading form inputs. 
- Removed the PV Rank Weights table and its inputs from `starforce-commander-ship-designer/index.html` and adjusted the form section order to: Identity → Engineering → Structure → Functions/Power/Maneuvering → Weapons → Shields → Systems → Point Value (Auto) → Import/Export. 
- Stopped restoring/prefilling removed PV rank inputs in `restoreDraft()` so drafts no longer try to populate non-existent controls.

### Testing
- Ran `node --check starforce-commander-ship-designer/app.js` and it completed successfully. 
- Ran `node --check starforce-commander-ship-designer/pv-calculator.js` and it completed successfully. 
- Verified removal of PV rank input fields with a repository search (`rg -n "rank[A-Z]|PV Rank"`) and confirmed the UI no longer contains editable PV weights. 
- Attempted an automated Playwright screenshot to visually verify layout but Chromium crashed in this environment (SIGSEGV), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e829287c8332ac7d47795249c8f6)