### PR TITLE
Auto-derive Size Class from Structure and rebalance point-value calculations for large hulls and weapons

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -393,6 +393,41 @@ function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
+function sizeClassFromStructure(repairable, permanent) {
+  const total = Math.max(0, Number(repairable || 0)) + Math.max(0, Number(permanent || 0));
+  if (total < 5) {
+    return 1;
+  }
+  if (total <= 8) {
+    return 2;
+  }
+  if (total <= 10) {
+    return 3;
+  }
+  if (total <= 12) {
+    return 4;
+  }
+  if (total <= 14) {
+    return 5;
+  }
+  if (total <= 16) {
+    return 6;
+  }
+  if (total <= 19) {
+    return 7;
+  }
+  return 8;
+}
+
+function syncDerivedSizeClassInput() {
+  const sizeField = form.elements.namedItem('move');
+  if (!sizeField || !('value' in sizeField)) {
+    return;
+  }
+  const sizeClass = sizeClassFromStructure(num('structureBlack'), num('structureRed'));
+  sizeField.value = String(sizeClass);
+}
+
 function normalizeTurnOption(value) {
   return TURN_OPTIONS.includes(value) ? value : 20;
 }
@@ -494,6 +529,12 @@ function syncDerivedFunctionInputs() {
 
 
 function getBuild() {
+  const structure = {
+    repairable: num('structureBlack'),
+    permanent: num('structureRed')
+  };
+  const derivedSizeClass = sizeClassFromStructure(structure.repairable, structure.permanent);
+
   return {
     identity: {
       name: form.elements.name.value,
@@ -503,7 +544,7 @@ function getBuild() {
       pointValue: num('pointValueCalculated')
     },
     engineering: {
-      move: num('move'),
+      move: derivedSizeClass,
       vector: num('vector'),
       turn: num('turn'),
       special: num('special')
@@ -527,10 +568,7 @@ function getBuild() {
     functionsConfig: readFunctionsConfig(),
     powerSystem: readPowerSystem(),
     sublight: readSublight(),
-    structure: {
-      repairable: num('structureBlack'),
-      permanent: num('structureRed')
-    },
+    structure,
     shipArtDataUrl,
     weapons: readWeaponsFromForm(),
     systems: parseSystems(form.elements.systems.value),
@@ -1047,6 +1085,7 @@ function pulseLiveBadge() {
 function render(options = {}) {
   const { recalculatePointValue = true } = options;
   syncDerivedFunctionInputs();
+  syncDerivedSizeClassInput();
   const build = withEmbeddedShipArt(getBuild());
   renderPreview(build, { recalculatePointValue });
   jsonPreview.textContent = getJsonPreview(build);
@@ -1105,7 +1144,6 @@ function restoreDraft(draft) {
   setValue('faction', draft.identity?.faction ?? '');
   setValue('era', draft.identity?.era ?? '');
 
-  setValue('move', draft.engineering?.move ?? 0);
   setValue('vector', draft.engineering?.vector ?? 0);
   setValue('turn', draft.engineering?.turn ?? 0);
   setValue('special', draft.engineering?.special ?? 0);
@@ -1198,6 +1236,8 @@ function restoreDraft(draft) {
 
   setValue('structureBlack', draft.structure?.repairable ?? 0);
   setValue('structureRed', draft.structure?.permanent ?? 0);
+
+  syncDerivedSizeClassInput();
 
   shipArtDataUrl = draft.shipArtDataUrl ?? '';
   const normalizedWeapons = (Array.isArray(draft.weapons) ? draft.weapons : []).map((weapon) => normalizeWeapon(weapon));

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -23,7 +23,7 @@
 
         <h2>Engineering</h2>
         <div class="grid2">
-          <label>Size Class <input name="move" type="number" min="0" value="3" /></label>
+          <label>Size Class (auto from total structure) <input name="move" type="number" min="1" max="8" value="3" readonly /></label>
           <label>Acceleration <input name="vector" type="number" min="0" value="2" /></label>
           <label>Stress Damage <input name="turn" type="number" min="0" value="2" /></label>
           <label>Damage Control <input name="special" type="number" min="0" value="3" /></label>

--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -116,12 +116,12 @@ function mountFacingScore(weapon) {
 const SECTION_MULTIPLIERS = {
   identity: 0.4,
   engineering: 1.2,
-  defense: 1.9,
+  defense: 2.05,
   maneuvering: 1.4,
   systemsCrew: 1.0,
   powerTracks: 1.9,
   functions: 1.7,
-  weapons: 1.35
+  weapons: 2.25
 };
 
 const PV_RANKING_BASELINE = {
@@ -132,8 +132,10 @@ const PV_RANKING_BASELINE = {
   rankEngineeringSpecial: 0.75,
   rankDefenseShields: 0.42,
   rankDefenseArmor: 0.4,
-  rankDefenseRepairable: 0.3,
-  rankDefensePermanent: 0.28,
+  // Structure durability was underpriced during battleship tuning passes.
+  // Boost both repairable and permanent structure weights by ~3x.
+  rankDefenseRepairable: 0.9,
+  rankDefensePermanent: 0.84,
   rankDefenseShieldGen: 0.45,
   rankManeuverMaxAcc: 0.65,
   rankManeuverGreen: 0.5,
@@ -181,6 +183,44 @@ function rank(build, key) {
   return Number.isFinite(baseline) ? Math.max(0, baseline) : 1;
 }
 
+function sizeClassFromStructure(build) {
+  const structure = build?.structure || {};
+  const total = positivePart(structure.repairable) + positivePart(structure.permanent);
+
+  if (total < 5) {
+    return 1;
+  }
+  if (total <= 8) {
+    return 2;
+  }
+  if (total <= 10) {
+    return 3;
+  }
+  if (total <= 12) {
+    return 4;
+  }
+  if (total <= 14) {
+    return 5;
+  }
+  if (total <= 16) {
+    return 6;
+  }
+  if (total <= 19) {
+    return 7;
+  }
+  return 8;
+}
+
+function sizeClassCostMultiplier(sizeClass) {
+  const normalized = clampSizeClass(sizeClass);
+  // Requested curve anchor points: size 4 => 0.5, size 8 => 1.0.
+  return normalized * 0.125;
+}
+
+function clampSizeClass(value) {
+  return Math.min(8, Math.max(1, positivePart(value, 1)));
+}
+
 
 function scoreIdentity(build) {
   const identity = build?.identity || {};
@@ -193,7 +233,8 @@ function scoreIdentity(build) {
 
 function scoreEngineering(build) {
   const engineering = build?.engineering || {};
-  return (positivePart(engineering.move) * 1.4 * rank(build, 'rankEngineeringMove'))
+  const sizeClass = sizeClassFromStructure(build);
+  return (sizeClass * 1.4 * rank(build, 'rankEngineeringMove'))
     + (positivePart(engineering.vector) * 1.5 * rank(build, 'rankEngineeringVector'))
     + (positivePart(engineering.turn) * 1.2 * rank(build, 'rankEngineeringTurn'))
     + (positivePart(engineering.special) * 1.1 * rank(build, 'rankEngineeringSpecial'));
@@ -228,9 +269,16 @@ function scoreDefense(build) {
     * (sum([shields.forward, shields.aft, shields.port, shields.starboard]) * 0.05))
     * ((rank(build, 'rankDefenseRepairable') + rank(build, 'rankDefensePermanent')) / 2);
 
+  // Capital-hull premium: large structure pools and onboard repair scale better in long fights.
+  const capitalHullPremium = 1
+    + Math.min(0.55, Math.max(0, (totalStructure - 12) * 0.03) + (repairable * 0.05));
+
   const generatorScore = positivePart(build?.shieldGen) * 1.3 * rank(build, 'rankDefenseShieldGen');
 
-  return shieldScore + armorScore + repairableScore + permanentScore + durabilitySynergy + generatorScore;
+  return shieldScore
+    + armorScore
+    + ((repairableScore + permanentScore + durabilitySynergy) * capitalHullPremium)
+    + generatorScore;
 }
 
 function scoreManeuvering(build) {
@@ -370,8 +418,38 @@ function scoreWeaponQuality(weapon, build) {
   const powerScoreRaw = (circleAdjustment + stopDiscount) * rank(build, 'rankWeaponsPower');
   const structureScore = positivePart(weapon?.structure) * 0.35;
 
+  const traitKeywords = {
+    HVY: 1.2,
+    FTL: 1.0,
+    NOBAT: 0.85,
+    LEAK: 1.0,
+    STR: 1.0,
+    DMG: 1.1,
+    'PD MODE': 0.55
+  };
+  const traits = (Array.isArray(weapon?.traits) ? weapon.traits : [])
+    .map((trait) => String(trait || '').trim())
+    .filter(Boolean);
+  const traitKeywordScore = traits.reduce((total, trait) => {
+    const upper = trait.toUpperCase();
+    const direct = traitKeywords[upper];
+    if (Number.isFinite(direct)) {
+      return total + direct;
+    }
+    return total + 0.55;
+  }, 0);
+  const specialText = String(weapon?.special || '').trim();
+  const specialTokenCount = specialText
+    ? specialText.split(/[\s,/:;()]+/).filter(Boolean).length
+    : 0;
+  const traitsAndSpecialScore = ((traitKeywordScore * 0.65)
+    + (traits.length * 0.2)
+    + Math.min(3.25, (specialText ? 0.75 : 0) + (specialTokenCount * 0.16)))
+    * rank(build, 'rankWeaponsTraitsSpecial');
+
   const baseWeaponValue = (rangeScore * 1.35 * rank(build, 'rankWeaponsRange'))
-    + (structureScore * rank(build, 'rankWeaponsStructure'));
+    + (structureScore * rank(build, 'rankWeaponsStructure'))
+    + traitsAndSpecialScore;
 
   // Discounts can be substantial, but never reduce a mount below 50% of base value.
   const maxDiscount = baseWeaponValue * 0.5;
@@ -390,6 +468,16 @@ function effectiveMountCount(weapon) {
   return Math.min(8, rawCount);
 }
 
+function scaledMountCount(mountCount) {
+  const normalizedCount = Math.max(1, positivePart(mountCount, 1));
+  if (normalizedCount <= 1) {
+    return 1;
+  }
+
+  // Additional mounts improve coverage and redundancy, but with diminishing value.
+  return 1 + (Math.pow(normalizedCount - 1, 0.8) * 0.75);
+}
+
 function scoreWeapons(build) {
   const weapons = normalizeWeapons(build?.weapons);
   return weapons.reduce((total, weapon) => {
@@ -397,8 +485,32 @@ function scoreWeapons(build) {
     const arcWeight = 0.12 + (mountFacingScore(weapon) * rank(build, 'rankWeaponsMountArc'));
     const weaponQuality = Math.max(0, scoreWeaponQuality(weapon, build));
     const singleMountValue = weaponQuality * arcWeight;
-    return total + (singleMountValue * mountCount);
+    return total + (singleMountValue * scaledMountCount(mountCount));
   }, 0);
+}
+
+
+function hullScaleEscalation(build, contributions) {
+  const structure = build?.structure || {};
+  const structureTotal = positivePart(structure.repairable) + positivePart(structure.permanent);
+
+  const tracks = Array.isArray(build?.powerSystem?.tracks) ? build.powerSystem.tracks : [];
+  const powerPoints = sum(tracks.map((track) => positivePart(track?.points)));
+
+  const weapons = normalizeWeapons(build?.weapons);
+  const mountCoverage = sum(weapons.map((weapon) => effectiveMountCount(weapon)));
+
+  const capabilityIndex = (structureTotal * 0.06)
+    + (powerPoints * 0.05)
+    + (weapons.length * 0.4)
+    + (mountCoverage * 0.04)
+    + ((positivePart(contributions?.weapons) + positivePart(contributions?.defense)) * 0.008);
+
+  const growthBand = Math.max(0, capabilityIndex - 7.5);
+  const growth = Math.pow(growthBand, 1.15) * 0.028;
+
+  // Cap keeps escalation predictable while still separating capital builds from midline ships.
+  return 1 + Math.min(0.28, growth);
 }
 
 
@@ -414,6 +526,10 @@ export function calculatePointValue(build) {
     weapons: safeRun(() => scoreWeapons(build)) * SECTION_MULTIPLIERS.weapons
   };
 
-  const totalScore = sum(Object.values(contributions)) * rank(build, 'rankGlobalScale');
+  const baseScore = sum(Object.values(contributions)) * rank(build, 'rankGlobalScale');
+  const escalation = hullScaleEscalation(build, contributions);
+  const sizeClass = sizeClassFromStructure(build);
+  const sizeMultiplier = sizeClassCostMultiplier(sizeClass);
+  const totalScore = baseScore * escalation * sizeMultiplier;
   return Math.max(1, Math.round(totalScore));
 }


### PR DESCRIPTION
### Motivation
- Make `Size Class` a deterministic value derived from total structure boxes so designers cannot desync hull durability from movement classification.
- Increase the relative point-value contribution of large / capital hulls and onboard repair to better reflect endurance in long engagements.
- Improve weapon valuation by factoring traits and special text and apply diminishing returns for multiple mounts.
- Provide a size-based cost multiplier and hull-scale escalation to separate capital builds from midline ships in PV.

### Description
- Added `sizeClassFromStructure` and `syncDerivedSizeClassInput` in `app.js` to compute size class from `structureBlack` and `structureRed` and auto-sync the `move` field; `move` input is now `readonly` and labeled accordingly in `index.html`.
- Updated `getBuild` and draft restoration to expose `structure` separately and use the derived size class for `engineering.move` when building JSON.
- Rebalanced PV calculation in `pv-calculator.js` by raising `SECTION_MULTIPLIERS.defense` and `weapons`, and substantially increasing `rankDefenseRepairable` and `rankDefensePermanent` to weight structure higher.
- Introduced size-aware scoring: added `sizeClassFromStructure`, `sizeClassCostMultiplier`, `clampSizeClass`, `capitalHullPremium` in `scoreDefense`, `scaledMountCount`, trait/special-token scoring in `scoreWeaponQuality`, `hullScaleEscalation`, and combined these in `calculatePointValue` to apply escalation and size multipliers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4493a0a608332afbd25cdfc28c8a4)