### PR TITLE
Align weapons A/C/D editor UI with weapon B layout

### DIFF
--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -147,22 +147,16 @@
           <fieldset class="weapon-editor-card">
             <legend>Weapon A</legend>
             <div class="grid2">
-              <label>Name <input name="wpn1Name" value="WPN NAME" /></label>
+              <label>Name <input name="wpn1Name" value="WPN NAME" placeholder="Optional" /></label>
             </div>
-            <label>Mount arcs (per mount as wedge values, e.g. <code>1,2|5,6</code>)
-              <input name="wpn1MountArcs" value="1,2|5,6" />
-            </label>
+            <label>Mount arcs <input name="wpn1MountArcs" value="1,2|5,6" placeholder="1,2|5,6" /></label>
             <div class="special-row">
               <label>Power circles (1-6) <input name="wpn1PowerCircles" type="number" min="1" max="6" value="3" /></label>
               <label>Power stop positions (comma) <input name="wpn1PowerStops" value="2" placeholder="2,4" /></label>
               <label>Structure per mount (1-4) <input name="wpn1Structure" type="number" min="1" max="4" value="2" /></label>
             </div>
-            <label>Range bands (format <code>0-4:green,5-9:black</code> or <code>0-4,green,5-9,black</code>)
-              <input name="wpn1Ranges" value="0-4:green,5-9:black,10-13:red,14-16:red" />
-            </label>
-            <label>Dice per band (optional bonus first: <code>8,R,R|4,R,R</code>)
-              <input name="wpn1Dice" value="8,R,R|4,R,R|4,R,R|2,R,R" />
-            </label>
+            <label>Range bands <input name="wpn1Ranges" value="0-4:green,5-9:black,10-13:red,14-16:red" placeholder="0-6:green,7-12:black" /></label>
+            <label>Dice per band <input name="wpn1Dice" value="8,R,R|4,R,R|4,R,R|2,R,R" placeholder="R,R|Y,Y" /></label>
             <div class="special-row">
               <label>Special DMG (0-8)
                 <select name="wpn1SpecialDmg">
@@ -225,15 +219,15 @@
             <div class="grid2">
               <label>Name <input name="wpn3Name" value="" placeholder="Optional" /></label>
             </div>
-            <label>Mount arcs <input name="wpn3MountArcs" value="" /></label>
-            <div class="grid3">
+            <label>Mount arcs <input name="wpn3MountArcs" value="" placeholder="1,2|5,6" /></label>
+            <div class="special-row">
               <label>Power circles (1-6) <input name="wpn3PowerCircles" type="number" min="1" max="6" value="2" /></label>
               <label>Power stop positions (comma) <input name="wpn3PowerStops" value="" /></label>
               <label>Structure per mount (1-4) <input name="wpn3Structure" type="number" min="1" max="4" value="2" /></label>
             </div>
-            <label>Range bands <input name="wpn3Ranges" value="" /></label>
-            <label>Dice per band <input name="wpn3Dice" value="" /></label>
-            <div class="grid3">
+            <label>Range bands <input name="wpn3Ranges" value="" placeholder="0-6:green,7-12:black" /></label>
+            <label>Dice per band <input name="wpn3Dice" value="" placeholder="R,R|Y,Y" /></label>
+            <div class="special-row">
               <label>Special DMG (0-8)
                 <select name="wpn3SpecialDmg">
                   <option value="0" selected>0</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option>
@@ -260,15 +254,15 @@
             <div class="grid2">
               <label>Name <input name="wpn4Name" value="" placeholder="Optional" /></label>
             </div>
-            <label>Mount arcs <input name="wpn4MountArcs" value="" /></label>
-            <div class="grid3">
+            <label>Mount arcs <input name="wpn4MountArcs" value="" placeholder="1,2|5,6" /></label>
+            <div class="special-row">
               <label>Power circles (1-6) <input name="wpn4PowerCircles" type="number" min="1" max="6" value="2" /></label>
               <label>Power stop positions (comma) <input name="wpn4PowerStops" value="" /></label>
               <label>Structure per mount (1-4) <input name="wpn4Structure" type="number" min="1" max="4" value="2" /></label>
             </div>
-            <label>Range bands <input name="wpn4Ranges" value="" /></label>
-            <label>Dice per band <input name="wpn4Dice" value="" /></label>
-            <div class="grid3">
+            <label>Range bands <input name="wpn4Ranges" value="" placeholder="0-6:green,7-12:black" /></label>
+            <label>Dice per band <input name="wpn4Dice" value="" placeholder="R,R|Y,Y" /></label>
+            <div class="special-row">
               <label>Special DMG (0-8)
                 <select name="wpn4SpecialDmg">
                   <option value="0" selected>0</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option><option value="6">6</option><option value="7">7</option><option value="8">8</option>


### PR DESCRIPTION
### Motivation
- Make the weapons editor consistent so Weapons A, C, and D can be configured with the same controls, grouping, and input guidance as Weapon B. 
- Improve affordances and placeholders to reduce confusion when entering mount arcs, range bands, and dice profiles.

### Description
- Updated `starforce-commander-ship-designer/index.html` to add `placeholder` attributes for `Name`, `Mount arcs`, `Range bands`, and `Dice per band` inputs on Weapons A, C, and D to match Weapon B. 
- Changed the layout grouping for Weapon C and Weapon D power/structure controls from `.grid3` to the same `.special-row` grouping used by Weapon B for consistent spacing and alignment. 
- Normalized Weapon A labeling to use the simplified label style used by Weapon B while preserving its default values. 
- This PR is a UI markup change only and does not modify weapon parsing, normalization, or rendering logic in `app.js`.

### Testing
- Ran `git diff --check -- starforce-commander-ship-designer/index.html` to verify there are no whitespace or diff-check issues, and it passed. 
- Verified the changed markup with a local diff inspection of `starforce-commander-ship-designer/index.html` to confirm the intended input attribute and layout updates were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08f9adab88332a17fd54700bc4d7c)