### PR TITLE
SSD: support special-system power & split shield layout, simplify power tracks, and update defaults

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -7,29 +7,30 @@ const liveBadge = document.getElementById('liveBadge');
 const STORAGE_KEY = 'sfCommanderSsdDrafts';
 const TURN_OPTIONS = [0, 20, 25, 30, 35, 40, 45, 65];
 let shipArtDataUrl = '';
+const SPECIAL_SYSTEM_KEYS = new Set(['CLOAK', 'CMND', 'FCON', 'HNGR', 'LNCH', 'LAND', 'SCOUT']);
 
 
 const STANDARD_DEFAULT_LOADOUT = {
   identity: {
     name: 'SHIP NAME / ID',
-    classType: 'Class Name - Class ship type',
+    classType: 'CLASSNAME ID-class Weight Class',
     faction: '/',
     era: '/',
-    pointValue: 2
+    pointValue: 4
   },
-  engineering: { move: 0, vector: 0, turn: 0, special: 0 },
+  engineering: { move: 1, vector: 2, turn: 1, special: 1 },
   shields: { forward: 0, aft: 0, port: 0, starboard: 0 },
   armor: { forward: 0, aft: 0, port: 0, starboard: 0 },
   shieldGen: 0,
   textBlocks: { powerSystem: '' },
   functionsConfig: {
-    accDec: { values: [], free: 0 },
-    sifIdf: { values: [], free: 0, emer: false },
+    accDec: { values: ['1', '2', '3'], free: 0 },
+    sifIdf: { values: ['1', '2', '3'], free: 0, emer: true },
     batRech: { values: [], free: 0 },
-    ftl: { empty: 0 },
+    ftl: { empty: 2 },
     cloak: { enabled: false, empty: 0 },
     sensor: { values: [], free: 0 },
-    genSys: { values: [], free: 0 },
+    genSys: { values: ['NRM', 'MAX'], free: 0 },
     weapons: [
       { label: 'WPN A', enabled: false, free: 0, values: [] },
       { label: 'WPN B', enabled: false, free: 0, values: [] },
@@ -45,24 +46,24 @@ const STANDARD_DEFAULT_LOADOUT = {
       { key: 'slReac', label: 'SL REAC', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
       { key: 'auxPwr', label: 'AUX PWR', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
       { key: 'battery', label: 'BATTERY', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
-      { key: 'ftlDrive', label: 'FTL DRIVE', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: false }
+      { key: 'ftlDrive', label: 'FTL DRIVE', points: 1, boxesPerPoint: 1, boxPattern: [], hasDot: false }
     ]
   },
   sublight: {
-    maxAccPhs: 0,
-    greenCircles: 0,
-    redCircles: 0,
+    maxAccPhs: 2,
+    greenCircles: 3,
+    redCircles: 3,
     spd: [6, 5, 4, 3, 2, 1, 0],
-    turns: [0, 20, 30, 30, 35, 35, 40],
+    turns: [20, 20, 20, 20, 20, 20, 20],
     dmgStops: [false, false, false, false, false, false, false]
   },
-  structure: { repairable: 0, permanent: 0 },
+  structure: { repairable: 1, permanent: 4 },
   shipArtDataUrl: '',
   weapons: [
+    { name: 'WPN NAME', mountArcs: ['1', '2'], mountFacings: [[1, 2]], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
     { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
     { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
-    { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
-    { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' }
+    { name: '', mountArcs: [], mountFacings: [], powerCircles: 2, powerStops: [], structure: 2, ranges: [], traits: [], special: '' }
   ],
   systems: [
     { key: 'SCNC', value: '0' },
@@ -71,20 +72,27 @@ const STANDARD_DEFAULT_LOADOUT = {
     { key: 'TRAN', value: '0' },
     { key: 'SHTL', value: '0' },
     { key: 'QTRS', value: '0' },
-    { key: 'CRGO', value: '0' }
+    { key: 'CRGO', value: '0' },
+    { key: 'HNGR', value: '0' },
+    { key: 'LNCH', value: '0' },
+    { key: 'LAND', value: '0' },
+    { key: 'CLOAK', value: '0', power: '0' },
+    { key: 'CMND', value: '0', power: '0' },
+    { key: 'FCON', value: '0', power: '0' },
+    { key: 'SCOUT', value: '0', power: '0' }
   ],
   crew: { shuttleCraft: 0, marinesStationed: 0 }
 };
 
 
 const POWER_TRACK_CONFIG = [
-  { key: 'lMain', label: 'L MAIN', pointsField: 'powerLMainPoints', boxesField: 'powerLMainBoxes', patternField: 'powerLMainPattern', hasDotField: 'powerLMainHasDot' },
-  { key: 'rMain', label: 'R MAIN', pointsField: 'powerRMainPoints', boxesField: 'powerRMainBoxes', patternField: 'powerRMainPattern', hasDotField: 'powerRMainHasDot' },
-  { key: 'cMain', label: 'C MAIN', pointsField: 'powerCMainPoints', boxesField: 'powerCMainBoxes', patternField: 'powerCMainPattern', hasDotField: 'powerCMainHasDot' },
-  { key: 'slReac', label: 'SL REAC', pointsField: 'powerSlReacPoints', boxesField: 'powerSlReacBoxes', patternField: 'powerSlReacPattern', hasDotField: 'powerSlReacHasDot' },
-  { key: 'auxPwr', label: 'AUX PWR', pointsField: 'powerAuxPwrPoints', boxesField: 'powerAuxPwrBoxes', patternField: 'powerAuxPwrPattern', hasDotField: 'powerAuxPwrHasDot' },
-  { key: 'battery', label: 'BATTERY', pointsField: 'powerBatteryPoints', boxesField: 'powerBatteryBoxes', patternField: 'powerBatteryPattern', hasDotField: 'powerBatteryHasDot' },
-  { key: 'ftlDrive', label: 'FTL DRIVE', pointsField: 'powerFtlDrivePoints', boxesField: 'powerFtlDriveBoxes', patternField: 'powerFtlDrivePattern', hasDotField: 'powerFtlDriveHasDot' }
+  { key: 'lMain', label: 'L MAIN', pointsField: 'powerLMainPoints', patternField: 'powerLMainPattern', hasDotField: 'powerLMainHasDot' },
+  { key: 'rMain', label: 'R MAIN', pointsField: 'powerRMainPoints', patternField: 'powerRMainPattern', hasDotField: 'powerRMainHasDot' },
+  { key: 'cMain', label: 'C MAIN', pointsField: 'powerCMainPoints', patternField: 'powerCMainPattern', hasDotField: 'powerCMainHasDot' },
+  { key: 'slReac', label: 'SL REAC', pointsField: 'powerSlReacPoints', patternField: 'powerSlReacPattern', hasDotField: 'powerSlReacHasDot' },
+  { key: 'auxPwr', label: 'AUX PWR', pointsField: 'powerAuxPwrPoints', patternField: 'powerAuxPwrPattern', hasDotField: 'powerAuxPwrHasDot' },
+  { key: 'battery', label: 'BATTERY', pointsField: 'powerBatteryPoints', patternField: 'powerBatteryPattern', hasDotField: 'powerBatteryHasDot' },
+  { key: 'ftlDrive', label: 'FTL DRIVE', pointsField: 'powerFtlDrivePoints', patternField: 'powerFtlDrivePattern', hasDotField: 'powerFtlDriveHasDot' }
 ];
 
 function parseList(raw, separator = ',') {
@@ -366,13 +374,29 @@ function createMountDiagram(facings, structure, powerCircles, powerStops) {
 }
 
 function parseSystems(raw) {
-  return raw
+  return String(raw || '')
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [key, value] = line.split(':').map((part) => part.trim());
-      return { key, value: value ?? '' };
+      const parts = line.split(':').map((part) => part.trim()).filter((part) => part.length > 0);
+      if (parts.length >= 3) {
+        const [keyRaw, valueRaw, powerRaw] = parts;
+        const normalizedKey = keyRaw.toUpperCase();
+        if (SPECIAL_SYSTEM_KEYS.has(normalizedKey)) {
+          return { key: normalizedKey, value: valueRaw ?? '0', power: powerRaw ?? '0' };
+        }
+      }
+      if (parts.length >= 3) {
+        const [powerRaw, keyRaw, valueRaw] = parts;
+        const normalizedKey = keyRaw.toUpperCase();
+        if (SPECIAL_SYSTEM_KEYS.has(normalizedKey)) {
+          return { key: normalizedKey, value: valueRaw ?? '0', power: powerRaw ?? '0' };
+        }
+      }
+
+      const [keyRaw, valueRaw] = parts;
+      return { key: String(keyRaw || '').toUpperCase(), value: valueRaw ?? '0' };
     });
 }
 
@@ -404,9 +428,9 @@ function normalizeTurnOption(value) {
 function readSublight() {
   const speeds = [6, 5, 4, 3, 2, 1, 0];
   return {
-    maxAccPhs: num('sublightMaxAcc'),
-    greenCircles: clamp(num('sublightGreen'), 0, 3),
-    redCircles: clamp(num('sublightRed'), 0, 3),
+    maxAccPhs: Math.max(0, num('vector')),
+    greenCircles: clamp(num('sublightGreen'), 0, 5),
+    redCircles: clamp(num('sublightRed'), 0, 5),
     spd: speeds.map((speed) => speed),
     turns: speeds.map((speed) => normalizeTurnOption(num(`sublightTurn${speed}`))),
     dmgStops: speeds.map((speed) => Boolean(form.elements[`sublightDmg${speed}`]?.checked))
@@ -482,7 +506,7 @@ function readPowerSystem() {
       key: track.key,
       label: track.label,
       points: Math.max(0, num(track.pointsField)),
-      boxesPerPoint: clamp(num(track.boxesField), 1, 3),
+      boxesPerPoint: 1,
       boxPattern: parsePowerPattern(form.elements[track.patternField]?.value),
       hasDot: Boolean(form.elements[track.hasDotField]?.checked)
     }))
@@ -554,6 +578,34 @@ function renderBoxes(containerId, count, className) {
     box.className = className;
     container.appendChild(box);
   }
+}
+
+function renderShieldFacingBoxes(containerId, count, orientation = 'row') {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  container.innerHTML = '';
+  container.classList.add('is-split');
+
+  const total = Math.max(0, Number(count || 0));
+  if (total <= 0) {
+    return;
+  }
+
+  const outerCount = Math.ceil(total / 2);
+  const innerCount = total - outerCount;
+  const laneCounts = innerCount > 0 ? [outerCount, innerCount] : [outerCount];
+
+  laneCounts.forEach((laneCount) => {
+    const lane = document.createElement('div');
+    lane.className = `shield-split-lane ${orientation}-lane`;
+    for (let i = 0; i < laneCount; i += 1) {
+      const box = document.createElement('span');
+      box.className = 'shield-box';
+      lane.appendChild(box);
+    }
+    container.appendChild(lane);
+  });
 }
 
 function weaponSlot(id, rawWeapon, enabled = true) {
@@ -708,7 +760,7 @@ function renderStructure(build) {
 function circleRun(containerId, count) {
   const container = document.getElementById(containerId);
   container.innerHTML = '';
-  for (let i = 0; i < clamp(count, 0, 3); i += 1) {
+  for (let i = 0; i < clamp(count, 0, 5); i += 1) {
     const circle = document.createElement('span');
     circle.className = 'rnd-circle';
     container.appendChild(circle);
@@ -717,9 +769,9 @@ function circleRun(containerId, count) {
 
 function renderManeuvering(sublight) {
   const data = sublight || {
-    maxAccPhs: 0,
-    greenCircles: 0,
-    redCircles: 0,
+    maxAccPhs: 2,
+    greenCircles: 3,
+    redCircles: 3,
     spd: [6, 5, 4, 3, 2, 1, 0],
     turns: [20, 20, 20, 20, 20, 20, 20],
     dmgStops: [false, false, false, false, false, false, false]
@@ -786,10 +838,10 @@ function renderPreview(build, options = {}) {
     blackGenRow.appendChild(box);
   }
 
-  renderBoxes('pvFwdShieldBoxes', build.shields.forward, 'shield-box');
-  renderBoxes('pvAftShieldBoxes', build.shields.aft, 'shield-box');
-  renderBoxes('pvPortShieldBoxes', build.shields.port, 'shield-box');
-  renderBoxes('pvStbdShieldBoxes', build.shields.starboard, 'shield-box');
+  renderShieldFacingBoxes('pvFwdShieldBoxes', build.shields.forward, 'row');
+  renderShieldFacingBoxes('pvAftShieldBoxes', build.shields.aft, 'row');
+  renderShieldFacingBoxes('pvPortShieldBoxes', build.shields.port, 'column');
+  renderShieldFacingBoxes('pvStbdShieldBoxes', build.shields.starboard, 'column');
 
   const armor = build.armor || { forward: 0, aft: 0, port: 0, starboard: 0 };
   renderBoxes('pvFwdArmorBoxes', armor.forward, 'armor-box');
@@ -814,7 +866,7 @@ function renderPreview(build, options = {}) {
     silhouetteEl.style.display = 'block';
   }
 
-  renderFunctions(build.functionsConfig);
+  renderFunctions(build.functionsConfig, build.systems);
   renderPowerSystem(build.powerSystem);
   renderManeuvering(build.sublight);
 
@@ -840,7 +892,9 @@ function applyDynamicLayoutDensity(build) {
     return count + 1;
   }, 0);
 
-  const systemsCount = Array.isArray(build?.systems) ? build.systems.length : 0;
+  const systemsCount = Array.isArray(build?.systems)
+    ? build.systems.filter((entry) => Number(entry?.value || 0) > 0).length
+    : 0;
   const shieldDensity = Number(build?.shieldGen || 0) + Number(build?.shields?.forward || 0) + Number(build?.shields?.aft || 0);
 
   let density = 'normal';
@@ -854,7 +908,7 @@ function applyDynamicLayoutDensity(build) {
 }
 
 
-function renderFunctions(functionsConfig) {
+function renderFunctions(functionsConfig, systems = []) {
   const container = document.getElementById('pvFunctions');
   container.innerHTML = '';
   const cfg = functionsConfig || {};
@@ -900,7 +954,7 @@ function renderFunctions(functionsConfig) {
     });
   };
 
-  const acc = cfg.accDec || { values: ['1', '2', '3', '4', '5', '6'], free: 1 };
+  const acc = cfg.accDec || { values: ['1', '2', '3'], free: 0 };
   addValueDots(addRow('ACC/DEC', 'green'), acc.values, acc.free);
 
   const sif = cfg.sifIdf || { values: ['1', '2', '3'], free: 0, emer: true };
@@ -919,18 +973,12 @@ function renderFunctions(functionsConfig) {
     sifLevels.appendChild(emer);
   }
 
-  const bat = cfg.batRech || { values: ['1'], free: 0 };
+  const bat = cfg.batRech || { values: [], free: 0 };
   addValueDots(addRow('BAT RECH', 'green'), bat.values, 0);
 
   const ftl = cfg.ftl || { empty: 2 };
   const ftlLevels = addRow('FTL', 'green');
   for (let i = 0; i < Number(ftl.empty || 0); i += 1) addDot(ftlLevels, false);
-
-  const cloak = cfg.cloak || { enabled: false, empty: 3 };
-  if (cloak.enabled) {
-    const cloakLevels = addRow('CLOAK', 'magenta');
-    for (let i = 0; i < Number(cloak.empty || 0); i += 1) addDot(cloakLevels, false);
-  }
 
   const shldRenf = addRow('SHLD RNFC', 'cyan');
   ['F', 'P', 'S', 'A'].forEach((part) => {
@@ -944,11 +992,22 @@ function renderFunctions(functionsConfig) {
     addToken(shldRepr, part);
   });
 
-  const sensor = cfg.sensor || { values: ['2', '4', '6'], free: 1 };
+  const sensor = cfg.sensor || { values: [], free: 0 };
   addValueDots(addRow('SENSOR', 'gold'), sensor.values, sensor.free);
 
-  const gen = cfg.genSys || { values: ['NRM', 'MAX'], free: 1 };
+  const gen = cfg.genSys || { values: ['NRM', 'MAX'], free: 0 };
   addValueDots(addRow('GEN SYS', 'gold'), gen.values, gen.free);
+
+  const specialSystems = (Array.isArray(systems) ? systems : [])
+    .map((entry) => ({
+      key: String(entry?.key || '').toUpperCase(),
+      power: Math.max(0, Number(entry?.power || 0))
+    }))
+    .filter((entry) => SPECIAL_SYSTEM_KEYS.has(entry.key) && entry.power > 0);
+  specialSystems.forEach((entry) => {
+    const levels = addRow(entry.key, 'magenta');
+    for (let i = 0; i < entry.power; i += 1) addDot(levels, false);
+  });
 
   const weapons = Array.isArray(cfg.weapons) ? cfg.weapons : [];
   weapons.forEach((weapon, idx) => {
@@ -966,6 +1025,9 @@ function renderSystems(systems, crew) {
   const rows = Array.isArray(systems) ? systems : [];
 
   rows.forEach((entry) => {
+    const count = Math.max(0, Number(entry?.value || 0));
+    if (count <= 0) return;
+
     const row = document.createElement('div');
     row.className = 'system-row';
 
@@ -974,7 +1036,6 @@ function renderSystems(systems, crew) {
     key.textContent = String(entry.key || '').slice(0, 5).toUpperCase();
     row.appendChild(key);
 
-    const count = Math.max(0, Number(entry.value || 0));
     for (let i = 0; i < count; i += 1) {
       const box = document.createElement('span');
       box.className = 'system-box';
@@ -1192,18 +1253,16 @@ function restoreDraft(draft) {
   POWER_TRACK_CONFIG.forEach((track) => {
     const trackData = draftTracks.find((entry) => entry.key === track.key || entry.label === track.label);
     const pointsField = getField(track.pointsField);
-    const boxesField = getField(track.boxesField);
     const patternField = getField(track.patternField);
     const hasDotField = getField(track.hasDotField);
 
     if (pointsField) {
       pointsField.value = Math.max(0, Number(trackData?.points ?? 0));
     }
-    if (boxesField) {
-      boxesField.value = clamp(Number(trackData?.boxesPerPoint ?? 1), 1, 3);
-    }
     if (patternField) {
-      patternField.value = (trackData?.boxPattern ?? []).join(',');
+      const pattern = Array.isArray(trackData?.boxPattern) ? trackData.boxPattern : [];
+      const fallback = clamp(Number(trackData?.boxesPerPoint ?? 1), 1, 3);
+      patternField.value = (pattern.length > 0 ? pattern : [fallback]).join(',');
     }
     if (hasDotField) {
       hasDotField.checked = Boolean(trackData?.hasDot ?? (track.key !== 'ftlDrive'));
@@ -1211,14 +1270,13 @@ function restoreDraft(draft) {
   });
 
   const sublight = safeDraft.sublight ?? {
-    maxAccPhs: 0,
-    greenCircles: 0,
-    redCircles: 0,
+    maxAccPhs: 2,
+    greenCircles: 3,
+    redCircles: 3,
     spd: [6, 5, 4, 3, 2, 1, 0],
     turns: [20, 20, 20, 20, 20, 20, 20],
     dmgStops: [false, false, false, false, false, false, false]
   };
-  setValue('sublightMaxAcc', sublight.maxAccPhs ?? 0);
   setValue('sublightGreen', sublight.greenCircles ?? 0);
   setValue('sublightRed', sublight.redCircles ?? 0);
   [6, 5, 4, 3, 2, 1, 0].forEach((speed, index) => {
@@ -1253,7 +1311,11 @@ function restoreDraft(draft) {
   const normalizedSystems = Array.isArray(safeDraft.systems)
     ? safeDraft.systems
     : parseSystems(safeDraft.systems || '');
-  setValue('systems', normalizedSystems.map((item) => `${item.key}:${item.value ?? ''}`).join('\n'));
+  setValue('systems', normalizedSystems
+    .map((item) => (item?.power !== undefined
+      ? `${item.key}:${item.value ?? '0'}:${item.power ?? '0'}`
+      : `${item.key}:${item.value ?? '0'}`))
+    .join('\n'));
   setValue('shuttleCraft', safeDraft.crew?.shuttleCraft ?? 0);
   setValue('marinesStationed', safeDraft.crew?.marinesStationed ?? 0);
 

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -112,23 +112,22 @@
         <div class="power-system-editor">
           <strong>Power System Tracks</strong>
           <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
-          <div class="power-grid-head"><span>Track</span><span>Points</span><span>Boxes/Point</span><span>Pattern</span><span>Dot</span></div>
+          <div class="power-grid-head"><span>Track</span><span>Points</span><span>Boxes/Pattern</span><span>Dot</span></div>
           <div class="power-grid">
-            <label>L MAIN</label><input name="powerLMainPoints" type="number" min="0" value="4" /><input name="powerLMainBoxes" type="number" min="1" max="3" value="2" /><input name="powerLMainPattern" value="" placeholder="1,2,1,2" /><input name="powerLMainHasDot" type="checkbox" checked />
-            <label>R MAIN</label><input name="powerRMainPoints" type="number" min="0" value="4" /><input name="powerRMainBoxes" type="number" min="1" max="3" value="2" /><input name="powerRMainPattern" value="" placeholder="1,2,1,2" /><input name="powerRMainHasDot" type="checkbox" checked />
-            <label>C MAIN</label><input name="powerCMainPoints" type="number" min="0" value="0" /><input name="powerCMainBoxes" type="number" min="1" max="3" value="2" /><input name="powerCMainPattern" value="" placeholder="1,2,1,2" /><input name="powerCMainHasDot" type="checkbox" checked />
-            <label>SL REAC</label><input name="powerSlReacPoints" type="number" min="0" value="1" /><input name="powerSlReacBoxes" type="number" min="1" max="3" value="2" /><input name="powerSlReacPattern" value="" placeholder="1,2,1,2" /><input name="powerSlReacHasDot" type="checkbox" checked />
-            <label>AUX PWR</label><input name="powerAuxPwrPoints" type="number" min="0" value="1" /><input name="powerAuxPwrBoxes" type="number" min="1" max="3" value="2" /><input name="powerAuxPwrPattern" value="" placeholder="1,2,1,2" /><input name="powerAuxPwrHasDot" type="checkbox" checked />
-            <label>BATTERY</label><input name="powerBatteryPoints" type="number" min="0" value="1" /><input name="powerBatteryBoxes" type="number" min="1" max="3" value="1" /><input name="powerBatteryPattern" value="" placeholder="1,2,1,2" /><input name="powerBatteryHasDot" type="checkbox" checked />
-            <label>FTL DRIVE</label><input name="powerFtlDrivePoints" type="number" min="0" value="1" /><input name="powerFtlDriveBoxes" type="number" min="1" max="3" value="2" /><input name="powerFtlDrivePattern" value="" placeholder="1,2,1,2" /><input name="powerFtlDriveHasDot" type="checkbox" />
+            <label>L MAIN</label><input name="powerLMainPoints" type="number" min="0" value="4" /><input name="powerLMainPattern" value="2" placeholder="2,1,2" /><input name="powerLMainHasDot" type="checkbox" checked />
+            <label>R MAIN</label><input name="powerRMainPoints" type="number" min="0" value="4" /><input name="powerRMainPattern" value="2" placeholder="2,1,2" /><input name="powerRMainHasDot" type="checkbox" checked />
+            <label>C MAIN</label><input name="powerCMainPoints" type="number" min="0" value="0" /><input name="powerCMainPattern" value="2" placeholder="2,1,2" /><input name="powerCMainHasDot" type="checkbox" checked />
+            <label>SL REAC</label><input name="powerSlReacPoints" type="number" min="0" value="1" /><input name="powerSlReacPattern" value="2" placeholder="2,1,2" /><input name="powerSlReacHasDot" type="checkbox" checked />
+            <label>AUX PWR</label><input name="powerAuxPwrPoints" type="number" min="0" value="1" /><input name="powerAuxPwrPattern" value="2" placeholder="2,1,2" /><input name="powerAuxPwrHasDot" type="checkbox" checked />
+            <label>BATTERY</label><input name="powerBatteryPoints" type="number" min="0" value="1" /><input name="powerBatteryPattern" value="1" placeholder="2,1,2" /><input name="powerBatteryHasDot" type="checkbox" checked />
+            <label>FTL DRIVE</label><input name="powerFtlDrivePoints" type="number" min="0" value="1" /><input name="powerFtlDrivePattern" value="1" placeholder="2,1,2" /><input name="powerFtlDriveHasDot" type="checkbox" />
           </div>
         </div>
         <div class="maneuver-editor">
           <strong>Sublight Drive & Maneuvering</strong>
           <div class="grid3">
-            <label>MAX ACC / PHS <input name="sublightMaxAcc" type="number" min="0" value="2" /></label>
-            <label>Green RND Circles (0-3) <input name="sublightGreen" type="number" min="0" max="3" value="3" /></label>
-            <label>Red RND Circles (0-3) <input name="sublightRed" type="number" min="0" max="3" value="3" /></label>
+            <label>Green RND Circles (0-5) <input name="sublightGreen" type="number" min="0" max="5" value="3" /></label>
+            <label>Red RND Circles (0-5) <input name="sublightRed" type="number" min="0" max="5" value="3" /></label>
           </div>
           <div class="maneuver-grid-head"><span>Speed</span><span>DMG Stop</span><span>TURN °</span></div>
           <div class="maneuver-grid" id="maneuverGridInputs">
@@ -252,7 +251,21 @@
         <button type="button" id="clearArtBtn" class="ghost">Clear Ship Art</button>
 
         <h2>Systems (one per line)</h2>
-        <label><textarea name="systems" rows="4" placeholder="SCNC:3\nSENS:4\nQTRS:2"></textarea></label>
+        <label><textarea name="systems" rows="4">SCNC:0
+SENS:0
+TRAC:0
+TRAN:0
+SHTL:0
+QTRS:0
+CRGO:0
+HNGR:0
+LNCH:0
+LAND:0
+CLOAK:0:0
+CMND:0:0
+FCON:0:0
+SCOUT:0:0</textarea></label>
+        <p class="muted">Format: <code>KEY:boxes</code> or <code>KEY:boxes:power</code> for special systems. If <code>boxes</code> is 0, that line is hidden in the SSD systems panel.</p>
         <div class="grid2">
           <label>Shuttle Craft <input name="shuttleCraft" type="number" min="0" value="4" /></label>
           <label>Marines Stationed <input name="marinesStationed" type="number" min="0" value="10" /></label>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -91,7 +91,7 @@ textarea:focus, input:focus {
 .power-system-editor { border: 1px solid #7f93a2; border-radius: 6px; padding: 0.7rem; margin-top: 0.6rem; background: #edf3f7; }
 .power-system-editor strong { display: block; margin-bottom: 0.2rem; }
 .power-system-editor .muted { margin: 0 0 0.38rem; font-size: 0.8rem; color: #436079; }
-.power-grid-head, .power-grid { display: grid; grid-template-columns: minmax(0, 1fr) 74px 96px minmax(0, 1fr) 44px; gap: 0.4rem; align-items: center; }
+.power-grid-head, .power-grid { display: grid; grid-template-columns: minmax(0, 1fr) 74px minmax(0, 1fr) 44px; gap: 0.4rem; align-items: center; }
 .power-grid-head { margin: 0.15rem 0; color: #44617b; font-size: 0.76rem; }
 .power-grid label { margin: 0; font-weight: 700; }
 .power-grid input { margin: 0; }
@@ -282,6 +282,11 @@ button.ghost { background: #6d7f8d; border-color: #465764; }
 .shield-top { margin-bottom: 0.22rem; }
 .shield-bottom { margin-top: 0.22rem; }
 .shield-box-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.12rem 0.35rem; min-height: 20px; justify-content: center; }
+.shield-box-row.is-split {
+  flex-wrap: nowrap;
+  flex-direction: column;
+  align-items: center;
+}
 .armor-box-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.08rem 0.35rem; min-height: 18px; justify-content: center; }
 .shield-gen-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.12rem 0.35rem; min-height: 18px; justify-content: center; }
 .fwd-gen-row { padding-top: 0.16rem; padding-bottom: 0.04rem; }
@@ -386,6 +391,21 @@ button.ghost { background: #6d7f8d; border-color: #465764; }
   gap: 4px;
   min-height: 112px;
   justify-content: center;
+}
+.shield-box-col.is-split {
+  flex-direction: row;
+  align-items: center;
+}
+.shield-split-lane {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+.shield-split-lane.row-lane {
+  flex-direction: row;
+}
+.shield-split-lane.column-lane {
+  flex-direction: column;
 }
 .systems-box { border-top: 0; margin-top: 0.8rem; border: 12px solid #f0b500; background: #f8f8f8; padding-bottom: 0.25rem; }
 .systems-box h3 { border-color: #f0b500; }


### PR DESCRIPTION
### Motivation
- Introduce support for special systems that carry an additional `power` value and expose them in the functions panel. 
- Improve shield visualization by splitting facing boxes into lanes for clearer center/outer distribution. 
- Simplify power-track configuration by removing per-point "boxes" input and using a single pattern field, and update several sensible defaults across the SSD.

### Description
- Add `SPECIAL_SYSTEM_KEYS` and extend `parseSystems` to accept `KEY:boxes` and `KEY:boxes:power` formats, normalizing keys and preserving `power` for special systems (handled in `app.js`).
- Add `renderShieldFacingBoxes` to render split lanes for facing shields and replace calls to `renderBoxes` for shield facings; add corresponding CSS classes in `styles.css` for `.is-split`, `.shield-split-lane`, and column/row layouts.
- Simplify `POWER_TRACK_CONFIG` and `readPowerSystem` to drop `boxesPerPoint` and use a single `pattern` input; update `index.html` to remove the Boxes/Point inputs and set pattern defaults.
- Update `renderFunctions` to accept `systems` and render special systems (e.g. `CLOAK`, `CMND`, `FCON`, `HNGR`, `LNCH`, `LAND`, `SCOUT`) as magenta rows with dots equal to their `power` value.
- Only render non-zero system entries in `renderSystems` and change `applyDynamicLayoutDensity` to count only systems with value > 0 when selecting layout density.
- Change sublight handling: `readSublight` now maps `maxAccPhs` to `vector`, and allowed green/red circles range increased to 0–5; `renderManeuvering` and restore defaults adjusted accordingly.
- Adjust many `STANDARD_DEFAULT_LOADOUT` defaults (identity, engineering, power tracks, sublight, structure, weapons, systems) to match the new UI/behavior and include new system keys with `power` fields when relevant.
- Update `restoreDraft` serialization for `powerSystem` patterns and for `systems` textarea to include `:power` when present so saved drafts round-trip correctly.

### Testing
- No automated tests were present in the repository to run as part of this change; therefore no automated test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0675ae9448332af1b453ced02f485)