### PR TITLE
Tune structure valuation in PV baseline

### DIFF
--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -132,8 +132,10 @@ const PV_RANKING_BASELINE = {
   rankEngineeringSpecial: 0.75,
   rankDefenseShields: 0.42,
   rankDefenseArmor: 0.4,
-  rankDefenseRepairable: 0.3,
-  rankDefensePermanent: 0.28,
+  // Structure durability was underpriced during battleship tuning passes.
+  // Boost both repairable and permanent structure weights by ~3x.
+  rankDefenseRepairable: 0.9,
+  rankDefensePermanent: 0.84,
   rankDefenseShieldGen: 0.45,
   rankManeuverMaxAcc: 0.65,
   rankManeuverGreen: 0.5,


### PR DESCRIPTION
### Motivation
- The PV calculator was underpricing ship durability, so structure (repairable and permanent) should be valued higher to better reflect battleship survivability in point calculations.

### Description
- Increased `rankDefenseRepairable` from `0.3` to `0.9` and `rankDefensePermanent` from `0.28` to `0.84` in `starforce-commander-ship-designer/pv-calculator.js` and added a short inline comment noting the tuning.

### Testing
- Performed a smoke import and ran `calculatePointValue` against the Washington-class JSON; the value moved from `36` (pre-change) to `55` (post-change), demonstrating the intended uplift in defensive contribution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4493a0a608332afbd25cdfc28c8a4)