### PR TITLE
Add PNG/JPEG export for SSD preview by rendering preview to image

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -1514,6 +1514,121 @@ function exportCurrent() {
   downloadBlob(blob, `${name}.json`);
 }
 
+function cloneNodeWithInlineStyles(sourceNode) {
+  const clone = sourceNode.cloneNode(false);
+  if (sourceNode.nodeType !== Node.ELEMENT_NODE) {
+    return clone;
+  }
+
+  const computedStyle = window.getComputedStyle(sourceNode);
+  const styleText = Array.from(computedStyle)
+    .map((property) => `${property}:${computedStyle.getPropertyValue(property)};`)
+    .join('');
+  clone.setAttribute('style', styleText);
+
+  Array.from(sourceNode.childNodes).forEach((childNode) => {
+    clone.appendChild(cloneNodeWithInlineStyles(childNode));
+  });
+
+  return clone;
+}
+
+function buildPreviewSvgBlobUrl(previewElement, width, height) {
+  const clonedPreview = cloneNodeWithInlineStyles(previewElement);
+  const serializedPreview = new XMLSerializer().serializeToString(clonedPreview);
+  const svgMarkup = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <foreignObject x="0" y="0" width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml">${serializedPreview}</div>
+      </foreignObject>
+    </svg>
+  `;
+
+  const svgBlob = new Blob([svgMarkup], { type: 'image/svg+xml;charset=utf-8' });
+  return URL.createObjectURL(svgBlob);
+}
+
+function drawPreviewToCanvas(previewElement) {
+  const { width, height } = previewElement.getBoundingClientRect();
+  const exportWidth = Math.max(1, Math.round(width));
+  const exportHeight = Math.max(1, Math.round(height));
+  const scale = Math.max(1, Math.ceil(window.devicePixelRatio || 1));
+
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    const svgUrl = buildPreviewSvgBlobUrl(previewElement, exportWidth, exportHeight);
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = exportWidth * scale;
+      canvas.height = exportHeight * scale;
+      const context = canvas.getContext('2d');
+      if (!context) {
+        reject(new Error('Unable to create drawing context.'));
+        return;
+      }
+      context.scale(scale, scale);
+      context.drawImage(image, 0, 0, exportWidth, exportHeight);
+      URL.revokeObjectURL(svgUrl);
+      resolve(canvas);
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(svgUrl);
+      reject(new Error('Failed to render preview image.'));
+    };
+    image.src = svgUrl;
+  });
+}
+
+function canvasToBlob(canvas, mimeType, quality) {
+  return new Promise((resolve, reject) => {
+    if (typeof canvas.toBlob === 'function') {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error('Could not create image blob.'));
+          return;
+        }
+        resolve(blob);
+      }, mimeType, quality);
+      return;
+    }
+
+    try {
+      const dataUrl = canvas.toDataURL(mimeType, quality);
+      const [, base64 = ''] = dataUrl.split(',');
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+      }
+      resolve(new Blob([bytes], { type: mimeType }));
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function exportPreviewImage(format = 'png') {
+  const previewCard = document.getElementById('ssdCard');
+  if (!previewCard) {
+    window.alert('SSD preview area was not found.');
+    return;
+  }
+
+  const normalizedFormat = String(format).toLowerCase() === 'jpeg' ? 'jpeg' : 'png';
+  const name = slugifyFileName(form.elements.name.value);
+
+  try {
+    const canvas = await drawPreviewToCanvas(previewCard);
+    const mimeType = normalizedFormat === 'jpeg' ? 'image/jpeg' : 'image/png';
+    const extension = normalizedFormat === 'jpeg' ? 'jpg' : 'png';
+    const blob = await canvasToBlob(canvas, mimeType, 0.95);
+    downloadBlob(blob, `${name}.${extension}`);
+  } catch (error) {
+    console.error(error);
+    window.alert('Could not export image from preview. Please try again.');
+  }
+}
+
 function importJsonFile(file) {
   if (!file) {
     return;
@@ -1586,6 +1701,12 @@ form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+document.getElementById('exportPngBtn').addEventListener('click', () => {
+  exportPreviewImage('png');
+});
+document.getElementById('exportJpegBtn').addEventListener('click', () => {
+  exportPreviewImage('jpeg');
+});
 document.getElementById('importBtn').addEventListener('click', () => {
   const picker = document.createElement('input');
   picker.type = 'file';

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -345,6 +345,8 @@ SCOUT:0:0</textarea></label>
         <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="exportPngBtn">Export PNG</button>
+          <button type="button" id="exportJpegBtn">Export JPEG</button>
           <button type="button" id="importBtn">Import JSON</button>
           <button type="button" id="printBtn">Print to Paper</button>
           <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>


### PR DESCRIPTION
### Motivation

- Provide a way to export the SSD preview as a raster image (PNG or JPEG) that preserves the current preview styling and embedded ship art. 
- Ensure exported images render reliably across browsers and device pixel ratios by serializing the preview with inline styles and drawing it to a canvas.

### Description

- Added DOM-to-image export helpers: `cloneNodeWithInlineStyles`, `buildPreviewSvgBlobUrl`, `drawPreviewToCanvas`, and `canvasToBlob` to serialize the preview, render it into an SVG foreignObject, and rasterize it to a canvas with DPR-aware scaling. 
- Implemented `exportPreviewImage(format)` which produces a `Blob` in `image/png` or `image/jpeg` and uses existing `downloadBlob` to trigger download, with error handling and user alerts. 
- Wired two new UI buttons (`Export PNG` and `Export JPEG`) in `index.html` and attached event listeners in `app.js` to call the exporter.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17549f3c88332a975388024f2e70e)