### PR TITLE
Apply weapon escalation multiplier and resolve duplicate escalation function

### DIFF
--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -529,29 +529,6 @@ function hullScaleEscalation(build, contributions) {
 }
 
 
-function hullScaleEscalation(build, contributions) {
-  const structure = build?.structure || {};
-  const structureTotal = positivePart(structure.repairable) + positivePart(structure.permanent);
-
-  const tracks = Array.isArray(build?.powerSystem?.tracks) ? build.powerSystem.tracks : [];
-  const powerPoints = sum(tracks.map((track) => positivePart(track?.points)));
-
-  const weapons = normalizeWeapons(build?.weapons);
-  const mountCoverage = sum(weapons.map((weapon) => effectiveMountCount(weapon)));
-
-  const capabilityIndex = (structureTotal * 0.06)
-    + (powerPoints * 0.05)
-    + (weapons.length * 0.4)
-    + (mountCoverage * 0.04)
-    + ((positivePart(contributions?.weapons) + positivePart(contributions?.defense)) * 0.008);
-
-  const growthBand = Math.max(0, capabilityIndex - 7.5);
-  const growth = Math.pow(growthBand, 1.15) * 0.028;
-
-  // Cap keeps escalation predictable while still separating capital builds from midline ships.
-  return 1 + Math.min(0.28, growth);
-}
-
 function weaponProfileScale(build) {
   const weapons = normalizeWeapons(build?.weapons);
   if (!weapons.length) {
@@ -582,7 +559,7 @@ function weaponProfileScale(build) {
 }
 
 
-function hullScaleEscalation(build, contributions) {
+function weaponScaleEscalation(build, contributions) {
   const structure = build?.structure || {};
   const structureTotal = positivePart(structure.repairable) + positivePart(structure.permanent);
 
@@ -633,7 +610,8 @@ export function calculatePointValue(build) {
   };
 
   const weightedCoreScore = sum(Object.values(nonWeaponContributions)) * sizeMultiplier;
-  const weightedWeaponScore = contributions.weapons * weaponScale;
+  const weaponEscalation = weaponScaleEscalation(build, contributions);
+  const weightedWeaponScore = contributions.weapons * weaponScale * weaponEscalation;
 
   const baseScore = (weightedCoreScore + weightedWeaponScore) * rank(build, 'rankGlobalScale');
   const escalation = hullScaleEscalation(build, contributions);


### PR DESCRIPTION
### Motivation

- Introduce a distinct escalation factor for weapon systems so heavy weapon builds scale point cost more aggressively than just the weapon profile multiplier. 
- Remove a duplicated escalation definition and give the weapon-specific escalation its own name to avoid collisions and clarify intent. 
- Ensure total point calculation includes both the weapon profile scale and the new weapon escalation factor for more accurate PV calculation.

### Description

- Added a new function `weaponScaleEscalation(build, contributions)` which mirrors the capability-based escalation logic but is used specifically for weapons. 
- Removed the duplicate second `hullScaleEscalation` definition and renamed it to `weaponScaleEscalation` to prevent duplicate-symbol conflicts. 
- Updated `calculatePointValue` to compute `weaponEscalation` and multiply it into the weighted weapon score via `weightedWeaponScore = contributions.weapons * weaponScale * weaponEscalation`.

### Testing

- Ran the test suite with `npm test` and the full unit tests completed successfully. 
- Ran linting with `npm run lint` and static checks passed. 
- Verified that `calculatePointValue` returns numeric results for sample builds with weapons and without weapons during unit runs and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4943c69988332b16a9c696e73d76b)