### PR TITLE
Tune PV calculator: boost structure/weapons weighting, add trait scoring, scaled mounts & hull escalation

### DIFF
--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -116,12 +116,12 @@ function mountFacingScore(weapon) {
 const SECTION_MULTIPLIERS = {
   identity: 0.4,
   engineering: 1.2,
-  defense: 1.9,
+  defense: 2.05,
   maneuvering: 1.4,
   systemsCrew: 1.0,
   powerTracks: 1.9,
   functions: 1.7,
-  weapons: 1.35
+  weapons: 2.25
 };
 
 const PV_RANKING_BASELINE = {
@@ -132,8 +132,10 @@ const PV_RANKING_BASELINE = {
   rankEngineeringSpecial: 0.75,
   rankDefenseShields: 0.42,
   rankDefenseArmor: 0.4,
-  rankDefenseRepairable: 0.3,
-  rankDefensePermanent: 0.28,
+  // Structure durability was underpriced during battleship tuning passes.
+  // Boost both repairable and permanent structure weights by ~3x.
+  rankDefenseRepairable: 0.9,
+  rankDefensePermanent: 0.84,
   rankDefenseShieldGen: 0.45,
   rankManeuverMaxAcc: 0.65,
   rankManeuverGreen: 0.5,
@@ -228,9 +230,16 @@ function scoreDefense(build) {
     * (sum([shields.forward, shields.aft, shields.port, shields.starboard]) * 0.05))
     * ((rank(build, 'rankDefenseRepairable') + rank(build, 'rankDefensePermanent')) / 2);
 
+  // Capital-hull premium: large structure pools and onboard repair scale better in long fights.
+  const capitalHullPremium = 1
+    + Math.min(0.55, Math.max(0, (totalStructure - 12) * 0.03) + (repairable * 0.05));
+
   const generatorScore = positivePart(build?.shieldGen) * 1.3 * rank(build, 'rankDefenseShieldGen');
 
-  return shieldScore + armorScore + repairableScore + permanentScore + durabilitySynergy + generatorScore;
+  return shieldScore
+    + armorScore
+    + ((repairableScore + permanentScore + durabilitySynergy) * capitalHullPremium)
+    + generatorScore;
 }
 
 function scoreManeuvering(build) {
@@ -370,8 +379,38 @@ function scoreWeaponQuality(weapon, build) {
   const powerScoreRaw = (circleAdjustment + stopDiscount) * rank(build, 'rankWeaponsPower');
   const structureScore = positivePart(weapon?.structure) * 0.35;
 
+  const traitKeywords = {
+    HVY: 1.2,
+    FTL: 1.0,
+    NOBAT: 0.85,
+    LEAK: 1.0,
+    STR: 1.0,
+    DMG: 1.1,
+    'PD MODE': 0.55
+  };
+  const traits = (Array.isArray(weapon?.traits) ? weapon.traits : [])
+    .map((trait) => String(trait || '').trim())
+    .filter(Boolean);
+  const traitKeywordScore = traits.reduce((total, trait) => {
+    const upper = trait.toUpperCase();
+    const direct = traitKeywords[upper];
+    if (Number.isFinite(direct)) {
+      return total + direct;
+    }
+    return total + 0.55;
+  }, 0);
+  const specialText = String(weapon?.special || '').trim();
+  const specialTokenCount = specialText
+    ? specialText.split(/[\s,/:;()]+/).filter(Boolean).length
+    : 0;
+  const traitsAndSpecialScore = ((traitKeywordScore * 0.65)
+    + (traits.length * 0.2)
+    + Math.min(3.25, (specialText ? 0.75 : 0) + (specialTokenCount * 0.16)))
+    * rank(build, 'rankWeaponsTraitsSpecial');
+
   const baseWeaponValue = (rangeScore * 1.35 * rank(build, 'rankWeaponsRange'))
-    + (structureScore * rank(build, 'rankWeaponsStructure'));
+    + (structureScore * rank(build, 'rankWeaponsStructure'))
+    + traitsAndSpecialScore;
 
   // Discounts can be substantial, but never reduce a mount below 50% of base value.
   const maxDiscount = baseWeaponValue * 0.5;
@@ -390,6 +429,16 @@ function effectiveMountCount(weapon) {
   return Math.min(8, rawCount);
 }
 
+function scaledMountCount(mountCount) {
+  const normalizedCount = Math.max(1, positivePart(mountCount, 1));
+  if (normalizedCount <= 1) {
+    return 1;
+  }
+
+  // Additional mounts improve coverage and redundancy, but with diminishing value.
+  return 1 + (Math.pow(normalizedCount - 1, 0.8) * 0.75);
+}
+
 function scoreWeapons(build) {
   const weapons = normalizeWeapons(build?.weapons);
   return weapons.reduce((total, weapon) => {
@@ -397,8 +446,32 @@ function scoreWeapons(build) {
     const arcWeight = 0.12 + (mountFacingScore(weapon) * rank(build, 'rankWeaponsMountArc'));
     const weaponQuality = Math.max(0, scoreWeaponQuality(weapon, build));
     const singleMountValue = weaponQuality * arcWeight;
-    return total + (singleMountValue * mountCount);
+    return total + (singleMountValue * scaledMountCount(mountCount));
   }, 0);
+}
+
+
+function hullScaleEscalation(build, contributions) {
+  const structure = build?.structure || {};
+  const structureTotal = positivePart(structure.repairable) + positivePart(structure.permanent);
+
+  const tracks = Array.isArray(build?.powerSystem?.tracks) ? build.powerSystem.tracks : [];
+  const powerPoints = sum(tracks.map((track) => positivePart(track?.points)));
+
+  const weapons = normalizeWeapons(build?.weapons);
+  const mountCoverage = sum(weapons.map((weapon) => effectiveMountCount(weapon)));
+
+  const capabilityIndex = (structureTotal * 0.06)
+    + (powerPoints * 0.05)
+    + (weapons.length * 0.4)
+    + (mountCoverage * 0.04)
+    + ((positivePart(contributions?.weapons) + positivePart(contributions?.defense)) * 0.008);
+
+  const growthBand = Math.max(0, capabilityIndex - 7.5);
+  const growth = Math.pow(growthBand, 1.15) * 0.028;
+
+  // Cap keeps escalation predictable while still separating capital builds from midline ships.
+  return 1 + Math.min(0.28, growth);
 }
 
 
@@ -414,6 +487,8 @@ export function calculatePointValue(build) {
     weapons: safeRun(() => scoreWeapons(build)) * SECTION_MULTIPLIERS.weapons
   };
 
-  const totalScore = sum(Object.values(contributions)) * rank(build, 'rankGlobalScale');
+  const baseScore = sum(Object.values(contributions)) * rank(build, 'rankGlobalScale');
+  const escalation = hullScaleEscalation(build, contributions);
+  const totalScore = baseScore * escalation;
   return Math.max(1, Math.round(totalScore));
 }


### PR DESCRIPTION
### Motivation
- Adjust point-value math to better reflect durability, long-fight scaling for capital hulls, and weapon traits/coverage that were previously underpriced.
- Introduce diminishing-return scaling for additional mounts and an overall hull-scale escalation to separate capital builds from midline ships.

### Description
- Increased section multipliers for `defense` and `weapons`, and raised `rankDefenseRepairable` and `rankDefensePermanent` to value structure more heavily during battleship tuning passes.
- Added a `capitalHullPremium` factor inside `scoreDefense` to give large structure pools and onboard repair extra value in long fights and applied it to structure-related contributions.
- Implemented per-weapon trait and special-text scoring inside `scoreWeaponQuality` by adding a `traitKeywords` map and aggregating trait/special token scores into `traitsAndSpecialScore` included in the base weapon value.
- Replaced raw mount count contribution with a `scaledMountCount` function used by `scoreWeapons` to apply diminishing returns for additional mounts.
- Added `hullScaleEscalation` to compute an overall escalation multiplier from structure, power tracks, weapon counts, mount coverage, and contributions, and applied it to the base total in `calculatePointValue`.

### Testing
- Ran the project's automated test suite with `npm test`, which completed successfully.
- Ran linting with `npm run lint`, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4493a0a608332afbd25cdfc28c8a4)