### PR TITLE
Decouple weapon dice from structure and curve weapon PV scaling

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -166,12 +166,12 @@ function parseMountFacings(raw) {
     .map((group) => parseList(group).map((value) => clamp(Number(value), 1, 8)).filter((value) => Number.isFinite(value)));
 }
 
-function buildRangeProfile(ranges, diceByRange, structure = 1) {
+function buildRangeProfile(ranges, diceByRange) {
   return (Array.isArray(ranges) ? ranges : []).map((range, index) => ({
     band: range.band || '?',
     type: ['green', 'black', 'red'].includes((range.type || '').toLowerCase()) ? range.type.toLowerCase() : 'black',
     bonus: Number(diceByRange?.[index]?.bonus || 0),
-    dice: (Array.isArray(diceByRange?.[index]?.dice) ? diceByRange[index].dice : []).slice(0, Math.max(1, Number(structure || 1)))
+    dice: Array.isArray(diceByRange?.[index]?.dice) ? diceByRange[index].dice : []
   }));
 }
 
@@ -236,7 +236,7 @@ function readWeaponsFromForm() {
       ranges: (() => {
         const ranges = parseWeaponRanges(form.elements[`wpn${index}Ranges`]?.value);
         const diceByRange = parseWeaponDice(form.elements[`wpn${index}Dice`]?.value);
-        return buildRangeProfile(ranges, diceByRange, clamp(num(`wpn${index}Structure`), 1, 4));
+        return buildRangeProfile(ranges, diceByRange);
       })(),
       traits: parseList(form.elements[`wpn${index}Traits`]?.value),
       special: form.elements[`wpn${index}Special`]?.value?.trim() || ''
@@ -255,7 +255,7 @@ function normalizeWeapon(weapon = {}) {
         band: range.band || '?',
         type: ['green', 'black', 'red'].includes((range.type || '').toLowerCase()) ? range.type.toLowerCase() : 'black',
         bonus: Number(range.bonus || 0),
-        dice: (Array.isArray(range.dice) ? range.dice : []).slice(0, structure)
+        dice: Array.isArray(range.dice) ? range.dice : []
       };
     })
     : [];
@@ -265,12 +265,12 @@ function normalizeWeapon(weapon = {}) {
       band: range.band || '?',
       type: ['green', 'black', 'red'].includes((range.type || '').toLowerCase()) ? range.type.toLowerCase() : 'black',
       bonus: Number(range.bonus || 0),
-      dice: (Array.isArray(range.dice) ? range.dice : []).slice(0, structure)
+      dice: Array.isArray(range.dice) ? range.dice : []
     }))
