### PR TITLE
Add preview image export (PNG/JPEG) with modal and download UI

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -1514,6 +1514,152 @@ function exportCurrent() {
   downloadBlob(blob, `${name}.json`);
 }
 
+function cloneNodeWithInlineStyles(sourceNode) {
+  const clone = sourceNode.cloneNode(false);
+  if (sourceNode.nodeType !== Node.ELEMENT_NODE) {
+    return clone;
+  }
+
+  const computedStyle = window.getComputedStyle(sourceNode);
+  const styleText = Array.from(computedStyle)
+    .map((property) => `${property}:${computedStyle.getPropertyValue(property)};`)
+    .join('');
+  clone.setAttribute('style', styleText);
+
+  Array.from(sourceNode.childNodes).forEach((childNode) => {
+    clone.appendChild(cloneNodeWithInlineStyles(childNode));
+  });
+
+  return clone;
+}
+
+function buildPreviewSvgBlobUrl(previewElement, width, height) {
+  const clonedPreview = cloneNodeWithInlineStyles(previewElement);
+  const serializedPreview = new XMLSerializer().serializeToString(clonedPreview);
+  const svgMarkup = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <foreignObject x="0" y="0" width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml">${serializedPreview}</div>
+      </foreignObject>
+    </svg>
+  `;
+
+  const svgBlob = new Blob([svgMarkup], { type: 'image/svg+xml;charset=utf-8' });
+  return URL.createObjectURL(svgBlob);
+}
+
+function drawPreviewToCanvas(previewElement) {
+  const { width, height } = previewElement.getBoundingClientRect();
+  const exportWidth = Math.max(1, Math.round(width));
+  const exportHeight = Math.max(1, Math.round(height));
+  const scale = Math.max(1, Math.ceil(window.devicePixelRatio || 1));
+
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    const svgUrl = buildPreviewSvgBlobUrl(previewElement, exportWidth, exportHeight);
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = exportWidth * scale;
+      canvas.height = exportHeight * scale;
+      const context = canvas.getContext('2d');
+      if (!context) {
+        reject(new Error('Unable to create drawing context.'));
+        return;
+      }
+      context.scale(scale, scale);
+      context.drawImage(image, 0, 0, exportWidth, exportHeight);
+      URL.revokeObjectURL(svgUrl);
+      resolve(canvas);
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(svgUrl);
+      reject(new Error('Failed to render preview image.'));
+    };
+    image.src = svgUrl;
+  });
+}
+
+function canvasToBlob(canvas, mimeType, quality) {
+  return new Promise((resolve, reject) => {
+    if (typeof canvas.toBlob === 'function') {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error('Could not create image blob.'));
+          return;
+        }
+        resolve(blob);
+      }, mimeType, quality);
+      return;
+    }
+
+    try {
+      const dataUrl = canvas.toDataURL(mimeType, quality);
+      const [, base64 = ''] = dataUrl.split(',');
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+      }
+      resolve(new Blob([bytes], { type: mimeType }));
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function showImageExportModal(canvas, format, fileName) {
+  const modal = document.getElementById('imageExportModal');
+  const title = document.getElementById('imageExportTitle');
+  const previewWrap = document.getElementById('imageExportPreviewWrap');
+  const downloadBtn = document.getElementById('imageExportDownloadBtn');
+
+  if (!modal || !title || !previewWrap || !downloadBtn) {
+    window.alert('Preview image is ready. Right-click the preview area to save.');
+    return;
+  }
+
+  title.textContent = `Export Preview Image (${String(format).toUpperCase()})`;
+  previewWrap.innerHTML = '';
+  previewWrap.appendChild(canvas);
+
+  const mimeType = String(format).toLowerCase() === 'jpeg' ? 'image/jpeg' : 'image/png';
+  downloadBtn.textContent = `Try Direct Download (${String(format).toUpperCase()})`;
+  downloadBtn.onclick = async () => {
+    try {
+      const blob = await canvasToBlob(canvas, mimeType, 0.95);
+      downloadBlob(blob, fileName);
+    } catch {
+      window.alert('Direct download is blocked by browser security for this image. Please right-click the image and choose "Save image as…".');
+    }
+  };
+
+  if (typeof modal.showModal === 'function') {
+    modal.showModal();
+  } else {
+    modal.setAttribute('open', 'open');
+  }
+}
+
+async function exportPreviewImage(format = 'png') {
+  const previewCard = document.getElementById('ssdCard');
+  if (!previewCard) {
+    window.alert('SSD preview area was not found.');
+    return;
+  }
+
+  const normalizedFormat = String(format).toLowerCase() === 'jpeg' ? 'jpeg' : 'png';
+  const name = slugifyFileName(form.elements.name.value);
+
+  try {
+    const canvas = await drawPreviewToCanvas(previewCard);
+    const extension = normalizedFormat === 'jpeg' ? 'jpg' : 'png';
+    showImageExportModal(canvas, normalizedFormat, `${name}.${extension}`);
+  } catch (error) {
+    console.error(error);
+    window.alert('Could not export image from preview. Please try again.');
+  }
+}
+
 function importJsonFile(file) {
   if (!file) {
     return;
@@ -1586,6 +1732,12 @@ form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+document.getElementById('exportPngBtn').addEventListener('click', () => {
+  exportPreviewImage('png');
+});
+document.getElementById('exportJpegBtn').addEventListener('click', () => {
+  exportPreviewImage('jpeg');
+});
 document.getElementById('importBtn').addEventListener('click', () => {
   const picker = document.createElement('input');
   picker.type = 'file';

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -345,6 +345,8 @@ SCOUT:0:0</textarea></label>
         <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="exportPngBtn">Export PNG</button>
+          <button type="button" id="exportJpegBtn">Export JPEG</button>
           <button type="button" id="importBtn">Import JSON</button>
           <button type="button" id="printBtn">Print to Paper</button>
           <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>
@@ -467,6 +469,18 @@ SCOUT:0:0</textarea></label>
       <pre id="jsonPreview"></pre>
     </section>
   </main>
+
+  <dialog id="imageExportModal" class="export-image-modal">
+    <form method="dialog" class="export-image-modal-card">
+      <h3 id="imageExportTitle">Export Preview Image</h3>
+      <p class="muted">Right-click the image and choose <b>Save image as…</b>. You can also try the direct download button.</p>
+      <div id="imageExportPreviewWrap" class="export-image-preview-wrap"></div>
+      <div class="row row-actions">
+        <button type="button" id="imageExportDownloadBtn">Try Direct Download</button>
+        <button type="submit" class="ghost">Close</button>
+      </div>
+    </form>
+  </dialog>
 
   <script src="app.js" type="module"></script>
 </body>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -733,3 +733,38 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
 .pv-rank-table input {
   width: 70px;
 }
+
+.export-image-modal {
+  width: min(92vw, 1200px);
+  border: 1px solid #32516b;
+  border-radius: 10px;
+  padding: 0;
+}
+
+.export-image-modal::backdrop {
+  background: rgba(10, 26, 39, 0.65);
+}
+
+.export-image-modal-card {
+  margin: 0;
+  padding: 1rem;
+  background: #dbe4ec;
+}
+
+.export-image-preview-wrap {
+  max-height: 72vh;
+  overflow: auto;
+  background: #9fb2c4;
+  border: 1px solid #5f7892;
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: flex;
+  justify-content: center;
+}
+
+.export-image-preview-wrap canvas {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  background: #fff;
+}


### PR DESCRIPTION
### Motivation

- Provide a way to export the SSD preview as an image (PNG or JPEG) so users can save a visual representation of their ship design. 
- Ensure exported images preserve computed styles and render crisply on high-DPI displays.

### Description

- Added functions to capture the live preview with inline styles (`cloneNodeWithInlineStyles`), serialize it into an SVG `Blob` (`buildPreviewSvgBlobUrl`), render that SVG into a canvas (`drawPreviewToCanvas`), and convert the canvas to a `Blob` with a `toBlob` fallback (`canvasToBlob`).
- Implemented `exportPreviewImage` which ties the capture/render pipeline together and shows a UI modal (`showImageExportModal`) that allows downloading the generated image or saving via right-click.
- Wired two new buttons in the form (`#exportPngBtn` and `#exportJpegBtn`) to trigger PNG/JPEG export, added a dialog markup (`#imageExportModal`) to `index.html`, and added CSS rules for the modal and preview wrapping in `styles.css`.
- Kept the existing JSON export/import logic unchanged and reused the existing `downloadBlob` helper for direct downloads.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17549f3c88332a975388024f2e70e)