### PR TITLE
Add PNG/JPEG export for SSD preview with inline image rendering and export modal

### DIFF
--- a/starforce-commander-ship-designer/app.js
+++ b/starforce-commander-ship-designer/app.js
@@ -837,8 +837,10 @@ function renderStructure(build) {
       count.className = 'team-count';
       count.textContent = String(markerByGap.get(i));
 
-      const icon = document.createElement('span');
+      const icon = document.createElement('img');
       icon.className = 'wrench-icon';
+      icon.setAttribute('src', 'assets/wrench-icon.svg');
+      icon.setAttribute('alt', '');
       icon.setAttribute('aria-hidden', 'true');
 
       marker.appendChild(count);
@@ -1514,6 +1516,200 @@ function exportCurrent() {
   downloadBlob(blob, `${name}.json`);
 }
 
+function cloneNodeWithInlineStyles(sourceNode) {
+  const clone = sourceNode.cloneNode(false);
+  if (sourceNode.nodeType !== Node.ELEMENT_NODE) {
+    return clone;
+  }
+
+  const computedStyle = window.getComputedStyle(sourceNode);
+  const styleText = Array.from(computedStyle)
+    .map((property) => `${property}:${computedStyle.getPropertyValue(property)};`)
+    .join('');
+  clone.setAttribute('style', styleText);
+
+  Array.from(sourceNode.childNodes).forEach((childNode) => {
+    clone.appendChild(cloneNodeWithInlineStyles(childNode));
+  });
+
+  return clone;
+}
+
+function blobToDataUrl(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ''));
+    reader.onerror = () => reject(new Error('Failed to read image blob.'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+async function inlineImageSources(rootNode) {
+  const imageNodes = Array.from(rootNode.querySelectorAll('img'));
+  const cache = new Map();
+
+  await Promise.all(imageNodes.map(async (imageNode) => {
+    const src = imageNode.getAttribute('src');
+    if (!src || src.startsWith('data:') || src.startsWith('blob:')) {
+      return;
+    }
+
+    const absoluteUrl = new URL(src, window.location.href).href;
+    if (!cache.has(absoluteUrl)) {
+      cache.set(absoluteUrl, (async () => {
+        const response = await fetch(absoluteUrl);
+        if (!response.ok) {
+          throw new Error(`Image fetch failed: ${absoluteUrl}`);
+        }
+        const blob = await response.blob();
+        return blobToDataUrl(blob);
+      })());
+    }
+
+    try {
+      const dataUrl = await cache.get(absoluteUrl);
+      imageNode.setAttribute('src', dataUrl);
+    } catch (error) {
+      console.warn(error);
+    }
+  }));
+}
+
+async function buildPreviewSvgBlobUrl(previewElement, width, height) {
+  const clonedPreview = cloneNodeWithInlineStyles(previewElement);
+  await inlineImageSources(clonedPreview);
+  const serializedPreview = new XMLSerializer().serializeToString(clonedPreview);
+  const svgMarkup = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <foreignObject x="0" y="0" width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml">${serializedPreview}</div>
+      </foreignObject>
+    </svg>
+  `;
+
+  const svgBlob = new Blob([svgMarkup], { type: 'image/svg+xml;charset=utf-8' });
+  return URL.createObjectURL(svgBlob);
+}
+
+function drawPreviewToCanvas(previewElement) {
+  const bounds = previewElement.getBoundingClientRect();
+  const exportWidth = Math.max(
+    1,
+    Math.ceil(Math.max(bounds.width, previewElement.scrollWidth, previewElement.offsetWidth))
+  );
+  const exportHeight = Math.max(
+    1,
+    Math.ceil(Math.max(bounds.height, previewElement.scrollHeight, previewElement.offsetHeight))
+  );
+  const scale = Math.max(1, Math.ceil(window.devicePixelRatio || 1));
+  const bleed = 4;
+  const svgUrlPromise = buildPreviewSvgBlobUrl(previewElement, exportWidth, exportHeight);
+
+  return svgUrlPromise.then((svgUrl) => new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = (exportWidth + bleed * 2) * scale;
+      canvas.height = (exportHeight + bleed * 2) * scale;
+      const context = canvas.getContext('2d');
+      if (!context) {
+        reject(new Error('Unable to create drawing context.'));
+        return;
+      }
+      context.scale(scale, scale);
+      context.drawImage(image, bleed, bleed, exportWidth, exportHeight);
+      URL.revokeObjectURL(svgUrl);
+      resolve(canvas);
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(svgUrl);
+      reject(new Error('Failed to render preview image.'));
+    };
+    image.src = svgUrl;
+  }));
+}
+
+function canvasToBlob(canvas, mimeType, quality) {
+  return new Promise((resolve, reject) => {
+    if (typeof canvas.toBlob === 'function') {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          reject(new Error('Could not create image blob.'));
+          return;
+        }
+        resolve(blob);
+      }, mimeType, quality);
+      return;
+    }
+
+    try {
+      const dataUrl = canvas.toDataURL(mimeType, quality);
+      const [, base64 = ''] = dataUrl.split(',');
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index += 1) {
+        bytes[index] = binary.charCodeAt(index);
+      }
+      resolve(new Blob([bytes], { type: mimeType }));
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function showImageExportModal(canvas, format, fileName) {
+  const modal = document.getElementById('imageExportModal');
+  const title = document.getElementById('imageExportTitle');
+  const previewWrap = document.getElementById('imageExportPreviewWrap');
+  const downloadBtn = document.getElementById('imageExportDownloadBtn');
+
+  if (!modal || !title || !previewWrap || !downloadBtn) {
+    window.alert('Preview image is ready. Right-click the preview area to save.');
+    return;
+  }
+
+  title.textContent = `Export Preview Image (${String(format).toUpperCase()})`;
+  previewWrap.innerHTML = '';
+  previewWrap.appendChild(canvas);
+
+  const mimeType = String(format).toLowerCase() === 'jpeg' ? 'image/jpeg' : 'image/png';
+  downloadBtn.textContent = `Try Direct Download (${String(format).toUpperCase()})`;
+  downloadBtn.onclick = async () => {
+    try {
+      const blob = await canvasToBlob(canvas, mimeType, 0.95);
+      downloadBlob(blob, fileName);
+    } catch {
+      window.alert('Direct download is blocked by browser security for this image. Please right-click the image and choose "Save image as…".');
+    }
+  };
+
+  if (typeof modal.showModal === 'function') {
+    modal.showModal();
+  } else {
+    modal.setAttribute('open', 'open');
+  }
+}
+
+async function exportPreviewImage(format = 'png') {
+  const previewCard = document.getElementById('ssdCard');
+  if (!previewCard) {
+    window.alert('SSD preview area was not found.');
+    return;
+  }
+
+  const normalizedFormat = String(format).toLowerCase() === 'jpeg' ? 'jpeg' : 'png';
+  const name = slugifyFileName(form.elements.name.value);
+
+  try {
+    const canvas = await drawPreviewToCanvas(previewCard);
+    const extension = normalizedFormat === 'jpeg' ? 'jpg' : 'png';
+    showImageExportModal(canvas, normalizedFormat, `${name}.${extension}`);
+  } catch (error) {
+    console.error(error);
+    window.alert('Could not export image from preview. Please try again.');
+  }
+}
+
 function importJsonFile(file) {
   if (!file) {
     return;
@@ -1586,6 +1782,12 @@ form.addEventListener('change', () => render({ recalculatePointValue: false }));
 document.getElementById('saveBtn').addEventListener('click', saveDraft);
 document.getElementById('clearBtn').addEventListener('click', clearDrafts);
 document.getElementById('exportBtn').addEventListener('click', exportCurrent);
+document.getElementById('exportPngBtn').addEventListener('click', () => {
+  exportPreviewImage('png');
+});
+document.getElementById('exportJpegBtn').addEventListener('click', () => {
+  exportPreviewImage('jpeg');
+});
 document.getElementById('importBtn').addEventListener('click', () => {
   const picker = document.createElement('input');
   picker.type = 'file';

--- a/starforce-commander-ship-designer/index.html
+++ b/starforce-commander-ship-designer/index.html
@@ -345,6 +345,8 @@ SCOUT:0:0</textarea></label>
         <div class="row row-actions">
           <button type="button" id="saveBtn">Save Draft</button>
           <button type="button" id="exportBtn">Export JSON</button>
+          <button type="button" id="exportPngBtn">Export PNG</button>
+          <button type="button" id="exportJpegBtn">Export JPEG</button>
           <button type="button" id="importBtn">Import JSON</button>
           <button type="button" id="printBtn">Print to Paper</button>
           <button type="button" id="clearBtn" class="ghost">Clear Drafts</button>
@@ -467,6 +469,18 @@ SCOUT:0:0</textarea></label>
       <pre id="jsonPreview"></pre>
     </section>
   </main>
+
+  <dialog id="imageExportModal" class="export-image-modal">
+    <form method="dialog" class="export-image-modal-card">
+      <h3 id="imageExportTitle">Export Preview Image</h3>
+      <p class="muted">Right-click the image and choose <b>Save image as…</b>. You can also try the direct download button.</p>
+      <div id="imageExportPreviewWrap" class="export-image-preview-wrap"></div>
+      <div class="row row-actions">
+        <button type="button" id="imageExportDownloadBtn">Try Direct Download</button>
+        <button type="submit" class="ghost">Close</button>
+      </div>
+    </form>
+  </dialog>
 
   <script src="app.js" type="module"></script>
 </body>

--- a/starforce-commander-ship-designer/styles.css
+++ b/starforce-commander-ship-designer/styles.css
@@ -227,17 +227,18 @@ button.ghost { background: #6d7f8d; border-color: #465764; }
 .stat-icon { width: 18px; height: 18px; object-fit: contain; vertical-align: text-bottom; }
 .stat-tag { color: #b8b8b8 !important; background: #e9eef3 !important; border-color: #10a5df !important; }
 .green-block { border: 12px solid #02a45c; background: #f0f0f0; margin-bottom: 0.2rem; }
-.green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; }
+.green-block h4 { margin: 0; background: #07af52; color: #fff; padding: 0.15rem 0.25rem; font-size: 0.74rem; letter-spacing: 0.01em; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
+.green-block h4 span { white-space: nowrap; }
 .block-power h4 span:last-child { color: #d8ffd8; }
 .green-block pre { min-height: 80px; margin: 0; background: transparent; color: #233; white-space: pre-wrap; border-radius: 0; font-family: Arial, Helvetica, sans-serif; font-size: 0.8rem; }
 .fn-row { display: grid; grid-template-columns: 120px minmax(0, 1fr); align-items: center; gap: 0.35rem; margin-bottom: 0.12rem; font-weight: 900; font-size: 0.75rem; }
-.fn-name { text-transform: uppercase; letter-spacing: 0.01em; }
+.fn-name { text-transform: uppercase; letter-spacing: 0.01em; white-space: nowrap; }
 .fn-name.green { color: #0aa14e; }
 .fn-name.magenta { color: #d31ce0; }
 .fn-name.cyan { color: #08a7df; }
 .fn-name.gold { color: #e3ab00; }
 .fn-name.red { color: #ff0000; }
-.fn-levels { display: flex; flex-wrap: wrap; align-items: center; gap: 0.24rem; font-weight: 900; }
+.fn-levels { display: flex; flex-wrap: nowrap; align-items: center; gap: 0.24rem; font-weight: 900; white-space: nowrap; }
 .fn-token { display: inline-flex; align-items: center; justify-content: center; min-width: 12px; }
 .fn-emer { margin-left: auto; display: inline-flex; align-items: center; gap: 0.24rem; }
 .fn-dot {
@@ -567,7 +568,8 @@ button.ghost { background: #6d7f8d; border-color: #465764; }
   width: 15px;
   height: 15px;
   display: inline-block;
-  background: center / contain no-repeat url("assets/wrench-icon.svg");
+  object-fit: contain;
+  flex: 0 0 auto;
 }
 .structure-box {
   width: var(--structure-box-size);
@@ -688,9 +690,9 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
   font-size: 0.78rem;
   padding: 0.25rem 0.2rem;
 }
-.man-row { margin-bottom: 0.15rem; font-weight: 800; }
+.man-row { margin-bottom: 0.15rem; font-weight: 800; white-space: nowrap; }
 .man-row:not(.man-top) { display: grid; grid-template-columns: var(--man-label-width) max-content; column-gap: 0.35rem; align-items: center; }
-.man-top { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.22rem; }
+.man-top { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.22rem; flex-wrap: nowrap; }
 .rnd-circles { display: inline-flex; gap: 0.2rem; min-width: 44px; }
 .rnd-circle { width: 10px; height: 10px; border-radius: 999px; border: 2px solid currentColor; box-sizing: border-box; }
 .rnd-circles.green { color: #00b050; }
@@ -732,4 +734,39 @@ pre { background: #f3f8fc; color: #12314a; padding: 0.55rem; border-radius: 6px;
 
 .pv-rank-table input {
   width: 70px;
+}
+
+.export-image-modal {
+  width: min(92vw, 1200px);
+  border: 1px solid #32516b;
+  border-radius: 10px;
+  padding: 0;
+}
+
+.export-image-modal::backdrop {
+  background: rgba(10, 26, 39, 0.65);
+}
+
+.export-image-modal-card {
+  margin: 0;
+  padding: 1rem;
+  background: #dbe4ec;
+}
+
+.export-image-preview-wrap {
+  max-height: 72vh;
+  overflow: auto;
+  background: #9fb2c4;
+  border: 1px solid #5f7892;
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: flex;
+  justify-content: center;
+}
+
+.export-image-preview-wrap canvas {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  background: #fff;
 }


### PR DESCRIPTION
### Motivation
- Provide a way to export the SSD preview as an image (PNG or JPEG) that preserves computed styles and external images.
- Improve semantics for structure markers by switching the wrench icon from a CSS background span to an `<img>` so it can be inlined into exports.
- Add UI affordances for image export including direct-download attempts and a preview modal.

### Description
- Implemented serialization and export pipeline with `cloneNodeWithInlineStyles`, `inlineImageSources`, `buildPreviewSvgBlobUrl`, `drawPreviewToCanvas`, and `canvasToBlob` to capture the preview DOM with computed styles and embedded image data URLs.
- Added `exportPreviewImage(format)` entry point plus `showImageExportModal` to present the rendered canvas and attempt direct downloads, and hooked new buttons `exportPngBtn` and `exportJpegBtn` to trigger exports.
- Replaced the wrench marker span with an actual `<img>` and set its `src`/`alt` attributes, and updated `.wrench-icon` CSS to use `object-fit` and layout fixes.
- Added an export dialog (`#imageExportModal`) and supporting CSS rules for modal styling and canvas preview responsiveness, and applied several layout/whitespace CSS tweaks to improve export fidelity.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17549f3c88332a975388024f2e70e)