### PR TITLE
Dynamic preview density and print layout refinements

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -824,9 +824,32 @@ function renderPreview(build, options = {}) {
   weaponSlot(4, build.weapons[3], weaponPower[3] !== false);
 
   renderSystems(build.systems, build.crew);
+  applyDynamicLayoutDensity(build);
   renderStructure(build);
 }
 
+function applyDynamicLayoutDensity(build) {
+  const template = document.querySelector('.ssd-template');
+  if (!template) return;
+
+  const weaponSlots = [1, 2, 3, 4].reduce((count, id) => {
+    const slot = document.getElementById(`pvWpn${id}Slot`);
+    if (!slot || slot.style.display === 'none') return count;
+    return count + 1;
+  }, 0);
+
+  const systemsCount = Array.isArray(build?.systems) ? build.systems.length : 0;
+  const shieldDensity = Number(build?.shieldGen || 0) + Number(build?.shields?.forward || 0) + Number(build?.shields?.aft || 0);
+
+  let density = 'normal';
+  if (weaponSlots >= 3 || systemsCount >= 9 || shieldDensity >= 34) {
+    density = 'compact';
+  } else if (weaponSlots >= 2 || systemsCount >= 7 || shieldDensity >= 26) {
+    density = 'cozy';
+  }
+
+  template.dataset.density = density;
+}
 
 
 function renderFunctions(functionsConfig) {

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -293,7 +293,9 @@ button.ghost { background: #6d7f8d; border-color: #465764; }
 }
 
 .shield-body { position: relative; height: 385px; background: #ececec; display: flex; align-items: center; justify-content: center; overflow: hidden; }
-.ship-art-wrap { width: 76%; height: 100%; max-height: 100%; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.ship-art-wrap { width: 74%; height: 100%; max-height: 100%; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.ssd-template[data-density="cozy"] .ship-art-wrap { width: 66%; }
+.ssd-template[data-density="compact"] .ship-art-wrap { width: 58%; }
 .ship-art { width: 100%; height: 100%; object-fit: contain; display: none; filter: saturate(0.9) contrast(1.02); }
 .ship-silhouette { width: 58%; height: 82%; background: linear-gradient(180deg,#d8d8d8,#b5b5b5); border: 3px solid #121212; border-radius: 46% 46% 30% 30% / 58% 58% 42% 42%; }
 .side {
@@ -528,7 +530,7 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
 @media print {
   @page {
     size: letter landscape;
-    margin: 0.25in;
+    margin: 0.15in;
   }
 
   :root { color-scheme: light; }
@@ -554,14 +556,16 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
     position: static;
   }
   .ssd-template {
-    width: 100%;
-    max-width: 100%;
-    margin: 0;
+    width: min(100%, 10.7in);
+    max-width: 10.7in;
+    margin: 0 auto;
     break-inside: avoid;
     page-break-inside: avoid;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }
+
+  .ssd-template[data-density="compact"] .ship-art-wrap { width: 54%; }
 
   .ssd-template,
   .ssd-template * {
@@ -578,7 +582,7 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
   #pvFaction,
   #pvPointValue,
   #pvEra {
-    font-size: 1.18rem;
+    font-size: 1.02rem;
   }
 
   .eng-stats span,
@@ -591,8 +595,8 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
   .wpn-special-row,
   .wpn-trait-row,
   .slot-body {
-    font-size: 0.96rem;
-    line-height: 1.2;
+    font-size: 0.82rem;
+    line-height: 1.15;
   }
 
   .wpn-die {
@@ -615,14 +619,14 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
   .fn-dot,
   .power-dot,
   .rnd-circle {
-    transform: scale(1.28);
+    transform: scale(1.08);
     transform-origin: center;
   }
 
   .stat-icon,
   .crew-img {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Make the ship preview adaptively condense its artwork and layout when builds contain many weapons, systems, or heavy shields so content remains legible. 
- Improve printed output fit and visual scaling by tightening print margins and reducing font/icon sizes for high-density prints.

### Description
- Added `applyDynamicLayoutDensity(build)` and invoked it from `renderPreview` to set a `data-density` attribute on `.ssd-template` based on weapon slot count, systems count, and shield capacity. 
- Updated CSS to support density variants by changing base `.ship-art-wrap` width and adding `.ssd-template[data-density="cozy"]` and `.ssd-template[data-density="compact"]` rules (including a compact print-width override). 
- Adjusted print layout metrics by reducing `@page` margin, constraining `.ssd-template` width to `10.7in`, centering it, and scaling down fonts, icons, and UI element transforms for printed output. 
- Minor responsive tweaks to `.ship-art-wrap` and various element sizes to keep proportions consistent across screen and print contexts.

### Testing
- Ran the linter with `npm run lint` and it completed without errors. 
- Executed the test suite with `npm test` and all tests passed. 
- Built the project with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc332e71883328d90ef91b6fbffd5)