### PR TITLE
Add 'World Mapper' deterministic RPG region generator (self-contained web app)

### DIFF
--- a/World Mapper/README.md
+++ b/World Mapper/README.md
@@ -1,0 +1,29 @@
+# World Mapper
+
+A self-contained HTML/CSS/JS app for deterministic RPG campaign region generation.
+
+## Project Location
+This project now lives in the `World Mapper/` folder.
+
+## Tables
+This version uses bundled table data from `sample-data.csv` (loaded automatically on page load).
+CSV upload controls were intentionally removed so we can pivot to first-party in-app tables.
+
+## Active Schema (bundled table source)
+- `ID,Category,Label,DistrictRange,DistrictType,D6Roll,TypesPOI,MechanicalEffect,Tags,FollowUps,Persistence`
+- Mixed Travel/Realm rows are detected by `Category` (`TravelEvent` / `RealmTrait`) and mapped into:
+  - `ID,Category,Label,TriggerRange,MechanicalEffect,FictionText,Tags,FollowUps,Persistence`
+
+## Generator Flow
+1. Load bundled table file and validate required columns.
+2. Seed deterministic PRNG from seed string.
+3. Generate districts (size 1–8):
+   - Pick place matching `DistrictRange` (fallback random if no match).
+   - Generate 1–3 POIs and at least one NPC.
+4. Generate NPCs using d100 race rarity/race, class, and motivation tables plus d6 attitude.
+5. Resolve follow-ups by row ID or label; skip gracefully if missing.
+6. Render map/detail panels, tag filters, and logs.
+7. Export full JSON and persist notes/persistent flags in localStorage.
+
+## Reproducibility
+Same **seed + region size + bundled table data** => identical exported JSON.

