### PR TITLE
Tighten SSD print layout to reduce letter-page whitespace

### DIFF
--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -528,7 +528,7 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
 @media print {
   @page {
     size: letter landscape;
-    margin: 0.25in;
+    margin: 0.15in;
   }
 
   :root { color-scheme: light; }
@@ -578,7 +578,7 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
   #pvFaction,
   #pvPointValue,
   #pvEra {
-    font-size: 1.18rem;
+    font-size: 1.02rem;
   }
 
   .eng-stats span,
@@ -591,8 +591,8 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
   .wpn-special-row,
   .wpn-trait-row,
   .slot-body {
-    font-size: 0.96rem;
-    line-height: 1.2;
+    font-size: 0.82rem;
+    line-height: 1.15;
   }
 
   .wpn-die {
@@ -615,14 +615,14 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
   .fn-dot,
   .power-dot,
   .rnd-circle {
-    transform: scale(1.28);
+    transform: scale(1.08);
     transform-origin: center;
   }
 
   .stat-icon,
   .crew-img {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Printed SSD previews left excessive white space on US Letter (landscape) at typical browser print scales, so the sheet felt undersized on the page.

### Description
- Reduced the `@page` print margin to `0.15in` to reclaim printable area on letter landscape sheets in `starforce-commander-ship-designer/styles.css`.
- Scaled down print-only heading and body sizes inside `@media print` (`font-size` adjustments to `1.02rem` and `0.82rem`, and `line-height` to `1.15`) to avoid aggressive browser scaling that created extra whitespace.
- Reduced symbol/marker enlargement used only for print (`transform: scale(1.08)`) and reduced icon sizes to `20px` to keep the template within page bounds at normal scale.
- Changes are scoped to `@media print` rules so regular on-screen layout is unaffected.

### Testing
- Verified the edits appear only in the `@media print` section of `starforce-commander-ship-designer/styles.css` and affect the expected selectors, and this verification succeeded.
- Confirmed the repo shows only the intended stylesheet change and file differences reflect the listed adjustments, and this verification succeeded.
- No automated unit test suite applies to visual/CSS output for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc332e71883328d90ef91b6fbffd5)