-    : buildRangeProfile(normalizedRanges, Array.isArray(weapon.diceByRange) ? weapon.diceByRange : [], structure).map((range, index) => ({
+    : buildRangeProfile(normalizedRanges, Array.isArray(weapon.diceByRange) ? weapon.diceByRange : []).map((range, index) => ({
       ...range,
       bonus: Number(range.bonus || normalizedRanges[index]?.bonus || 0),
-      dice: range.dice.length ? range.dice : (normalizedRanges[index]?.dice || []).slice(0, structure)
+      dice: range.dice.length ? range.dice : (normalizedRanges[index]?.dice || [])
     }));
 
   const mountFacings = Array.isArray(weapon.mountFacings)
@@ -610,7 +610,7 @@ function weaponSlot(id, rawWeapon, enabled = true) {
       bonus.textContent = `+${Number(range.bonus)}`;
       dice.appendChild(bonus);
     }
-    const diceValues = (range.dice || []).slice(0, weapon.structure);
+    const diceValues = range.dice || [];
     diceValues.forEach((die) => {
       const pip = document.createElement('span');
       pip.className = `wpn-die ${String(die).toLowerCase()}`;

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -143,7 +143,7 @@
         </div>
 
         <h2>Weapons (up to 4)</h2>
-        <p class="muted">Each weapon supports up to 8 mounts, power circles/stops, structure, per-range dice colors, HOMING band boxes, and optional SPECIAL text (enabled by the HVY trait).</p>
+        <p class="muted">Each weapon supports up to 8 mounts, power circles/stops, structure, per-range dice colors (no longer capped by structure), HOMING band boxes, and optional SPECIAL text (enabled by the HVY trait).</p>
         <div class="weapon-editor-list">
           <fieldset class="weapon-editor-card">
             <legend>Weapon A</legend>

--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -113,6 +113,14 @@ function mountFacingScore(weapon) {
   return summedFacing / Math.max(1, arcs.length);
 }
 
+function curvedDiceValue(dice = []) {
+  const linear = sum((Array.isArray(dice) ? dice : []).map((die) => diceColorWeight(die)));
+  if (linear <= 0) {
+    return 0;
+  }
+  return Math.pow(linear, 1.18);
+}
+
 const SECTION_MULTIPLIERS = {
   identity: 0.4,
   engineering: 1.2,
@@ -379,7 +387,7 @@ function scoreWeaponQuality(weapon, build) {
   const ranges = Array.isArray(weapon?.ranges) ? weapon.ranges : [];
 
   const rangeScore = ranges.reduce((rangeTotal, range) => {
-    const diceScore = sum((Array.isArray(range?.dice) ? range.dice : []).map((die) => diceColorWeight(die)));
+    const diceScore = curvedDiceValue(range?.dice);
     const bonus = positivePart(range?.bonus);
     const rangeType = rangeTypeWeight(String(range?.type || 'black').toLowerCase());
     const maxDistance = bandMax(range?.band);
@@ -401,7 +409,7 @@ function scoreWeaponQuality(weapon, build) {
   const stopDiscount = -Array.from({ length: stopCount }, (_, index) => 1.45 + (index * 0.65)).reduce((a, b) => a + b, 0);
 
   const powerScoreRaw = (circleAdjustment + stopDiscount) * rank(build, 'rankWeaponsPower');
-  const structureScore = positivePart(weapon?.structure) * 0.35;
+  const structureScore = Math.pow(Math.max(1, positivePart(weapon?.structure, 1)), 1.2) * 0.42;
 
   const traitKeywords = {
     HVY: 1.2,
@@ -516,7 +524,7 @@ function weaponProfileScale(build) {
     const mountScale = scaledMountCount(effectiveMountCount(weapon));
 
     const rangeDicePressure = ranges.reduce((rangeTotal, range) => {
-      const diceScore = sum((Array.isArray(range?.dice) ? range.dice : []).map((die) => diceColorWeight(die)));
+      const diceScore = curvedDiceValue(range?.dice);
       const bonus = positivePart(range?.bonus);
       const maxDistance = bandMax(range?.band);
       const rangeReach = 0.55 + (Math.max(1, maxDistance) / 20);


### PR DESCRIPTION
### Motivation
- Separate the number of dice a weapon can have from its per-mount structure boxes so weapon dice pools are independent of structure configuration.
- Make weapon point-value (PV) scale nonlinearly with dice pools so larger dice counts increase cost more aggressively while slightly increasing structure contribution to PV.

### Description
- Stop truncating per-range dice by structure in parsing and normalization by removing `.slice(...)` truncation in `buildRangeProfile` and `normalizeWeapon` in `starforce-commander-ship-designer/app.js`, and render full dice arrays in the preview UI.
- Add a new `curvedDiceValue` helper in `starforce-commander-ship-designer/pv-calculator.js` and use it where dice were previously summed so dice contributions scale according to a power curve instead of linearly.
- Replace flat weapon structure contribution with a mild power curve in `scoreWeaponQuality` to increase structure's PV impact for larger values in `pv-calculator.js`.
- Update the weapons editor helper text in `starforce-commander-ship-designer/index.html` to clarify that per-range dice are no longer capped by structure.

### Testing
- Ran syntax checks with `node --check starforce-commander-ship-designer/app.js`, which succeeded.
- Ran syntax checks with `node --check starforce-commander-ship-designer/pv-calculator.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc00b57ac83328caee236901854c1)