### PR TITLE
Add PNG/JPEG export for live SSD preview

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -1514,6 +1514,91 @@ function exportCurrent() {
   downloadBlob(blob, `${name}.json`);
 }
 
+function cloneNodeWithInlineStyles(sourceNode) {
+  const clone = sourceNode.cloneNode(false);
+  if (sourceNode.nodeType !== Node.ELEMENT_NODE) {
+    return clone;
+  }
+
+  const computedStyle = window.getComputedStyle(sourceNode);
+  const styleText = Array.from(computedStyle)
+    .map((property) => `${property}:${computedStyle.getPropertyValue(property)};`)
+    .join('');
+  clone.setAttribute('style', styleText);
+
+  Array.from(sourceNode.childNodes).forEach((childNode) => {
+    clone.appendChild(cloneNodeWithInlineStyles(childNode));
+  });
+
+  return clone;
+}
+
+function buildPreviewSvgDataUrl(previewElement, width, height) {
+  const clonedPreview = cloneNodeWithInlineStyles(previewElement);
+  const serializedPreview = new XMLSerializer().serializeToString(clonedPreview);
+  const svgMarkup = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <foreignObject x="0" y="0" width="100%" height="100%">
+        ${serializedPreview}
+      </foreignObject>
+    </svg>
+  `;
+
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgMarkup)}`;
+}
+
+function drawPreviewToCanvas(previewElement) {
+  const { width, height } = previewElement.getBoundingClientRect();
+  const exportWidth = Math.max(1, Math.round(width));
+  const exportHeight = Math.max(1, Math.round(height));
+  const scale = Math.max(1, Math.ceil(window.devicePixelRatio || 1));
+
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = exportWidth * scale;
+      canvas.height = exportHeight * scale;
+      const context = canvas.getContext('2d');
+      if (!context) {
+        reject(new Error('Unable to create drawing context.'));
+        return;
+      }
+      context.scale(scale, scale);
+      context.drawImage(image, 0, 0, exportWidth, exportHeight);
+      resolve(canvas);
+    };
+    image.onerror = () => reject(new Error('Failed to render preview image.'));
+    image.src = buildPreviewSvgDataUrl(previewElement, exportWidth, exportHeight);
+  });
+}
+
+async function exportPreviewImage(format = 'png') {
+  const previewCard = document.getElementById('ssdCard');
+  if (!previewCard) {
+    window.alert('SSD preview area was not found.');
+    return;
+  }
+
+  const normalizedFormat = String(format).toLowerCase() === 'jpeg' ? 'jpeg' : 'png';
+  const name = slugifyFileName(form.elements.name.value);
+
+  try {
+    const canvas = await drawPreviewToCanvas(previewCard);
+    const mimeType = normalizedFormat === 'jpeg' ? 'image/jpeg' : 'image/png';
+    const extension = normalizedFormat === 'jpeg' ? 'jpg' : 'png';
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        window.alert('Could not export image.');
+        return;
+      }
+      downloadBlob(blob, `${name}.${extension}`);
+    }, mimeType, 0.95);
+  } catch {
+    window.alert('Could not export image from preview. Please try again.');
+  }
+}
+
 function importJsonFile(file) {
   if (!file) {
     return;
@@ -1586,6 +1671,12 @@ form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+document.getElementById('exportPngBtn').addEventListener('click', () => {
+  exportPreviewImage('png');
+});
+document.getElementById('exportJpegBtn').addEventListener('click', () => {
+  exportPreviewImage('jpeg');
+});
 document.getElementById('importBtn').addEventListener('click', () => {
   const picker = document.createElement('input');
   picker.type = 'file';

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -345,6 +345,8 @@ SCOUT:0:0</textarea></label>
         <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="exportPngBtn">Export PNG</button>
+          <button type="button" id="exportJpegBtn">Export JPEG</button>
           <button type="button" id="importBtn">Import JSON</button>
           <button type="button" id="printBtn">Print to Paper</button>
           <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>


### PR DESCRIPTION
### Motivation
- Provide a way to capture the live SSD preview as an image so users can save the rendered card as a PNG or JPEG file from the browser.
- Match the existing export UX by naming image files using the ship name slug and triggering a browser download.

### Description
- Added two new action buttons in the controls: `Export PNG` and `Export JPEG` in `starforce-commander-ship-designer/index.html`.
- Implemented a DOM-to-image export pipeline in `starforce-commander-ship-designer/app.js` that clones the `#ssdCard` preview, inlines computed styles with `cloneNodeWithInlineStyles`, serializes into an SVG `foreignObject` via `buildPreviewSvgDataUrl`, rasterizes to a canvas with `drawPreviewToCanvas`, and downloads the result as PNG/JPEG using `exportPreviewImage` and `downloadBlob`.
- Wired the new buttons to call `exportPreviewImage('png')` and `exportPreviewImage('jpeg')`, and reuse the existing slug logic via `slugifyFileName` for filenames.

### Testing
- Ran a JavaScript syntax check with `node --check starforce-commander-ship-designer/app.js`, which completed successfully.
- No automated browser rendering tests were executed in this environment (image export validated by code paths only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17549f3c88332a975388024f2e70e)