### PR TITLE
Add trait grid, shield-generator split layout, and richer weapon/system inputs

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -7,29 +7,31 @@ const liveBadge = document.getElementById('liveBadge');
 const STORAGE_KEY = 'sfCommanderSsdDrafts';
 const TURN_OPTIONS = [0, 20, 25, 30, 35, 40, 45, 65];
 let shipArtDataUrl = '';
+const SPECIAL_SYSTEM_KEYS = new Set(['CLOAK', 'CMND', 'FCON', 'HNGR', 'LNCH', 'LAND', 'SCOUT']);
+const TRAIT_OPTIONS = ['AMMO X', 'AREA EFC', 'ARMOR +X', 'ARRAY', 'ATMO', 'FTL', 'HOMING X', 'MISSILE-X', 'NOBAT', 'NOSTRCT', 'PARTCL', 'PD AREA', 'PDMODE', 'PDWPN', 'PREC X'];
 
 
 const STANDARD_DEFAULT_LOADOUT = {
   identity: {
     name: 'SHIP NAME / ID',
-    classType: 'Class Name - Class ship type',
+    classType: 'CLASSNAME ID-class Weight Class',
     faction: '/',
     era: '/',
-    pointValue: 2
+    pointValue: 4
   },
-  engineering: { move: 0, vector: 0, turn: 0, special: 0 },
+  engineering: { move: 1, vector: 2, turn: 1, special: 1 },
   shields: { forward: 0, aft: 0, port: 0, starboard: 0 },
   armor: { forward: 0, aft: 0, port: 0, starboard: 0 },
-  shieldGen: 0,
+  shieldGen: { count: 0, value: 0 },
   textBlocks: { powerSystem: '' },
   functionsConfig: {
-    accDec: { values: [], free: 0 },
-    sifIdf: { values: [], free: 0, emer: false },
+    accDec: { values: ['1', '2', '3'], free: 0 },
+    sifIdf: { values: ['1', '2', '3'], free: 0, emer: true },
     batRech: { values: [], free: 0 },
-    ftl: { empty: 0 },
+    ftl: { empty: 2 },
     cloak: { enabled: false, empty: 0 },
     sensor: { values: [], free: 0 },
-    genSys: { values: [], free: 0 },
+    genSys: { values: ['NRM', 'MAX'], free: 0 },
     weapons: [
       { label: 'WPN A', enabled: false, free: 0, values: [] },
       { label: 'WPN B', enabled: false, free: 0, values: [] },
@@ -45,24 +47,24 @@ const STANDARD_DEFAULT_LOADOUT = {
       { key: 'slReac', label: 'SL REAC', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
       { key: 'auxPwr', label: 'AUX PWR', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
       { key: 'battery', label: 'BATTERY', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: true },
-      { key: 'ftlDrive', label: 'FTL DRIVE', points: 0, boxesPerPoint: 1, boxPattern: [], hasDot: false }
+      { key: 'ftlDrive', label: 'FTL DRIVE', points: 1, boxesPerPoint: 1, boxPattern: [], hasDot: false }
     ]
   },
   sublight: {
-    maxAccPhs: 0,
-    greenCircles: 0,
-    redCircles: 0,
+    maxAccPhs: 2,
+    greenCircles: 3,
+    redCircles: 3,
     spd: [6, 5, 4, 3, 2, 1, 0],
-    turns: [0, 20, 30, 30, 35, 35, 40],
+    turns: [20, 20, 20, 20, 20, 20, 20],
     dmgStops: [false, false, false, false, false, false, false]
   },
-  structure: { repairable: 0, permanent: 0 },
+  structure: { repairable: 1, permanent: 4 },
   shipArtDataUrl: '',
   weapons: [
+    { name: 'WPN NAME', mountArcs: ['1', '2'], mountFacings: [[1, 2]], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
     { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
     { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
-    { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' },
-    { name: '', mountArcs: [], mountFacings: [], powerCircles: 1, powerStops: [], structure: 1, ranges: [], traits: [], special: '' }
+    { name: '', mountArcs: [], mountFacings: [], powerCircles: 2, powerStops: [], structure: 2, ranges: [], traits: [], special: '' }
   ],
   systems: [
     { key: 'SCNC', value: '0' },
@@ -71,20 +73,27 @@ const STANDARD_DEFAULT_LOADOUT = {
     { key: 'TRAN', value: '0' },
     { key: 'SHTL', value: '0' },
     { key: 'QTRS', value: '0' },
-    { key: 'CRGO', value: '0' }
+    { key: 'CRGO', value: '0' },
+    { key: 'HNGR', value: '0' },
+    { key: 'LNCH', value: '0' },
+    { key: 'LAND', value: '0' },
+    { key: 'CLOAK', value: '0', power: '0' },
+    { key: 'CMND', value: '0', power: '0' },
+    { key: 'FCON', value: '0', power: '0' },
+    { key: 'SCOUT', value: '0', power: '0' }
   ],
   crew: { shuttleCraft: 0, marinesStationed: 0 }
 };
 
 
 const POWER_TRACK_CONFIG = [
-  { key: 'lMain', label: 'L MAIN', pointsField: 'powerLMainPoints', boxesField: 'powerLMainBoxes', patternField: 'powerLMainPattern', hasDotField: 'powerLMainHasDot' },
-  { key: 'rMain', label: 'R MAIN', pointsField: 'powerRMainPoints', boxesField: 'powerRMainBoxes', patternField: 'powerRMainPattern', hasDotField: 'powerRMainHasDot' },
-  { key: 'cMain', label: 'C MAIN', pointsField: 'powerCMainPoints', boxesField: 'powerCMainBoxes', patternField: 'powerCMainPattern', hasDotField: 'powerCMainHasDot' },
-  { key: 'slReac', label: 'SL REAC', pointsField: 'powerSlReacPoints', boxesField: 'powerSlReacBoxes', patternField: 'powerSlReacPattern', hasDotField: 'powerSlReacHasDot' },
-  { key: 'auxPwr', label: 'AUX PWR', pointsField: 'powerAuxPwrPoints', boxesField: 'powerAuxPwrBoxes', patternField: 'powerAuxPwrPattern', hasDotField: 'powerAuxPwrHasDot' },
-  { key: 'battery', label: 'BATTERY', pointsField: 'powerBatteryPoints', boxesField: 'powerBatteryBoxes', patternField: 'powerBatteryPattern', hasDotField: 'powerBatteryHasDot' },
-  { key: 'ftlDrive', label: 'FTL DRIVE', pointsField: 'powerFtlDrivePoints', boxesField: 'powerFtlDriveBoxes', patternField: 'powerFtlDrivePattern', hasDotField: 'powerFtlDriveHasDot' }
+  { key: 'lMain', label: 'L MAIN', pointsField: 'powerLMainPoints', patternField: 'powerLMainPattern', hasDotField: 'powerLMainHasDot' },
+  { key: 'rMain', label: 'R MAIN', pointsField: 'powerRMainPoints', patternField: 'powerRMainPattern', hasDotField: 'powerRMainHasDot' },
+  { key: 'cMain', label: 'C MAIN', pointsField: 'powerCMainPoints', patternField: 'powerCMainPattern', hasDotField: 'powerCMainHasDot' },
+  { key: 'slReac', label: 'SL REAC', pointsField: 'powerSlReacPoints', patternField: 'powerSlReacPattern', hasDotField: 'powerSlReacHasDot' },
+  { key: 'auxPwr', label: 'AUX PWR', pointsField: 'powerAuxPwrPoints', patternField: 'powerAuxPwrPattern', hasDotField: 'powerAuxPwrHasDot' },
+  { key: 'battery', label: 'BATTERY', pointsField: 'powerBatteryPoints', patternField: 'powerBatteryPattern', hasDotField: 'powerBatteryHasDot' },
+  { key: 'ftlDrive', label: 'FTL DRIVE', pointsField: 'powerFtlDrivePoints', patternField: 'powerFtlDrivePattern', hasDotField: 'powerFtlDriveHasDot' }
 ];
 
 function parseList(raw, separator = ',') {
@@ -224,6 +233,31 @@ function resolveImportedShipArt(importedDraft = {}) {
 }
 
 function readWeaponsFromForm() {
+  const readWeaponTraits = (index) => {
+    const grid = document.getElementById(`wpn${index}TraitsGrid`);
+    if (grid) {
+      return Array.from(grid.querySelectorAll('.trait-toggle.active'))
+        .map((button) => button.dataset.value || '')
+        .filter(Boolean);
+    }
+    const field = form.elements[`wpn${index}Traits`];
+    if (!field) return [];
+    if ('selectedOptions' in field && field.selectedOptions) {
+      return Array.from(field.selectedOptions).map((option) => option.value).filter(Boolean);
+    }
+    return parseList(field.value);
+  };
+  const readWeaponSpecial = (index) => {
+    const dmg = clamp(num(`wpn${index}SpecialDmg`), 0, 8);
+    const leak = clamp(num(`wpn${index}SpecialLeak`), 0, 4);
+    const str = clamp(num(`wpn${index}SpecialStr`), 0, 4);
+    const tags = [];
+    if (dmg > 0) tags.push(`DMG ${dmg}`);
+    if (leak > 0) tags.push(`LEAK ${leak}`);
+    if (str > 0) tags.push(`STR ${str}`);
+    return tags.join(', ');
+  };
+
   return [1, 2, 3, 4].map((index) => {
     const name = form.elements[`wpn${index}Name`]?.value?.trim() || '';
     return {
@@ -238,8 +272,8 @@ function readWeaponsFromForm() {
         const diceByRange = parseWeaponDice(form.elements[`wpn${index}Dice`]?.value);
         return buildRangeProfile(ranges, diceByRange);
       })(),
-      traits: parseList(form.elements[`wpn${index}Traits`]?.value),
-      special: form.elements[`wpn${index}Special`]?.value?.trim() || ''
+      traits: readWeaponTraits(index),
+      special: readWeaponSpecial(index)
     };
   });
 }
@@ -366,13 +400,29 @@ function createMountDiagram(facings, structure, powerCircles, powerStops) {
 }
 
 function parseSystems(raw) {
-  return raw
+  return String(raw || '')
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [key, value] = line.split(':').map((part) => part.trim());
-      return { key, value: value ?? '' };
+      const parts = line.split(':').map((part) => part.trim()).filter((part) => part.length > 0);
+      if (parts.length >= 3) {
+        const [keyRaw, valueRaw, powerRaw] = parts;
+        const normalizedKey = keyRaw.toUpperCase();
+        if (SPECIAL_SYSTEM_KEYS.has(normalizedKey)) {
+          return { key: normalizedKey, value: valueRaw ?? '0', power: powerRaw ?? '0' };
+        }
+      }
+      if (parts.length >= 3) {
+        const [powerRaw, keyRaw, valueRaw] = parts;
+        const normalizedKey = keyRaw.toUpperCase();
+        if (SPECIAL_SYSTEM_KEYS.has(normalizedKey)) {
+          return { key: normalizedKey, value: valueRaw ?? '0', power: powerRaw ?? '0' };
+        }
+      }
+
+      const [keyRaw, valueRaw] = parts;
+      return { key: String(keyRaw || '').toUpperCase(), value: valueRaw ?? '0' };
     });
 }
 
@@ -387,6 +437,30 @@ function num(name) {
   }
   const parsed = Number(raw);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeShieldGenConfig(rawShieldGen) {
+  if (rawShieldGen && typeof rawShieldGen === 'object') {
+    return {
+      count: Math.max(0, Number(rawShieldGen.count || 0)),
+      value: Math.max(0, Number(rawShieldGen.value || 0))
+    };
+  }
+  const legacyTotal = Math.max(0, Number(rawShieldGen || 0));
+  return { count: legacyTotal > 0 ? 1 : 0, value: legacyTotal };
+}
+
+function getShieldGenTotal(rawShieldGen) {
+  const cfg = normalizeShieldGenConfig(rawShieldGen);
+  return cfg.count * cfg.value;
+}
+
+function getBalancedGeneratorSegments(value) {
+  const total = Math.max(0, Number(value || 0));
+  if (total <= 4) return [total];
+  const outer = Math.ceil(total / 2);
+  const inner = total - outer;
+  return inner > 0 ? [outer, inner] : [outer];
 }
 
 function clamp(value, min, max) {
@@ -404,9 +478,9 @@ function normalizeTurnOption(value) {
 function readSublight() {
   const speeds = [6, 5, 4, 3, 2, 1, 0];
   return {
-    maxAccPhs: num('sublightMaxAcc'),
-    greenCircles: clamp(num('sublightGreen'), 0, 3),
-    redCircles: clamp(num('sublightRed'), 0, 3),
+    maxAccPhs: Math.max(0, num('vector')),
+    greenCircles: clamp(num('sublightGreen'), 0, 5),
+    redCircles: clamp(num('sublightRed'), 0, 5),
     spd: speeds.map((speed) => speed),
     turns: speeds.map((speed) => normalizeTurnOption(num(`sublightTurn${speed}`))),
     dmgStops: speeds.map((speed) => Boolean(form.elements[`sublightDmg${speed}`]?.checked))
@@ -482,7 +556,7 @@ function readPowerSystem() {
       key: track.key,
       label: track.label,
       points: Math.max(0, num(track.pointsField)),
-      boxesPerPoint: clamp(num(track.boxesField), 1, 3),
+      boxesPerPoint: 1,
       boxPattern: parsePowerPattern(form.elements[track.patternField]?.value),
       hasDot: Boolean(form.elements[track.hasDotField]?.checked)
     }))
@@ -528,7 +602,10 @@ function getBuild() {
       port: num('armorPort'),
       starboard: num('armorStbd')
     },
-    shieldGen: num('shieldGen'),
+    shieldGen: {
+      count: Math.max(0, num('shieldGenCount')),
+      value: Math.max(0, num('shieldGenValue'))
+    },
     textBlocks: {
       powerSystem: form.elements.powerSystem?.value ?? ''
     },
@@ -553,6 +630,59 @@ function renderBoxes(containerId, count, className) {
     const box = document.createElement('span');
     box.className = className;
     container.appendChild(box);
+  }
+}
+
+function renderShieldFacingBoxes(containerId, count, orientation = 'row') {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  container.innerHTML = '';
+  container.classList.add('is-split');
+
+  const total = Math.max(0, Number(count || 0));
+  if (total <= 0) {
+    return;
+  }
+
+  const outerCount = Math.ceil(total / 2);
+  const innerCount = total - outerCount;
+  const laneCounts = innerCount > 0 ? [outerCount, innerCount] : [outerCount];
+
+  laneCounts.forEach((laneCount) => {
+    const lane = document.createElement('div');
+    lane.className = `shield-split-lane ${orientation}-lane`;
+    for (let i = 0; i < laneCount; i += 1) {
+      const box = document.createElement('span');
+      box.className = 'shield-box';
+      lane.appendChild(box);
+    }
+    container.appendChild(lane);
+  });
+}
+
+function renderShieldGeneratorFacingBoxes(containerId, shieldGenConfig, orientation = 'row') {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  container.innerHTML = '';
+  container.classList.add('is-split');
+
+  const cfg = normalizeShieldGenConfig(shieldGenConfig);
+  if (cfg.count <= 0 || cfg.value <= 0) return;
+
+  for (let laneIdx = 0; laneIdx < cfg.count; laneIdx += 1) {
+    const segments = getBalancedGeneratorSegments(cfg.value);
+    segments.forEach((segmentValue) => {
+      const lane = document.createElement('div');
+      lane.className = `shield-split-lane ${orientation}-lane`;
+      for (let boxIdx = 0; boxIdx < segmentValue; boxIdx += 1) {
+        const box = document.createElement('span');
+        box.className = 'shield-gen';
+        lane.appendChild(box);
+      }
+      container.appendChild(lane);
+    });
   }
 }
 
@@ -590,8 +720,12 @@ function weaponSlot(id, rawWeapon, enabled = true) {
   const rangeGrid = document.createElement('div');
   rangeGrid.className = 'wpn-range-grid';
   const traits = weapon.traits.map((trait) => trait.trim()).filter(Boolean);
-  const hasHvy = traits.some((trait) => trait.toUpperCase() === 'HVY');
-  const hasHoming = traits.some((trait) => trait.toUpperCase() === 'HOMING');
+  const hasHoming = traits.some((trait) => {
+    const normalizedTrait = trait.toUpperCase();
+    return normalizedTrait === 'HOMING' || normalizedTrait.startsWith('HOMING ');
+  });
+  const hasRedDice = weapon.ranges.some((range) => (Array.isArray(range?.dice) ? range.dice : [])
+    .some((die) => String(die).trim().toUpperCase() === 'R'));
 
   weapon.ranges.forEach((range) => {
     const rangeCol = document.createElement('div');
@@ -623,7 +757,7 @@ function weaponSlot(id, rawWeapon, enabled = true) {
   });
   body.appendChild(rangeGrid);
 
-  if (hasHvy && weapon.special) {
+  if (hasRedDice && weapon.special) {
     const special = document.createElement('div');
     special.className = 'wpn-special-row';
     special.innerHTML = `<b>SPECIAL:</b> ${weapon.special}`;
@@ -708,7 +842,7 @@ function renderStructure(build) {
 function circleRun(containerId, count) {
   const container = document.getElementById(containerId);
   container.innerHTML = '';
-  for (let i = 0; i < clamp(count, 0, 3); i += 1) {
+  for (let i = 0; i < clamp(count, 0, 5); i += 1) {
     const circle = document.createElement('span');
     circle.className = 'rnd-circle';
     container.appendChild(circle);
@@ -717,9 +851,9 @@ function circleRun(containerId, count) {
 
 function renderManeuvering(sublight) {
   const data = sublight || {
-    maxAccPhs: 0,
-    greenCircles: 0,
-    redCircles: 0,
+    maxAccPhs: 2,
+    greenCircles: 3,
+    redCircles: 3,
     spd: [6, 5, 4, 3, 2, 1, 0],
     turns: [20, 20, 20, 20, 20, 20, 20],
     dmgStops: [false, false, false, false, false, false, false]
@@ -780,16 +914,25 @@ function renderPreview(build, options = {}) {
 
   const blackGenRow = document.getElementById('pvShieldGenBlackBoxes');
   blackGenRow.innerHTML = '';
-  for (let i = 0; i < build.shieldGen; i += 1) {
-    const box = document.createElement('span');
-    box.className = 'shield-gen-black';
-    blackGenRow.appendChild(box);
+  const shieldGenConfig = normalizeShieldGenConfig(build.shieldGen);
+  for (let laneIdx = 0; laneIdx < shieldGenConfig.count; laneIdx += 1) {
+    const segments = getBalancedGeneratorSegments(shieldGenConfig.value);
+    segments.forEach((segmentValue) => {
+      const lane = document.createElement('div');
+      lane.className = 'shield-split-lane row-lane';
+      for (let boxIdx = 0; boxIdx < segmentValue; boxIdx += 1) {
+        const box = document.createElement('span');
+        box.className = 'shield-gen-black';
+        lane.appendChild(box);
+      }
+      blackGenRow.appendChild(lane);
+    });
   }
 
-  renderBoxes('pvFwdShieldBoxes', build.shields.forward, 'shield-box');
-  renderBoxes('pvAftShieldBoxes', build.shields.aft, 'shield-box');
-  renderBoxes('pvPortShieldBoxes', build.shields.port, 'shield-box');
-  renderBoxes('pvStbdShieldBoxes', build.shields.starboard, 'shield-box');
+  renderShieldFacingBoxes('pvFwdShieldBoxes', build.shields.forward, 'row');
+  renderShieldFacingBoxes('pvAftShieldBoxes', build.shields.aft, 'row');
+  renderShieldFacingBoxes('pvPortShieldBoxes', build.shields.port, 'column');
+  renderShieldFacingBoxes('pvStbdShieldBoxes', build.shields.starboard, 'column');
 
   const armor = build.armor || { forward: 0, aft: 0, port: 0, starboard: 0 };
   renderBoxes('pvFwdArmorBoxes', armor.forward, 'armor-box');
@@ -797,10 +940,10 @@ function renderPreview(build, options = {}) {
   renderBoxes('pvPortArmorBoxes', armor.port, 'armor-box');
   renderBoxes('pvStbdArmorBoxes', armor.starboard, 'armor-box');
 
-  renderBoxes('pvFwdGenBoxes', build.shieldGen, 'shield-gen');
-  renderBoxes('pvAftGenBoxes', build.shieldGen, 'shield-gen');
-  renderBoxes('pvPortGenBoxes', build.shieldGen, 'shield-gen');
-  renderBoxes('pvStbdGenBoxes', build.shieldGen, 'shield-gen');
+  renderShieldGeneratorFacingBoxes('pvFwdGenBoxes', shieldGenConfig, 'row');
+  renderShieldGeneratorFacingBoxes('pvAftGenBoxes', shieldGenConfig, 'row');
+  renderShieldGeneratorFacingBoxes('pvPortGenBoxes', shieldGenConfig, 'column');
+  renderShieldGeneratorFacingBoxes('pvStbdGenBoxes', shieldGenConfig, 'column');
 
   const artEl = document.getElementById('pvShipArt');
   const silhouetteEl = document.getElementById('pvShipSilhouette');
@@ -814,7 +957,7 @@ function renderPreview(build, options = {}) {
     silhouetteEl.style.display = 'block';
   }
 
-  renderFunctions(build.functionsConfig);
+  renderFunctions(build.functionsConfig, build.systems);
   renderPowerSystem(build.powerSystem);
   renderManeuvering(build.sublight);
 
@@ -840,8 +983,10 @@ function applyDynamicLayoutDensity(build) {
     return count + 1;
   }, 0);
 
-  const systemsCount = Array.isArray(build?.systems) ? build.systems.length : 0;
-  const shieldDensity = Number(build?.shieldGen || 0) + Number(build?.shields?.forward || 0) + Number(build?.shields?.aft || 0);
+  const systemsCount = Array.isArray(build?.systems)
+    ? build.systems.filter((entry) => Number(entry?.value || 0) > 0).length
+    : 0;
+  const shieldDensity = getShieldGenTotal(build?.shieldGen) + Number(build?.shields?.forward || 0) + Number(build?.shields?.aft || 0);
 
   let density = 'normal';
   if (weaponSlots >= 3 || systemsCount >= 9 || shieldDensity >= 34) {
@@ -854,7 +999,7 @@ function applyDynamicLayoutDensity(build) {
 }
 
 
-function renderFunctions(functionsConfig) {
+function renderFunctions(functionsConfig, systems = []) {
   const container = document.getElementById('pvFunctions');
   container.innerHTML = '';
   const cfg = functionsConfig || {};
@@ -900,7 +1045,7 @@ function renderFunctions(functionsConfig) {
     });
   };
 
-  const acc = cfg.accDec || { values: ['1', '2', '3', '4', '5', '6'], free: 1 };
+  const acc = cfg.accDec || { values: ['1', '2', '3'], free: 0 };
   addValueDots(addRow('ACC/DEC', 'green'), acc.values, acc.free);
 
   const sif = cfg.sifIdf || { values: ['1', '2', '3'], free: 0, emer: true };
@@ -919,18 +1064,12 @@ function renderFunctions(functionsConfig) {
     sifLevels.appendChild(emer);
   }
 
-  const bat = cfg.batRech || { values: ['1'], free: 0 };
+  const bat = cfg.batRech || { values: [], free: 0 };
   addValueDots(addRow('BAT RECH', 'green'), bat.values, 0);
 
   const ftl = cfg.ftl || { empty: 2 };
   const ftlLevels = addRow('FTL', 'green');
   for (let i = 0; i < Number(ftl.empty || 0); i += 1) addDot(ftlLevels, false);
-
-  const cloak = cfg.cloak || { enabled: false, empty: 3 };
-  if (cloak.enabled) {
-    const cloakLevels = addRow('CLOAK', 'magenta');
-    for (let i = 0; i < Number(cloak.empty || 0); i += 1) addDot(cloakLevels, false);
-  }
 
   const shldRenf = addRow('SHLD RNFC', 'cyan');
   ['F', 'P', 'S', 'A'].forEach((part) => {
@@ -944,11 +1083,22 @@ function renderFunctions(functionsConfig) {
     addToken(shldRepr, part);
   });
 
-  const sensor = cfg.sensor || { values: ['2', '4', '6'], free: 1 };
+  const sensor = cfg.sensor || { values: [], free: 0 };
   addValueDots(addRow('SENSOR', 'gold'), sensor.values, sensor.free);
 
-  const gen = cfg.genSys || { values: ['NRM', 'MAX'], free: 1 };
+  const gen = cfg.genSys || { values: ['NRM', 'MAX'], free: 0 };
   addValueDots(addRow('GEN SYS', 'gold'), gen.values, gen.free);
+
+  const specialSystems = (Array.isArray(systems) ? systems : [])
+    .map((entry) => ({
+      key: String(entry?.key || '').toUpperCase(),
+      power: Math.max(0, Number(entry?.power || 0))
+    }))
+    .filter((entry) => SPECIAL_SYSTEM_KEYS.has(entry.key) && entry.power > 0);
+  specialSystems.forEach((entry) => {
+    const levels = addRow(entry.key, 'magenta');
+    for (let i = 0; i < entry.power; i += 1) addDot(levels, false);
+  });
 
   const weapons = Array.isArray(cfg.weapons) ? cfg.weapons : [];
   weapons.forEach((weapon, idx) => {
@@ -966,6 +1116,9 @@ function renderSystems(systems, crew) {
   const rows = Array.isArray(systems) ? systems : [];
 
   rows.forEach((entry) => {
+    const count = Math.max(0, Number(entry?.value || 0));
+    if (count <= 0) return;
+
     const row = document.createElement('div');
     row.className = 'system-row';
 
@@ -974,7 +1127,6 @@ function renderSystems(systems, crew) {
     key.textContent = String(entry.key || '').slice(0, 5).toUpperCase();
     row.appendChild(key);
 
-    const count = Math.max(0, Number(entry.value || 0));
     for (let i = 0; i < count; i += 1) {
       const box = document.createElement('span');
       box.className = 'system-box';
@@ -1130,6 +1282,58 @@ function restoreDraft(draft) {
       field.checked = Boolean(checked);
     }
   };
+  const setWeaponTraitSelections = (index, traits = []) => {
+    const grid = getField(`wpn${index}TraitsGrid`) || document.getElementById(`wpn${index}TraitsGrid`);
+    if (grid) {
+      const normalized = new Set((Array.isArray(traits) ? traits : [])
+        .map((trait) => String(trait || '').trim().toUpperCase())
+        .filter(Boolean));
+      grid.querySelectorAll('.trait-toggle').forEach((button) => {
+        const value = String(button.dataset.value || '').toUpperCase();
+        const active = normalized.has(value);
+        button.classList.toggle('active', active);
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+      return;
+    }
+
+    const field = getField(`wpn${index}Traits`);
+    if (!field || !('options' in field)) return;
+
+    const normalized = new Set((Array.isArray(traits) ? traits : [])
+      .map((trait) => String(trait || '').trim().toUpperCase())
+      .filter(Boolean));
+
+    normalized.forEach((trait) => {
+      if (![...field.options].some((option) => option.value.toUpperCase() === trait)) {
+        const option = document.createElement('option');
+        option.value = trait;
+        option.textContent = trait;
+        field.appendChild(option);
+      }
+    });
+
+    [...field.options].forEach((option) => {
+      option.selected = normalized.has(String(option.value || '').toUpperCase());
+    });
+  };
+  const setWeaponSpecialSelections = (index, specialText = '') => {
+    const matches = String(specialText || '').matchAll(/\b(DMG|LEAK|STR)\b\s*[:=]?\s*(\d+)/gi);
+    let dmg = 0;
+    let leak = 0;
+    let str = 0;
+    for (const [, keyRaw, valueRaw] of matches) {
+      const key = String(keyRaw || '').toUpperCase();
+      const value = Number(valueRaw || 0);
+      if (!Number.isFinite(value)) continue;
+      if (key === 'DMG') dmg = clamp(value, 0, 8);
+      if (key === 'LEAK') leak = clamp(value, 0, 4);
+      if (key === 'STR') str = clamp(value, 0, 4);
+    }
+    setValue(`wpn${index}SpecialDmg`, dmg > 0 ? dmg : 0);
+    setValue(`wpn${index}SpecialLeak`, leak > 0 ? leak : '');
+    setValue(`wpn${index}SpecialStr`, str > 0 ? str : '');
+  };
 
   setValue('name', safeDraft.identity?.name ?? '');
   setValue('classType', safeDraft.identity?.classType ?? '');
@@ -1150,7 +1354,9 @@ function restoreDraft(draft) {
   setValue('armorPort', safeDraft.armor?.port ?? 0);
   setValue('armorStbd', safeDraft.armor?.starboard ?? 0);
 
-  setValue('shieldGen', safeDraft.shieldGen ?? 0);
+  const shieldGen = normalizeShieldGenConfig(safeDraft.shieldGen);
+  setValue('shieldGenCount', shieldGen.count);
+  setValue('shieldGenValue', shieldGen.value);
 
   const fn = safeDraft.functionsConfig || {};
   setValue('fnAccDecValues', (fn.accDec?.values ?? []).join(','));
@@ -1192,18 +1398,16 @@ function restoreDraft(draft) {
   POWER_TRACK_CONFIG.forEach((track) => {
     const trackData = draftTracks.find((entry) => entry.key === track.key || entry.label === track.label);
     const pointsField = getField(track.pointsField);
-    const boxesField = getField(track.boxesField);
     const patternField = getField(track.patternField);
     const hasDotField = getField(track.hasDotField);
 
     if (pointsField) {
       pointsField.value = Math.max(0, Number(trackData?.points ?? 0));
     }
-    if (boxesField) {
-      boxesField.value = clamp(Number(trackData?.boxesPerPoint ?? 1), 1, 3);
-    }
     if (patternField) {
-      patternField.value = (trackData?.boxPattern ?? []).join(',');
+      const pattern = Array.isArray(trackData?.boxPattern) ? trackData.boxPattern : [];
+      const fallback = clamp(Number(trackData?.boxesPerPoint ?? 1), 1, 3);
+      patternField.value = (pattern.length > 0 ? pattern : [fallback]).join(',');
     }
     if (hasDotField) {
       hasDotField.checked = Boolean(trackData?.hasDot ?? (track.key !== 'ftlDrive'));
@@ -1211,14 +1415,13 @@ function restoreDraft(draft) {
   });
 
   const sublight = safeDraft.sublight ?? {
-    maxAccPhs: 0,
-    greenCircles: 0,
-    redCircles: 0,
+    maxAccPhs: 2,
+    greenCircles: 3,
+    redCircles: 3,
     spd: [6, 5, 4, 3, 2, 1, 0],
     turns: [20, 20, 20, 20, 20, 20, 20],
     dmgStops: [false, false, false, false, false, false, false]
   };
-  setValue('sublightMaxAcc', sublight.maxAccPhs ?? 0);
   setValue('sublightGreen', sublight.greenCircles ?? 0);
   setValue('sublightRed', sublight.redCircles ?? 0);
   [6, 5, 4, 3, 2, 1, 0].forEach((speed, index) => {
@@ -1237,7 +1440,7 @@ function restoreDraft(draft) {
   [1, 2, 3, 4].forEach((index) => {
     const weapon = normalizedWeapons[index - 1] || normalizeWeapon({});
     setValue(`wpn${index}Name`, weapon.name || '');
-    setValue(`wpn${index}Traits`, (weapon.traits || []).join(', '));
+    setWeaponTraitSelections(index, weapon.traits || []);
     setValue(`wpn${index}MountArcs`, (weapon.mountFacings || []).map((mount) => mount.join(',')).join('|'));
     setValue(`wpn${index}PowerCircles`, weapon.powerCircles ?? 1);
     setValue(`wpn${index}PowerStops`, (weapon.powerStops || []).join(', '));
@@ -1247,13 +1450,17 @@ function restoreDraft(draft) {
       const dice = (range.dice || []).join(',');
       return Number(range.bonus || 0) > 0 ? `${Number(range.bonus)},${dice}` : dice;
     }).join('|'));
-    setValue(`wpn${index}Special`, weapon.special || '');
+    setWeaponSpecialSelections(index, weapon.special || '');
   });
 
   const normalizedSystems = Array.isArray(safeDraft.systems)
     ? safeDraft.systems
     : parseSystems(safeDraft.systems || '');
-  setValue('systems', normalizedSystems.map((item) => `${item.key}:${item.value ?? ''}`).join('\n'));
+  setValue('systems', normalizedSystems
+    .map((item) => (item?.power !== undefined
+      ? `${item.key}:${item.value ?? '0'}:${item.power ?? '0'}`
+      : `${item.key}:${item.value ?? '0'}`))
+    .join('\n'));
   setValue('shuttleCraft', safeDraft.crew?.shuttleCraft ?? 0);
   setValue('marinesStationed', safeDraft.crew?.marinesStationed ?? 0);
 
@@ -1322,6 +1529,31 @@ function importJsonFile(file) {
   reader.readAsText(file);
 }
 
+function initializeTraitToggleGrids() {
+  document.querySelectorAll('.trait-toggle-grid').forEach((gridEl) => {
+    const selectedByDefault = new Set(String(gridEl.dataset.defaultTraits || '')
+      .split(',')
+      .map((trait) => trait.trim().toUpperCase())
+      .filter(Boolean));
+
+    gridEl.innerHTML = '';
+    TRAIT_OPTIONS.forEach((trait) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = `trait-toggle${selectedByDefault.has(trait.toUpperCase()) ? ' active' : ''}`;
+      button.dataset.value = trait;
+      button.setAttribute('aria-pressed', selectedByDefault.has(trait.toUpperCase()) ? 'true' : 'false');
+      button.textContent = trait;
+      button.addEventListener('click', () => {
+        const isActive = button.classList.toggle('active');
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        gridEl.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+      gridEl.appendChild(button);
+    });
+  });
+}
+
 form.addEventListener('input', () => render({ recalculatePointValue: false }));
 form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
@@ -1366,6 +1598,8 @@ shipArtInput.addEventListener('change', (event) => {
   };
   reader.readAsDataURL(file);
 });
+
+initializeTraitToggleGrids();
 
 applyCrossBrowserPrintFit();
 

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -112,23 +112,22 @@
         <div class="power-system-editor">
           <strong>Power System Tracks</strong>
           <p class="muted">Set points, optional per-point box pattern (e.g. 1,2,1,2), and whether a track shows a green dot.</p>
-          <div class="power-grid-head"><span>Track</span><span>Points</span><span>Boxes/Point</span><span>Pattern</span><span>Dot</span></div>
+          <div class="power-grid-head"><span>Track</span><span>Points</span><span>Boxes/Pattern</span><span>Dot</span></div>
           <div class="power-grid">
-            <label>L MAIN</label><input name="powerLMainPoints" type="number" min="0" value="4" /><input name="powerLMainBoxes" type="number" min="1" max="3" value="2" /><input name="powerLMainPattern" value="" placeholder="1,2,1,2" /><input name="powerLMainHasDot" type="checkbox" checked />
-            <label>R MAIN</label><input name="powerRMainPoints" type="number" min="0" value="4" /><input name="powerRMainBoxes" type="number" min="1" max="3" value="2" /><input name="powerRMainPattern" value="" placeholder="1,2,1,2" /><input name="powerRMainHasDot" type="checkbox" checked />
-            <label>C MAIN</label><input name="powerCMainPoints" type="number" min="0" value="0" /><input name="powerCMainBoxes" type="number" min="1" max="3" value="2" /><input name="powerCMainPattern" value="" placeholder="1,2,1,2" /><input name="powerCMainHasDot" type="checkbox" checked />
-            <label>SL REAC</label><input name="powerSlReacPoints" type="number" min="0" value="1" /><input name="powerSlReacBoxes" type="number" min="1" max="3" value="2" /><input name="powerSlReacPattern" value="" placeholder="1,2,1,2" /><input name="powerSlReacHasDot" type="checkbox" checked />
-            <label>AUX PWR</label><input name="powerAuxPwrPoints" type="number" min="0" value="1" /><input name="powerAuxPwrBoxes" type="number" min="1" max="3" value="2" /><input name="powerAuxPwrPattern" value="" placeholder="1,2,1,2" /><input name="powerAuxPwrHasDot" type="checkbox" checked />
-            <label>BATTERY</label><input name="powerBatteryPoints" type="number" min="0" value="1" /><input name="powerBatteryBoxes" type="number" min="1" max="3" value="1" /><input name="powerBatteryPattern" value="" placeholder="1,2,1,2" /><input name="powerBatteryHasDot" type="checkbox" checked />
-            <label>FTL DRIVE</label><input name="powerFtlDrivePoints" type="number" min="0" value="1" /><input name="powerFtlDriveBoxes" type="number" min="1" max="3" value="2" /><input name="powerFtlDrivePattern" value="" placeholder="1,2,1,2" /><input name="powerFtlDriveHasDot" type="checkbox" />
+            <label>L MAIN</label><input name="powerLMainPoints" type="number" min="0" value="4" /><input name="powerLMainPattern" value="2" placeholder="2,1,2" /><input name="powerLMainHasDot" type="checkbox" checked />
+            <label>R MAIN</label><input name="powerRMainPoints" type="number" min="0" value="4" /><input name="powerRMainPattern" value="2" placeholder="2,1,2" /><input name="powerRMainHasDot" type="checkbox" checked />
+            <label>C MAIN</label><input name="powerCMainPoints" type="number" min="0" value="0" /><input name="powerCMainPattern" value="2" placeholder="2,1,2" /><input name="powerCMainHasDot" type="checkbox" checked />
+            <label>SL REAC</label><input name="powerSlReacPoints" type="number" min="0" value="1" /><input name="powerSlReacPattern" value="2" placeholder="2,1,2" /><input name="powerSlReacHasDot" type="checkbox" checked />
+            <label>AUX PWR</label><input name="powerAuxPwrPoints" type="number" min="0" value="1" /><input name="powerAuxPwrPattern" value="2" placeholder="2,1,2" /><input name="powerAuxPwrHasDot" type="checkbox" checked />
+            <label>BATTERY</label><input name="powerBatteryPoints" type="number" min="0" value="1" /><input name="powerBatteryPattern" value="1" placeholder="2,1,2" /><input name="powerBatteryHasDot" type="checkbox" checked />
+            <label>FTL DRIVE</label><input name="powerFtlDrivePoints" type="number" min="0" value="1" /><input name="powerFtlDrivePattern" value="1" placeholder="2,1,2" /><input name="powerFtlDriveHasDot" type="checkbox" />
           </div>
         </div>
         <div class="maneuver-editor">
           <strong>Sublight Drive & Maneuvering</strong>
           <div class="grid3">
-            <label>MAX ACC / PHS <input name="sublightMaxAcc" type="number" min="0" value="2" /></label>
-            <label>Green RND Circles (0-3) <input name="sublightGreen" type="number" min="0" max="3" value="3" /></label>
-            <label>Red RND Circles (0-3) <input name="sublightRed" type="number" min="0" max="3" value="3" /></label>
+            <label>Green RND Circles (0-5) <input name="sublightGreen" type="number" min="0" max="5" value="3" /></label>
+            <label>Red RND Circles (0-5) <input name="sublightRed" type="number" min="0" max="5" value="3" /></label>
           </div>
           <div class="maneuver-grid-head"><span>Speed</span><span>DMG Stop</span><span>TURN °</span></div>
           <div class="maneuver-grid" id="maneuverGridInputs">
@@ -143,13 +142,12 @@
         </div>
 
         <h2>Weapons (up to 4)</h2>
-        <p class="muted">Each weapon supports up to 8 mounts, power circles/stops, structure, per-range dice colors (no longer capped by structure), HOMING band boxes, and optional SPECIAL text (enabled by the HVY trait).</p>
+        <p class="muted">Each weapon supports up to 8 mounts, power circles/stops, structure, per-range dice colors (no longer capped by structure), HOMING band boxes, and optional SPECIAL text (shown when red dice are present).</p>
         <div class="weapon-editor-list">
           <fieldset class="weapon-editor-card">
             <legend>Weapon A</legend>
             <div class="grid2">
               <label>Name <input name="wpn1Name" value="WPN NAME" /></label>
-              <label>Traits (comma separated) <input name="wpn1Traits" value="HVY, FTL, NoBAT" /></label>
             </div>
             <label>Mount arcs (per mount as wedge values, e.g. <code>1,2|5,6</code>)
               <input name="wpn1MountArcs" value="1,2|5,6" />
@@ -165,8 +163,25 @@
             <label>Dice per band (optional bonus first: <code>8,R,R|4,R,R</code>)
               <input name="wpn1Dice" value="8,R,R|4,R,R|4,R,R|2,R,R" />
             </label>
-            <label>Special (shown only when HVY trait is present)
-              <input name="wpn1Special" value="H(4+1), STR 2" />
+            <div class="grid3">
+              <label>Special DMG (0-8)
+                <select name="wpn1SpecialDmg">
+                  <option value="0">0</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4" selected>4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option>
+                </select>
+              </label>
+              <label>Special LEAK (1-4)
+                <select name="wpn1SpecialLeak">
+                  <option value="" selected>—</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option>
+                </select>
+              </label>
+              <label>Special STR (1-4)
+                <select name="wpn1SpecialStr">
+                  <option value="">—</option><option value="1">1</option><option value="2" selected>2</option><option value="3">3</option><option value="4">4</option>
+                </select>
+              </label>
+            </div>
+            <label>Traits
+              <div id="wpn1TraitsGrid" class="trait-toggle-grid" data-default-traits="FTL,NOBAT"></div>
             </label>
           </fieldset>
 
@@ -174,7 +189,6 @@
             <legend>Weapon B</legend>
             <div class="grid2">
               <label>Name <input name="wpn2Name" value="" placeholder="Optional" /></label>
-              <label>Traits (comma separated) <input name="wpn2Traits" value="" /></label>
             </div>
             <label>Mount arcs <input name="wpn2MountArcs" value="" placeholder="1,2|5,6" /></label>
             <div class="grid3">
@@ -184,14 +198,32 @@
             </div>
             <label>Range bands <input name="wpn2Ranges" value="" placeholder="0-6:green,7-12:black" /></label>
             <label>Dice per band <input name="wpn2Dice" value="" placeholder="R,R|Y,Y" /></label>
-            <label>Special <input name="wpn2Special" value="" /></label>
+            <div class="grid3">
+              <label>Special DMG (0-8)
+                <select name="wpn2SpecialDmg">
+                  <option value="0" selected>0</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option>
+                </select>
+              </label>
+              <label>Special LEAK (1-4)
+                <select name="wpn2SpecialLeak">
+                  <option value="" selected>—</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option>
+                </select>
+              </label>
+              <label>Special STR (1-4)
+                <select name="wpn2SpecialStr">
+                  <option value="" selected>—</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option>
+                </select>
+              </label>
+            </div>
+            <label>Traits
+              <div id="wpn2TraitsGrid" class="trait-toggle-grid"></div>
+            </label>
           </fieldset>
 
           <fieldset class="weapon-editor-card">
             <legend>Weapon C</legend>
             <div class="grid2">
               <label>Name <input name="wpn3Name" value="" placeholder="Optional" /></label>
-              <label>Traits (comma separated) <input name="wpn3Traits" value="" /></label>
             </div>
             <label>Mount arcs <input name="wpn3MountArcs" value="" /></label>
             <div class="grid3">
@@ -201,14 +233,32 @@
             </div>
             <label>Range bands <input name="wpn3Ranges" value="" /></label>
             <label>Dice per band <input name="wpn3Dice" value="" /></label>
-            <label>Special <input name="wpn3Special" value="" /></label>
+            <div class="grid3">
+              <label>Special DMG (0-8)
+                <select name="wpn3SpecialDmg">
+                  <option value="0" selected>0</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option>
+                </select>
+              </label>
+              <label>Special LEAK (1-4)
+                <select name="wpn3SpecialLeak">
+                  <option value="" selected>—</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option>
+                </select>
+              </label>
+              <label>Special STR (1-4)
+                <select name="wpn3SpecialStr">
+                  <option value="" selected>—</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option>
+                </select>
+              </label>
+            </div>
+            <label>Traits
+              <div id="wpn3TraitsGrid" class="trait-toggle-grid"></div>
+            </label>
           </fieldset>
 
           <fieldset class="weapon-editor-card">
             <legend>Weapon D</legend>
             <div class="grid2">
               <label>Name <input name="wpn4Name" value="" placeholder="Optional" /></label>
-              <label>Traits (comma separated) <input name="wpn4Traits" value="" /></label>
             </div>
             <label>Mount arcs <input name="wpn4MountArcs" value="" /></label>
             <div class="grid3">
@@ -218,7 +268,26 @@
             </div>
             <label>Range bands <input name="wpn4Ranges" value="" /></label>
             <label>Dice per band <input name="wpn4Dice" value="" /></label>
-            <label>Special <input name="wpn4Special" value="" /></label>
+            <div class="grid3">
+              <label>Special DMG (0-8)
+                <select name="wpn4SpecialDmg">
+                  <option value="0" selected>0</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option>
+                </select>
+              </label>
+              <label>Special LEAK (1-4)
+                <select name="wpn4SpecialLeak">
+                  <option value="" selected>—</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option>
+                </select>
+              </label>
+              <label>Special STR (1-4)
+                <select name="wpn4SpecialStr">
+                  <option value="" selected>—</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option>
+                </select>
+              </label>
+            </div>
+            <label>Traits
+              <div id="wpn4TraitsGrid" class="trait-toggle-grid"></div>
+            </label>
           </fieldset>
         </div>
 
@@ -245,14 +314,31 @@
             <label>Armor <input name="armorStbd" type="number" min="0" value="0" /></label>
           </fieldset>
         </div>
-        <label>Shield Generators (single value for all facings) <input name="shieldGen" type="number" min="0" value="0" /></label>
+        <div class="grid2">
+          <label>Shield Generators: Count (rows) <input name="shieldGenCount" type="number" min="0" value="0" /></label>
+          <label>Shield Generators: Value (boxes per row) <input name="shieldGenValue" type="number" min="0" value="0" /></label>
+        </div>
         <label>Ship Art (for shield center)
           <input name="shipArt" id="shipArt" type="file" accept="image/*" />
         </label>
         <button type="button" id="clearArtBtn" class="ghost">Clear Ship Art</button>
 
         <h2>Systems (one per line)</h2>
-        <label><textarea name="systems" rows="4" placeholder="SCNC:3\nSENS:4\nQTRS:2"></textarea></label>
+        <label><textarea name="systems" rows="4">SCNC:0
+SENS:0
+TRAC:0
+TRAN:0
+SHTL:0
+QTRS:0
+CRGO:0
+HNGR:0
+LNCH:0
+LAND:0
+CLOAK:0:0
+CMND:0:0
+FCON:0:0
+SCOUT:0:0</textarea></label>
+        <p class="muted">Format: <code>KEY:boxes</code> or <code>KEY:boxes:power</code> for special systems. If <code>boxes</code> is 0, that line is hidden in the SSD systems panel.</p>
         <div class="grid2">
           <label>Shuttle Craft <input name="shuttleCraft" type="number" min="0" value="4" /></label>
           <label>Marines Stationed <input name="marinesStationed" type="number" min="0" value="10" /></label>

--- a/starforce-commander-ship-designer/pv-calculator.js
+++ b/starforce-commander-ship-designer/pv-calculator.js
@@ -178,6 +178,15 @@ function positivePart(value, fallback = 0) {
   return Math.max(0, parsed);
 }
 
+function shieldGeneratorTotal(shieldGen) {
+  if (shieldGen && typeof shieldGen === 'object') {
+    const count = positivePart(shieldGen.count);
+    const value = positivePart(shieldGen.value);
+    return count * value;
+  }
+  return positivePart(shieldGen);
+}
+
 function safeRun(scorer, fallback = 0) {
   try {
     return positivePart(scorer(), fallback);
@@ -266,7 +275,7 @@ function scoreDefense(build) {
   const capitalHullPremium = 1
     + Math.min(0.55, Math.max(0, (totalStructure - 12) * 0.03) + (repairable * 0.05));
 
-  const generatorScore = positivePart(build?.shieldGen) * 1.3 * rank(build, 'rankDefenseShieldGen');
+  const generatorScore = shieldGeneratorTotal(build?.shieldGen) * 1.3 * rank(build, 'rankDefenseShieldGen');
 
   return shieldScore
     + armorScore

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -91,7 +91,7 @@ textarea:focus, input:focus {
 .power-system-editor { border: 1px solid #7f93a2; border-radius: 6px; padding: 0.7rem; margin-top: 0.6rem; background: #edf3f7; }
 .power-system-editor strong { display: block; margin-bottom: 0.2rem; }
 .power-system-editor .muted { margin: 0 0 0.38rem; font-size: 0.8rem; color: #436079; }
-.power-grid-head, .power-grid { display: grid; grid-template-columns: minmax(0, 1fr) 74px 96px minmax(0, 1fr) 44px; gap: 0.4rem; align-items: center; }
+.power-grid-head, .power-grid { display: grid; grid-template-columns: minmax(0, 1fr) 74px minmax(0, 1fr) 44px; gap: 0.4rem; align-items: center; }
 .power-grid-head { margin: 0.15rem 0; color: #44617b; font-size: 0.76rem; }
 .power-grid label { margin: 0; font-weight: 700; }
 .power-grid input { margin: 0; }
@@ -282,8 +282,18 @@ button.ghost { background: #6d7f8d; border-color: #465764; }
 .shield-top { margin-bottom: 0.22rem; }
 .shield-bottom { margin-top: 0.22rem; }
 .shield-box-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.12rem 0.35rem; min-height: 20px; justify-content: center; }
+.shield-box-row.is-split {
+  flex-wrap: nowrap;
+  flex-direction: column;
+  align-items: center;
+}
 .armor-box-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.08rem 0.35rem; min-height: 18px; justify-content: center; }
 .shield-gen-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.12rem 0.35rem; min-height: 18px; justify-content: center; }
+.shield-gen-row.is-split {
+  flex-wrap: nowrap;
+  flex-direction: column;
+  align-items: center;
+}
 .fwd-gen-row { padding-top: 0.16rem; padding-bottom: 0.04rem; }
 .shield-gen-label { text-align: center; font-weight: 900; color: #0872c2; margin: 0.18rem 0 0.24rem; display: flex; justify-content: center; align-items: center; gap: 10px; font-size: 1rem; letter-spacing: 0.04em; line-height: 1.2; }
 .shield-gen-black-row { display: flex; gap: 4px; flex-wrap: wrap; }
@@ -387,6 +397,25 @@ button.ghost { background: #6d7f8d; border-color: #465764; }
   min-height: 112px;
   justify-content: center;
 }
+.shield-gen-col.is-split {
+  flex-direction: row;
+  align-items: center;
+}
+.shield-box-col.is-split {
+  flex-direction: row;
+  align-items: center;
+}
+.shield-split-lane {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+.shield-split-lane.row-lane {
+  flex-direction: row;
+}
+.shield-split-lane.column-lane {
+  flex-direction: column;
+}
 .systems-box { border-top: 0; margin-top: 0.8rem; border: 12px solid #f0b500; background: #f8f8f8; padding-bottom: 0.25rem; }
 .systems-box h3 { border-color: #f0b500; }
 .systems-layout { display: grid; grid-template-columns: 1fr 72px; gap: 0.35rem; padding: 0.2rem 0.25rem 0.1rem; align-items: start; }
@@ -406,6 +435,29 @@ button.ghost { background: #6d7f8d; border-color: #465764; }
 .weapon-editor-card code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; }
 .weapon-editor-card label { color: #17344c; font-weight: 700; }
 .weapon-editor-card input { border-color: #95a9b8; }
+.trait-toggle-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.28rem;
+  width: 100%;
+}
+.trait-toggle {
+  border: 1px solid #95a9b8;
+  border-radius: 4px;
+  background: #fff;
+  color: #17344c;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.2;
+  padding: 0.28rem 0.25rem;
+  text-align: center;
+  cursor: pointer;
+}
+.trait-toggle.active {
+  background: #0f78c2;
+  border-color: #0f78c2;
+  color: #fff;
+}
 .weapon-editor-card .grid2,
 .weapon-editor-card .grid3 { grid-template-columns: 1fr; gap: 0.45rem; }
 


### PR DESCRIPTION
### Motivation

- Improve the SSD editor to support richer weapon traits/specials, multi-row shield generators, and special-system power tracking. 
- Normalize legacy fields (single numeric shield generator, legacy weapons/systems) into structured configs for better rendering and PV calculation. 
- Make the preview UI more expressive for new inputs (trait toggles, split shield lanes, separate special DMG/LEAK/STR controls).

### Description

- Introduced structured shield generator config and helpers: `shieldGen` is now `{count,value}`, added `normalizeShieldGenConfig`, `getShieldGenTotal`, and `getBalancedGeneratorSegments`, updated rendering (`renderShieldGeneratorFacingBoxes`, `renderShieldFacingBoxes`) and PV scoring (`shieldGeneratorTotal` in `pv-calculator.js`).
- Reworked weapon traits and special handling: added `TRAIT_OPTIONS`, trait toggle grids (`initializeTraitToggleGrids`), new per-weapon special selects (`wpn#SpecialDmg/Leak/Str`), parsing/serialization helpers (`readWeaponTraits`, `readWeaponSpecial`, `setWeaponTraitSelections`, `setWeaponSpecialSelections`), and updated preview logic to show `SPECIAL` when red dice are present.
- Enhanced systems parsing to support special entries with power (e.g. `CLOAK:0:2`) and a set of `SPECIAL_SYSTEM_KEYS`, updated `parseSystems`, `renderFunctions` to render special-system power dots, and updated form import/export/restore to round-trip the new format.
- Form and UI changes in `index.html` and `styles.css`: replace comma-typed trait inputs with toggle grids, add `shieldGenCount`/`shieldGenValue` inputs, change power track pattern handling (removed boxes-per-point inputs), expand sublight circle limits, update default `STANDARD_DEFAULT_LOADOUT` values, and various layout/style updates for split lanes and trait toggles.

### Testing

- No automated tests were added or executed as part of this change.
- Smoke-tested locally by restoring the default loadout and rendering the preview to ensure new inputs appear and do not throw console errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0675ae9448332af1b453ced02f485)