--- a/World Mapper/app.js
+++ b/World Mapper/app.js
@@ -1,0 +1,480 @@
+/*
+Quick README:
+- Parse bundled Place/Shop + Travel/Realm tables (from local sample file) with schema checks.
+- Use seeded RNG + dice roller for deterministic generation.
+- Build region districts with place selection, POIs, NPC contacts, quest hooks, follow-ups.
+- Render map/detail/filter/log UI and support JSON export + localStorage notes/persistence.
+*/
+
+const PLACE_COLUMNS = ["ID", "Category", "Label", "DistrictRange", "DistrictType", "D6Roll", "TypesPOI", "MechanicalEffect", "Tags", "FollowUps", "Persistence"];
+const TRAVEL_COLUMNS = ["ID", "Category", "Label", "TriggerRange", "MechanicalEffect", "FictionText", "Tags", "FollowUps", "Persistence"];
+
+const TOKEN_ALIASES = {
+  vilage: "village", distrects: "districts", distrect: "district", distrecttype: "districttype",
+  militaristic: "militaristic", milteristic: "militaristic", religios: "religious", anchint: "ancient",
+  industrual: "industrial", universty: "university", warhouse: "warehouse", luxery: "luxury",
+  theves: "thieves", merchents: "merchants", explores: "explorers", knowlage: "knowledge",
+  relec: "relic", "seat of power": "seat of power", seatofpower: "seat of power"
+};
+
+const state = {
+  placeRows: [], travelRows: [], followUpIndex: new Map(),
+  region: null, selectedDistrictId: null, selectedTags: new Set(), logs: [],
+  notes: {}, persistentOverrides: {}
+};
+
+const els = {
+  seedInput: document.getElementById("seedInput"),
+  sizeInput: document.getElementById("sizeInput"),
+  generateBtn: document.getElementById("generateBtn"),
+  randomSeedBtn: document.getElementById("randomSeedBtn"),
+  mapCanvas: document.getElementById("mapCanvas"),
+  detailContent: document.getElementById("detailContent"),
+  tagFilters: document.getElementById("tagFilters"),
+  logList: document.getElementById("logList"),
+  exportBtn: document.getElementById("exportBtn"),
+  exportModal: document.getElementById("exportModal"),
+  exportText: document.getElementById("exportText"),
+  copyExportBtn: document.getElementById("copyExportBtn"),
+  downloadExportBtn: document.getElementById("downloadExportBtn"),
+};
+
+const log = (msg) => { state.logs.push(`${new Date().toLocaleTimeString()} — ${msg}`); renderLogs(); };
+const nTok = (s) => {
+  const t = String(s || "").trim().toLowerCase();
+  return TOKEN_ALIASES[t] || t;
+};
+const listField = (v) => String(v || "").split(/[;,]/).map((x) => nTok(x)).filter(Boolean);
+
+function parseRange(s) {
+  const m = String(s || "").trim().match(/^(\d+)\s*(?:-\s*(\d+))?$/);
+  if (!m) return null;
+  const min = Number(m[1]);
+  const max = Number(m[2] || m[1]);
+  return { min, max };
+}
+
+function hashSeed(seed) {
+  let h = 1779033703 ^ seed.length;
+  for (let i = 0; i < seed.length; i++) { h = Math.imul(h ^ seed.charCodeAt(i), 3432918353); h = (h << 13) | (h >>> 19); }
+  h = Math.imul(h ^ (h >>> 16), 2246822507);
+  h = Math.imul(h ^ (h >>> 13), 3266489909);
+  return (h ^= h >>> 16) >>> 0;
+}
+function mulberry32(a) { return () => { let t = (a += 0x6d2b79f5); t = Math.imul(t ^ (t >>> 15), t | 1); t ^= t + Math.imul(t ^ (t >>> 7), t | 61); return ((t ^ (t >>> 14)) >>> 0) / 4294967296; }; }
+function createRng(seed) {
+  const rand = mulberry32(hashSeed(seed));
+  return { int: (min, max) => Math.floor(rand() * (max - min + 1)) + min, pick: (arr) => arr[Math.floor(rand() * arr.length)] };
+}
+function rollDice(notation, rng) {
+  const m = String(notation).toLowerCase().trim().match(/^(\d*)d(\d+)$/);
+  if (!m) throw new Error(`Invalid dice notation: ${notation}`);
+  const count = Number(m[1] || 1), sides = Number(m[2]);
+  let total = 0;
+  for (let i = 0; i < count; i++) total += rng.int(1, sides);
+  return total;
+}
+
+function parseCSV(text) {
+  const rows = [];
+  let i = 0, inQuotes = false, field = "", row = [];
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '"') {
+      if (inQuotes && text[i + 1] === '"') { field += '"'; i++; }
+      else inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) { row.push(field); field = ""; }
+    else if ((ch === '\n' || ch === '\r') && !inQuotes) {
+      if (ch === '\r' && text[i + 1] === '\n') i++;
+      row.push(field); field = "";
+      if (row.some((c) => c.trim() !== "")) rows.push(row);
+      row = [];
+    } else field += ch;
+    i++;
+  }
+  row.push(field);
+  if (row.some((c) => c.trim() !== "")) rows.push(row);
+  if (!rows.length) throw new Error("CSV is empty.");
+  const headers = rows[0].map((h) => h.trim());
+  const data = rows.slice(1).map((r) => {
+    const obj = {}; headers.forEach((h, idx) => { obj[h] = (r[idx] || "").trim(); }); return obj;
+  });
+  return { headers, data };
+}
+
+function requireColumns(headers, required, label) {
+  const missing = required.filter((c) => !headers.includes(c));
+  if (missing.length) throw new Error(`${label} CSV missing columns: ${missing.join(", ")}`);
+}
+
+function setRows(placeRows, travelRows) {
+  state.placeRows = placeRows;
+  state.travelRows = travelRows;
+  if (!state.placeRows.length) throw new Error("No Place/Shop rows loaded.");
+  state.followUpIndex = new Map();
+  [...state.placeRows, ...state.travelRows].forEach((r) => state.followUpIndex.set(r.ID, r));
+  log(`Loaded ${state.placeRows.length} place/shop rows and ${state.travelRows.length} travel/realm rows.`);
+}
+
+function parseMixedSampleRows(rows) {
+  const placeRows = rows.filter((r) => /meetingplace|shop/i.test(r.Category || ""));
+  const travelRows = rows
+    .filter((r) => /travelevent|realmtrait/i.test(r.Category || ""))
+    .map((r) => ({
+      ID: r.ID, Category: r.Category, Label: r.Label,
+      TriggerRange: r.DistrictRange,
+      MechanicalEffect: r.DistrictType,
+      FictionText: r.D6Roll,
+      Tags: r.TypesPOI,
+      FollowUps: r.MechanicalEffect,
+      Persistence: r.Tags || "no"
+    }));
+  return { placeRows, travelRows };
+}
+
+function districtMatch(place, idx) {
+  const r = parseRange(place.DistrictRange);
+  return !!r && idx >= r.min && idx <= r.max;
+}
+
+
+function rollD100(rng) { return rollDice("d100", rng); }
+
+function pickFromRangeTable(roll, table, fallback = "Unknown") {
+  const hit = table.find((entry) => roll >= entry.min && roll <= entry.max);
+  return hit ? hit.value : fallback;
+}
+
+const NPC_RACE_TABLE = {
+  rarity: [
+    { min: 1, max: 50, value: "Common" },
+    { min: 51, max: 80, value: "Uncommon" },
+    { min: 81, max: 100, value: "Rare" },
+  ],
+  common: [
+    { min: 1, max: 30, value: "Human" },
+    { min: 31, max: 50, value: "Elf" },
+    { min: 51, max: 70, value: "Dwarf" },
+    { min: 71, max: 80, value: "Half-Orc" },
+    { min: 81, max: 90, value: "Halfling" },
+    { min: 91, max: 100, value: "Dragonborn" },
+  ],
+  uncommon: [
+    { min: 1, max: 20, value: "Gnome" },
+    { min: 21, max: 40, value: "Tiefling" },
+    { min: 41, max: 60, value: "Half-Elf" },
+    { min: 61, max: 65, value: "Fairy Folk" },
+    { min: 66, max: 75, value: "Goblin" },
+    { min: 76, max: 90, value: "Tabaxi" },
+    { min: 91, max: 100, value: "Triton" },
+  ],
+  rare: [
+    { min: 1, max: 20, value: "Tortle" },
+    { min: 21, max: 40, value: "Warforged" },
+    { min: 41, max: 60, value: "Centaur" },
+    { min: 61, max: 80, value: "Minotaur" },
+    { min: 81, max: 100, value: "Changeling" },
+  ],
+};
+
+const NPC_CLASS_TABLE = [
+  { min: 1, max: 10, value: "Fighter" },
+  { min: 11, max: 20, value: "Ranger" },
+  { min: 21, max: 30, value: "Rogue" },
+  { min: 31, max: 40, value: "Wizard" },
+  { min: 41, max: 50, value: "Cleric" },
+  { min: 51, max: 55, value: "Barbarian" },
+  { min: 56, max: 60, value: "Bard" },
+  { min: 61, max: 70, value: "Monk" },
+  { min: 71, max: 80, value: "Druid" },
+  { min: 81, max: 85, value: "Warlock" },
+  { min: 86, max: 90, value: "Sorcerer" },
+  { min: 91, max: 95, value: "Artificer" },
+  { min: 96, max: 100, value: "Gunslinger" },
+];
+
+const NPC_MOTIVATION_TABLE = [
+  { min: 1, max: 9, value: "Wealth" },
+  { min: 10, max: 18, value: "Fame" },
+  { min: 19, max: 27, value: "Glory" },
+  { min: 28, max: 38, value: "Adventure" },
+  { min: 39, max: 46, value: "Truth" },
+  { min: 47, max: 54, value: "Knowledge" },
+  { min: 55, max: 60, value: "Revenge" },
+  { min: 61, max: 65, value: "Romance" },
+  { min: 66, max: 75, value: "Power" },
+  { min: 76, max: 84, value: "Freedom" },
+  { min: 85, max: 92, value: "Order" },
+  { min: 93, max: 100, value: "Escape" },
+];
+
+function generateNpcRace(rng) {
+  const rarityRoll = rollD100(rng);
+  const rarity = pickFromRangeTable(rarityRoll, NPC_RACE_TABLE.rarity, "Common");
+  const raceRoll = rollD100(rng);
+  const racePool = rarity.toLowerCase() === "common" ? NPC_RACE_TABLE.common
+    : (rarity.toLowerCase() === "uncommon" ? NPC_RACE_TABLE.uncommon : NPC_RACE_TABLE.rare);
+  const race = pickFromRangeTable(raceRoll, racePool, "Human");
+  return { rarity, rarityRoll, raceRoll, race };
+}
+
+function attitude(roll) {
+  const table = {
+    1: ["Hostile", "Demands payment before cooperation."], 2: ["Wary", "Needs proof before helping."],
+    3: ["Neutral", "Shares only basic info."], 4: ["Open", "Will trade a favor for a favor."],
+    5: ["Helpful", "Offers useful lead or resource."], 6: ["Friendly", "Offers direct help and advocacy."]
+  };
+  return { label: table[roll][0], effect: table[roll][1] };
+}
+
+function makeNPC(dId, place, rng) {
+  const names = ["Ari", "Thorne", "Mara", "Brigg", "Sel", "Jun", "Kest", "Rook"];
+  const quirks = ["speaks in proverbs", "never removes gloves", "collects broken keys", "keeps coded notes"];
+
+  const raceMeta = generateNpcRace(rng);
+  const classRoll = rollD100(rng);
+  const npcClass = pickFromRangeTable(classRoll, NPC_CLASS_TABLE, "Fighter");
+  const motivationRoll = rollD100(rng);
+  const motivation = pickFromRangeTable(motivationRoll, NPC_MOTIVATION_TABLE, "Adventure");
+
+  const attitudeRoll = rollDice("d6", rng);
+  return {
+    id: `NPC-${dId}-${rng.int(100, 999)}`,
+    name: rng.pick(names),
+    role: `${raceMeta.race} ${npcClass}`,
+    race: raceMeta.race,
+    raceRarity: raceMeta.rarity,
+    raceRolls: { rarityRoll: raceMeta.rarityRoll, raceRoll: raceMeta.raceRoll },
+    class: npcClass,
+    classRoll,
+    motivation,
+    motivationRoll,
+    attitudeRoll,
+    attitude: attitude(attitudeRoll),
+    goal: `${motivation.toLowerCase()}-driven objective near ${place.Label}`,
+    quirk: rng.pick(quirks),
+    contactTag: rng.pick(place.tags.length ? place.tags : ["local"])
+  };
+}
+
+function makeHook(place, npc, rng) {
+  const tag = rng.pick(place.tags.length ? place.tags : ["frontier"]);
+  const objective = rng.pick([
+    `Investigate escalating trouble around ${place.Label}`,
+    `Escort a team through the ${place.Label} district`,
+    `Retrieve evidence hidden near ${place.Label}`
+  ]);
+  const complication = rng.pick([
+    `${tag} hazards worsen every dusk`,
+    `a rival faction shadows ${npc.name}`,
+    `a local pact tied to ${place.Label} is collapsing`
+  ]);
+  const rewardHint = rng.pick(["favor with local powers", "access to restricted records", "payment plus a relic lead"]);
+  const urgency = Math.min(5, Math.ceil(rollDice("d6", rng) / 1.2));
+  return { objective, complication, rewardHint, urgency };
+}
+
+function enqueueFollowUps(entity, queue, rng) {
+  listField(entity.FollowUps).forEach((f) => queue.push({ name: f, source: entity.ID, roll: rollDice("d6", rng) }));
+}
+function resolveFollowUps(queue) {
+  while (queue.length) {
+    const item = queue.shift();
+    const found = [...state.followUpIndex.values()].find((r) => nTok(r.ID) === item.name || nTok(r.Label) === item.name);
+    if (found) log(`Resolved follow-up "${item.name}" from ${item.source} -> ${found.ID}.`);
+    else log(`Skipped follow-up "${item.name}" from ${item.source}: missing table row.`);
+  }
+}
+
+function buildRegion(seed, size) {
+  const rng = createRng(seed);
+  const queue = [];
+  const districts = [];
+
+  for (let i = 1; i <= size; i++) {
+    const matches = state.placeRows.filter((p) => districtMatch(p, i));
+    const place = matches.length ? rng.pick(matches) : rng.pick(state.placeRows);
+    if (!matches.length) log(`District ${i}: no DistrictRange match, fallback random place used.`);
+
+    const placeTags = listField(place.Tags);
+    const poiBase = listField(place.TypesPOI);
+    const poiCount = rng.int(1, 3);
+    const pois = Array.from({ length: poiCount }, (_, pIdx) => ({
+      id: `POI-${i}-${pIdx + 1}`,
+      type: poiBase.length ? rng.pick(poiBase) : "unknown",
+      summary: `${place.Label} point ${pIdx + 1}`,
+      tags: placeTags
+    }));
+
+    const npc = makeNPC(i, { ...place, tags: placeTags }, rng);
+    const questHook = makeHook({ ...place, tags: placeTags }, npc, rng);
+    const persistent = state.persistentOverrides[place.ID] ?? (nTok(place.Persistence) === "yes");
+
+    districts.push({
+      districtId: i,
+      place: { ...place, tags: placeTags, persistent },
+      pois,
+      npcs: [npc],
+      questHook,
+      note: state.notes[`district-${i}`] || ""
+    });
+
+    enqueueFollowUps(place, queue, rng);
+  }
+
+  const travel = state.travelRows.length ? rng.pick(state.travelRows) : null;
+  if (travel) enqueueFollowUps(travel, queue, rng);
+  resolveFollowUps(queue);
+
+  return {
+    seed,
+    settings: { regionSize: size },
+    travelHint: travel ? {
+      ...travel,
+      tags: listField(travel.Tags),
+      suggestions: districts.filter((d) => d.place.tags.some((t) => listField(travel.Tags).includes(t))).map((d) => ({ districtId: d.districtId, placeId: d.place.ID, label: d.place.Label }))
+    } : null,
+    districts
+  };
+}
+
+function renderLogs() { els.logList.innerHTML = state.logs.map((x) => `<li>${x}</li>`).join(""); }
+
+function renderMap() {
+  els.mapCanvas.innerHTML = "";
+  if (!state.region) return;
+
+  state.region.districts.forEach((d) => {
+    const b = document.createElement("button");
+    b.className = "tile";
+    if (d.districtId === state.selectedDistrictId) b.classList.add("selected");
+    if (d.place.persistent) b.classList.add("persistent");
+
+    const tagHit = state.selectedTags.size && [...state.selectedTags].some((t) => d.place.tags.includes(t) || d.pois.some((p) => p.tags.includes(t) || p.type.includes(t)) || d.npcs.some((n) => n.contactTag === t));
+    if (tagHit) b.classList.add("highlight");
+
+    b.innerHTML = `<span class="idx">District ${d.districtId}</span>${d.place.Label}${d.place.persistent ? ' <span class="persistent-badge">★</span>' : ''}`;
+    b.addEventListener("click", () => { state.selectedDistrictId = d.districtId; renderMap(); renderDetail(); });
+    els.mapCanvas.appendChild(b);
+  });
+}
+
+function renderDetail() {
+  const d = state.region?.districts.find((x) => x.districtId === state.selectedDistrictId);
+  if (!d) { els.detailContent.innerHTML = "<p>Select a district to view details.</p>"; return; }
+
+  const visiblePois = d.pois.filter((p) => !state.selectedTags.size || [...state.selectedTags].some((t) => p.tags.includes(t) || p.type.includes(t)));
+  const hint = state.region.travelHint
+    ? `<p class="suggestion">Travel/Realm hint <strong>${state.region.travelHint.Label}</strong>: matching districts ${state.region.travelHint.suggestions.map((s) => s.districtId).join(", ") || "none"}.</p>`
+    : "";
+
+  els.detailContent.innerHTML = `
+    <div class="card">
+      <h3>${d.place.Label} ${d.place.persistent ? '<span class="persistent-badge">★ persistent</span>' : ''}</h3>
+      <p>${d.place.MechanicalEffect}</p>
+      <p><strong>Tags:</strong> ${d.place.tags.join(", ") || "none"}</p>
+      ${hint}
+    </div>
+    <div class="card"><h4>POIs (${visiblePois.length}/${d.pois.length})</h4><ul>${visiblePois.map((p) => `<li class="poi-item">${p.type} — ${p.summary}</li>`).join("")}</ul></div>
+    <div class="card"><h4>NPC Contact</h4>${d.npcs.map((n) => `<p><strong>${n.name}</strong> (${n.role}) | d6 ${n.attitudeRoll} ${n.attitude.label}: ${n.attitude.effect}<br/>Goal: ${n.goal}. Quirk: ${n.quirk}. Tag: ${n.contactTag}<br/>Race: ${n.race} (${n.raceRarity}, rolls ${n.raceRolls.rarityRoll}/${n.raceRolls.raceRoll}) | Class: ${n.class} (d100 ${n.classRoll}) | Motivation: ${n.motivation} (d100 ${n.motivationRoll})</p>`).join("")}</div>
+    <div class="card"><h4>Quest Hook</h4><p>${d.questHook.objective}; complication: ${d.questHook.complication}; reward: ${d.questHook.rewardHint}. <strong>Urgency:</strong> ${d.questHook.urgency}/5.</p></div>
+    <div class="card">
+      <div class="button-row"><button id="followUpBtn">Roll Follow-up</button><button id="persistentBtn">Mark Persistent</button></div>
+      <label for="noteInput">Add Note</label>
+      <textarea id="noteInput" rows="3" placeholder="Session note">${d.note || ""}</textarea>
+    </div>
+  `;
+
+  document.getElementById("followUpBtn").addEventListener("click", () => {
+    const rng = createRng(`${state.region.seed}-followup-${d.districtId}-${state.logs.length}`);
+    const q = []; enqueueFollowUps(d.place, q, rng); resolveFollowUps(q);
+  });
+  document.getElementById("persistentBtn").addEventListener("click", () => {
+    d.place.persistent = !d.place.persistent;
+    state.persistentOverrides[d.place.ID] = d.place.persistent;
+    persistLocal(); renderMap(); renderDetail();
+  });
+  document.getElementById("noteInput").addEventListener("input", (e) => {
+    d.note = e.target.value; state.notes[`district-${d.districtId}`] = d.note; persistLocal();
+  });
+}
+
+function renderTagFilters() {
+  const tags = new Set();
+  state.region?.districts.forEach((d) => {
+    d.place.tags.forEach((t) => tags.add(t));
+    d.pois.forEach((p) => p.tags.forEach((t) => tags.add(t)));
+    d.npcs.forEach((n) => tags.add(n.contactTag));
+  });
+  els.tagFilters.innerHTML = "";
+  [...tags].sort().forEach((tag) => {
+    const b = document.createElement("button");
+    b.className = `tag-chip${state.selectedTags.has(tag) ? " active" : ""}`;
+    b.textContent = tag;
+    b.addEventListener("click", () => {
+      if (state.selectedTags.has(tag)) state.selectedTags.delete(tag); else state.selectedTags.add(tag);
+      renderTagFilters(); renderMap(); renderDetail();
+    });
+    els.tagFilters.appendChild(b);
+  });
+}
+
+function persistLocal() {
+  localStorage.setItem("rpg-region-notes", JSON.stringify(state.notes));
+  localStorage.setItem("rpg-region-persistent", JSON.stringify(state.persistentOverrides));
+}
+function loadLocal() {
+  state.notes = JSON.parse(localStorage.getItem("rpg-region-notes") || "{}");
+  state.persistentOverrides = JSON.parse(localStorage.getItem("rpg-region-persistent") || "{}");
+}
+
+function exportRegion() {
+  if (!state.region) return;
+  els.exportText.value = JSON.stringify(state.region, null, 2);
+  els.exportModal.showModal();
+}
+
+
+els.generateBtn.addEventListener("click", () => {
+  try {
+    if (!state.placeRows.length) throw new Error("Bundled tables are not loaded yet.");
+
+    state.logs = [];
+    const seed = els.seedInput.value.trim() || "default-seed";
+    const size = Math.min(8, Math.max(1, Number(els.sizeInput.value || 6)));
+    state.region = buildRegion(seed, size);
+    state.selectedDistrictId = 1;
+    renderTagFilters(); renderMap(); renderDetail();
+    log(`Generated region with seed="${seed}" and size=${size}.`);
+  } catch (e) {
+    log(`Generation error: ${e.message}`);
+  }
+});
+
+els.randomSeedBtn.addEventListener("click", () => { els.seedInput.value = `seed-${Math.random().toString(36).slice(2, 10)}`; });
+els.exportBtn.addEventListener("click", exportRegion);
+els.copyExportBtn.addEventListener("click", async () => { await navigator.clipboard.writeText(els.exportText.value); log("Copied exported JSON to clipboard."); });
+els.downloadExportBtn.addEventListener("click", () => {
+  const blob = new Blob([els.exportText.value], { type: "application/json" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = `region-${state.region.seed}.json`;
+  a.click();
+  URL.revokeObjectURL(a.href);
+});
+
+async function bootstrapTables() {
+  try {
+    const sampleText = await (await fetch("sample-data.csv")).text();
+    const parsed = parseCSV(sampleText);
+    requireColumns(parsed.headers, PLACE_COLUMNS, "Sample");
+    const mixed = parseMixedSampleRows(parsed.data);
+    setRows(mixed.placeRows, mixed.travelRows);
+    log("Bundled tables loaded. Ready to generate.");
+  } catch (e) {
+    log(`Bootstrap error: ${e.message}`);
+  }
+}
+
+loadLocal();
+bootstrapTables();

--- a/World Mapper/index.html
+++ b/World Mapper/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>RPG Campaign Region Generator</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <h1>RPG Region & POI Generator</h1>
+    <p>Deterministic campaign generator for districts, POIs, NPCs, quest hooks, and follow-ups.</p>
+  </header>
+
+  <main class="layout">
+    <section class="panel map-panel" aria-label="Map canvas">
+      <h2>Map Canvas</h2>
+      <p class="help">Click a district tile to inspect details.</p>
+      <div id="mapCanvas" class="map-canvas" role="grid" aria-label="District map"></div>
+    </section>
+
+    <section class="panel detail-panel" aria-live="polite" aria-label="Detail panel">
+      <h2>Detail Panel</h2>
+      <div id="detailContent" class="detail-content">
+        <p>Select a district to view Place, POIs, NPC contact, and quest hook.</p>
+      </div>
+    </section>
+
+    <section class="panel controls-panel" aria-label="Controls and logs">
+      <h2>Controls & Logs</h2>
+
+      <label for="seedInput" title="Same seed + region size + CSV data = same output.">Seed</label>
+      <div class="inline-row">
+        <input id="seedInput" type="text" value="mistwatch-001" />
+        <button id="randomSeedBtn" title="Create a random seed value">Randomize</button>
+      </div>
+
+      <label for="sizeInput" title="How many districts to create">Region Size (1–8)</label>
+      <input id="sizeInput" type="number" min="1" max="8" value="6" />
+
+      <h3>Tables</h3>
+      <p class="help">This build uses bundled world tables based on your shared format (no CSV upload).</p>
+      <button id="generateBtn" title="Generate deterministic region">Generate Region</button>
+
+      <h3>Tag Filter</h3>
+      <p class="help">Click tags to highlight matching Places/POIs/NPCs and narrow POIs.</p>
+      <div id="tagFilters" class="tag-filters"></div>
+
+      <div class="button-row">
+        <button id="exportBtn" title="Export full region JSON">Export Region</button>
+      </div>
+
+      <h3>Generator Log</h3>
+      <ol id="logList" class="log-list"></ol>
+    </section>
+  </main>
+
+  <dialog id="exportModal">
+    <form method="dialog" class="modal-content">
+      <h3>Exported Region JSON</h3>
+      <textarea id="exportText" rows="14"></textarea>
+      <div class="button-row">
+        <button id="copyExportBtn" type="button">Copy to Clipboard</button>
+        <button id="downloadExportBtn" type="button">Download JSON</button>
+        <button type="submit">Close</button>
+      </div>
+    </form>
+  </dialog>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/World Mapper/sample-data.csv
+++ b/World Mapper/sample-data.csv
@@ -1,0 +1,13 @@
+ID,Category,Label,DistrictRange,DistrictType,D6Roll,TypesPOI,MechanicalEffect,Tags,FollowUps,Persistence
+PL-ML1,MeetingPlace,Magic Library,1-4,Village,1,"Farming;Trade;University;Guild HQ;Docks","Source of lore; +1 to research rolls; may host an Archivist NPC","library;university;docks","RumorTable;NPC-Archivist",yes
+PL-TV1,MeetingPlace,Tavern,1-3,Civilized,2,"Social hub;Rumor source;Lodging","Primary rumor source; hire mercs; low-cost lodging","tavern;rumor;lodging","HireTable;RumorTable",no
+PL-CS1,MeetingPlace,Coffee Shop,5-7,Town,3,"Trade;Shops;Seat of Power;Docks","Social hub; roll D6 for rumor quality; low-cost intel","social;trade;rumor","RumorTable;NPC-Fixer",no
+PL-SC1,MeetingPlace,School,8-9,City,5,"Housing;Factory;Fortress;Warehouse","Training site; offers a short training job (gain 1 XP)","education;training","TrainingTable;NPC-Teacher",no
+PL-TP1,MeetingPlace,Temple,10,Huge City,7,"Manner;Guilds;Temple;Trade","Place of sanctuary; healing services available; may host a quest","religion;healing","QuestTable;NPC-Priest",yes
+PL-MU1,MeetingPlace,Museum,11-12,Port,2,"Tower;Mansion;Historic;Bank","Historic artifacts; rumor seed about lost relic; hire a guide","history;relics","RumorTable;NPC-Curator",no
+PL-HH1,MeetingPlace,Hall of Heroes,1-4,City,4,"Historic;Heroes Home;Battle Site","Ceremony site; reputation gain for heroic acts","heroic;reputation","FactionTable;QuestTable",yes
+PL-CV1,MeetingPlace,Cave,7-8,Isolated,6,"Trade;Goods;Luxury;Magic","Hidden POI; good for secret meetings or smuggling","cave;secret","SmuggleTable;EncounterTable",no
+SH-MM1,Shop,Mini Market,14-15,Frontier,1,"Basic goods;Food;Local trade","Cheap supplies; barter possible; hire local courier","market;frontier","TradeTable",no
+SH-AL1,Shop,Alchemy,18,Ancient,4,"Factory;Goods;Steel;Weapons;Magic","Crafting services; can convert reagents into items","alchemy;craft","CraftTable;RepairTable",no
+TE-04,TravelEvent,Ghost Ship,18-25,"Gain 2 LootTable rolls","An ancient ship drifts in the warp; salvage what you can.","salvage;ship;relics","LootTable",no
+RT-01,RealmTrait,Mist Covered,1-3,"-1 to ranged sight checks; +tag fog","Low, clinging mists hide the streets and docks.","fog;visibility",no

--- a/World Mapper/styles.css
+++ b/World Mapper/styles.css
@@ -1,0 +1,114 @@
+:root {
+  --bg: #0f1420;
+  --panel: #1a2333;
+  --panel-2: #202c40;
+  --text: #eaf1ff;
+  --accent: #7dd3fc;
+  --muted: #9fb3cc;
+  --persistent: #f59e0b;
+  --highlight: #34d399;
+  --danger: #fb7185;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.topbar {
+  padding: 1rem;
+  background: #111827;
+  border-bottom: 1px solid #334155;
+}
+.topbar h1 { margin: 0 0 0.3rem; }
+.topbar p { margin: 0; color: var(--muted); }
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr 0.9fr;
+  gap: 0.9rem;
+  padding: 0.9rem;
+}
+.panel {
+  background: var(--panel);
+  border: 1px solid #334155;
+  border-radius: 10px;
+  padding: 0.8rem;
+  min-height: 70vh;
+}
+
+.map-canvas {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+.tile {
+  border: 1px solid #475569;
+  border-radius: 8px;
+  background: var(--panel-2);
+  color: var(--text);
+  text-align: left;
+  padding: 0.5rem;
+  min-height: 90px;
+  cursor: pointer;
+}
+.tile.selected { outline: 2px solid var(--accent); }
+.tile.persistent { border-color: var(--persistent); }
+.tile.highlight { box-shadow: 0 0 0 2px var(--highlight) inset; }
+.tile .idx { color: var(--accent); font-weight: bold; display: block; }
+
+.help { color: var(--muted); font-size: 0.9rem; }
+.inline-row, .button-row { display: flex; gap: 0.5rem; }
+input, button, textarea {
+  width: 100%;
+  background: #0b1220;
+  color: var(--text);
+  border: 1px solid #475569;
+  border-radius: 6px;
+  padding: 0.45rem;
+}
+button { cursor: pointer; }
+
+.tag-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.6rem;
+}
+.tag-chip {
+  border: 1px solid #64748b;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+  background: #0f172a;
+  font-size: 0.82rem;
+}
+.tag-chip.active { border-color: var(--highlight); color: var(--highlight); }
+
+.card {
+  background: #111827;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 0.55rem;
+  margin-bottom: 0.45rem;
+}
+.poi-item.hidden-by-filter { display: none; }
+.persistent-badge { color: var(--persistent); font-weight: bold; }
+.suggestion { color: var(--highlight); }
+.error { color: var(--danger); }
+.log-list { font-size: 0.88rem; padding-left: 1.2rem; }
+
+dialog {
+  border: 1px solid #334155;
+  border-radius: 10px;
+  width: min(900px, 95vw);
+  background: #0f172a;
+  color: var(--text);
+}
+
+@media (max-width: 980px) {
+  .layout { grid-template-columns: 1fr; }
+  .panel { min-height: auto; }
+}


### PR DESCRIPTION
### Motivation

- Provide a self-contained HTML/CSS/JS app for deterministic RPG campaign region generation using bundled first-party tables instead of CSV upload.
- Offer a reproducible generator (seed + region size + bundled data) that builds districts, POIs, NPCs, quest hooks and resolves follow-ups.

### Description

- Add a new `World Mapper/` app including `index.html`, `styles.css`, `app.js`, `sample-data.csv`, and `README.md` implementing the UI and generation logic. 
- Implement CSV parsing, schema checks, token aliasing, seeded RNG (`hashSeed` + `mulberry32`), dice roller, and mixed table mapping from the bundled sample CSV. 
- Implement deterministic region building with district matching, POI and NPC generation (race/class/motivation/attitude tables), quest hooks, follow-up enqueue/resolve, tag filtering, persistence via `localStorage`, and JSON export. 
- Add UI controls for seed/size, tag filters, logs, export modal, and interactivity for marking persistent places and adding notes.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3a0fbed7483329acbc05c0fc5ea6b)