### PR TITLE
Rebuild homepage into lightweight, brand-aligned static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,34 @@
-# RPG Campaign Region Generator
+# X-Wing Alliance Website Rebuild
 
-A self-contained HTML/CSS/JS app for deterministic RPG campaign region generation.
+A lightweight static rebuild focused on three goals:
 
-## CSV Inputs
-The UI supports **two client-side CSV inputs**:
+1. **Easy volunteer upkeep** (content comes from one JSON file).
+2. **Clear audience communication** (hero, quick links, updates).
+3. **Brand-aligned presentation** (XWA-inspired palette and visual hierarchy).
 
-1. **Places/Shops CSV** (required)
-   - `ID,Category,Label,DistrictRange,DistrictType,D6Roll,TypesPOI,MechanicalEffect,Tags,FollowUps,Persistence`
-2. **Travel/Realm CSV** (optional if mixed rows are included in place file)
-   - `ID,Category,Label,TriggerRange,MechanicalEffect,FictionText,Tags,FollowUps,Persistence`
+## How to Update Content
+Most updates happen in `data/site-content.json`:
 
-`TypesPOI`, `Tags`, and `FollowUps` support comma or semicolon lists.
+- `hero`: top-of-page summary, milestone, buttons.
+- `nav`: primary navigation links.
+- `quickLinks`: featured destinations.
+- `updates`: latest communications.
+- `footer`: maintenance guidance.
 
-## Generator Flow
-1. Parse CSV files and validate required columns.
-2. Seed deterministic PRNG from seed string.
-3. Generate districts (size 1–8):
-   - Pick a place matching district index by `DistrictRange`.
-   - Fallback to random place if no match.
-   - Generate 1–3 POIs, at least one NPC, and one quest hook.
-4. Generate NPCs using your d100-inspired race rarity -> race table, class table, and motivation table, plus d6 attitude.
-5. Queue follow-ups from Place/Travel rows and resolve by table row name or ID.
-6. Render map/detail panels, tag filters, and logs.
-7. Export full JSON and persist notes/persistence flags in localStorage.
+No HTML/CSS changes are required for normal content updates.
 
-## Notes on Table Variants
-The app normalizes common table typos/aliases from hand-authored tables (for example: `vilage -> village`, `milteristic -> militaristic`, `universty -> university`).
+## Local Preview
+Because `app.js` fetches JSON, use a local server (instead of opening `index.html` directly):
 
-## Reproducibility
-Same **seed + region size + CSV data** => identical exported JSON.
+```bash
+python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080`.
+
+## Brand Notes
+This implementation encodes brand color tokens in `styles.css` and links to the official brand book page for current guidance:
+
+- https://www.xwing.life/resources/xwa-brand-book
+
+If the PR team releases updated guidance, update the CSS variables and any typography choices to match.

--- a/app.js
+++ b/app.js
@@ -1,503 +1,80 @@
-/*
-Quick README:
-- Parse Place/Shop CSV and Travel/Realm CSV client-side with schema checks.
-- Use seeded RNG + dice roller for deterministic generation.
-- Build region districts with place selection, POIs, NPC contacts, quest hooks, follow-ups.
-- Render map/detail/filter/log UI and support JSON export + localStorage notes/persistence.
-*/
+const contentPath = "data/site-content.json";
 
-const PLACE_COLUMNS = ["ID", "Category", "Label", "DistrictRange", "DistrictType", "D6Roll", "TypesPOI", "MechanicalEffect", "Tags", "FollowUps", "Persistence"];
-const TRAVEL_COLUMNS = ["ID", "Category", "Label", "TriggerRange", "MechanicalEffect", "FictionText", "Tags", "FollowUps", "Persistence"];
+const render = async () => {
+  const response = await fetch(contentPath);
+  const data = await response.json();
 
-const TOKEN_ALIASES = {
-  vilage: "village", distrects: "districts", distrect: "district", distrecttype: "districttype",
-  militaristic: "militaristic", milteristic: "militaristic", religios: "religious", anchint: "ancient",
-  industrual: "industrial", universty: "university", warhouse: "warehouse", luxery: "luxury",
-  theves: "thieves", merchents: "merchants", explores: "explorers", knowlage: "knowledge",
-  relec: "relic", "seat of power": "seat of power", seatofpower: "seat of power"
+  renderNav(data.nav || []);
+  renderHero(data.hero || {});
+  renderQuickLinks(data.quickLinks || []);
+  renderUpdates(data.updates || []);
+
+  const footerText = document.getElementById("footerText");
+  footerText.textContent = data.footer?.text || "";
 };
 
-const state = {
-  placeRows: [], travelRows: [], followUpIndex: new Map(),
-  region: null, selectedDistrictId: null, selectedTags: new Set(), logs: [],
-  notes: {}, persistentOverrides: {}
+const renderNav = (items) => {
+  const nav = document.getElementById("primaryNav");
+  nav.innerHTML = items
+    .map(
+      (item) =>
+        `<li><a href="${item.href}" target="_blank" rel="noopener noreferrer">${item.label}</a></li>`
+    )
+    .join("");
 };
 
-const els = {
-  seedInput: document.getElementById("seedInput"),
-  sizeInput: document.getElementById("sizeInput"),
-  placeCsvFile: document.getElementById("placeCsvFile"),
-  travelCsvFile: document.getElementById("travelCsvFile"),
-  loadSampleBtn: document.getElementById("loadSampleBtn"),
-  generateBtn: document.getElementById("generateBtn"),
-  randomSeedBtn: document.getElementById("randomSeedBtn"),
-  mapCanvas: document.getElementById("mapCanvas"),
-  detailContent: document.getElementById("detailContent"),
-  tagFilters: document.getElementById("tagFilters"),
-  logList: document.getElementById("logList"),
-  exportBtn: document.getElementById("exportBtn"),
-  exportModal: document.getElementById("exportModal"),
-  exportText: document.getElementById("exportText"),
-  copyExportBtn: document.getElementById("copyExportBtn"),
-  downloadExportBtn: document.getElementById("downloadExportBtn"),
+const renderHero = (hero) => {
+  document.getElementById("heroSummary").textContent = hero.summary || "";
+  document.getElementById("nextEventText").textContent = hero.nextEvent || "";
+
+  const actionContainer = document.getElementById("heroActions");
+  actionContainer.innerHTML = (hero.actions || [])
+    .map((action) => {
+      const classes = action.primary
+        ? "button button-primary"
+        : "button button-secondary";
+      return `<a class="${classes}" href="${action.href}" target="_blank" rel="noopener noreferrer">${action.label}</a>`;
+    })
+    .join("");
 };
 
-const log = (msg) => { state.logs.push(`${new Date().toLocaleTimeString()} — ${msg}`); renderLogs(); };
-const nTok = (s) => {
-  const t = String(s || "").trim().toLowerCase();
-  return TOKEN_ALIASES[t] || t;
-};
-const listField = (v) => String(v || "").split(/[;,]/).map((x) => nTok(x)).filter(Boolean);
-
-function parseRange(s) {
-  const m = String(s || "").trim().match(/^(\d+)\s*(?:-\s*(\d+))?$/);
-  if (!m) return null;
-  const min = Number(m[1]);
-  const max = Number(m[2] || m[1]);
-  return { min, max };
-}
-
-function hashSeed(seed) {
-  let h = 1779033703 ^ seed.length;
-  for (let i = 0; i < seed.length; i++) { h = Math.imul(h ^ seed.charCodeAt(i), 3432918353); h = (h << 13) | (h >>> 19); }
-  h = Math.imul(h ^ (h >>> 16), 2246822507);
-  h = Math.imul(h ^ (h >>> 13), 3266489909);
-  return (h ^= h >>> 16) >>> 0;
-}
-function mulberry32(a) { return () => { let t = (a += 0x6d2b79f5); t = Math.imul(t ^ (t >>> 15), t | 1); t ^= t + Math.imul(t ^ (t >>> 7), t | 61); return ((t ^ (t >>> 14)) >>> 0) / 4294967296; }; }
-function createRng(seed) {
-  const rand = mulberry32(hashSeed(seed));
-  return { int: (min, max) => Math.floor(rand() * (max - min + 1)) + min, pick: (arr) => arr[Math.floor(rand() * arr.length)] };
-}
-function rollDice(notation, rng) {
-  const m = String(notation).toLowerCase().trim().match(/^(\d*)d(\d+)$/);
-  if (!m) throw new Error(`Invalid dice notation: ${notation}`);
-  const count = Number(m[1] || 1), sides = Number(m[2]);
-  let total = 0;
-  for (let i = 0; i < count; i++) total += rng.int(1, sides);
-  return total;
-}
-
-function parseCSV(text) {
-  const rows = [];
-  let i = 0, inQuotes = false, field = "", row = [];
-  while (i < text.length) {
-    const ch = text[i];
-    if (ch === '"') {
-      if (inQuotes && text[i + 1] === '"') { field += '"'; i++; }
-      else inQuotes = !inQuotes;
-    } else if (ch === ',' && !inQuotes) { row.push(field); field = ""; }
-    else if ((ch === '\n' || ch === '\r') && !inQuotes) {
-      if (ch === '\r' && text[i + 1] === '\n') i++;
-      row.push(field); field = "";
-      if (row.some((c) => c.trim() !== "")) rows.push(row);
-      row = [];
-    } else field += ch;
-    i++;
-  }
-  row.push(field);
-  if (row.some((c) => c.trim() !== "")) rows.push(row);
-  if (!rows.length) throw new Error("CSV is empty.");
-  const headers = rows[0].map((h) => h.trim());
-  const data = rows.slice(1).map((r) => {
-    const obj = {}; headers.forEach((h, idx) => { obj[h] = (r[idx] || "").trim(); }); return obj;
-  });
-  return { headers, data };
-}
-
-function requireColumns(headers, required, label) {
-  const missing = required.filter((c) => !headers.includes(c));
-  if (missing.length) throw new Error(`${label} CSV missing columns: ${missing.join(", ")}`);
-}
-
-function setRows(placeRows, travelRows) {
-  state.placeRows = placeRows;
-  state.travelRows = travelRows;
-  if (!state.placeRows.length) throw new Error("No Place/Shop rows loaded.");
-  state.followUpIndex = new Map();
-  [...state.placeRows, ...state.travelRows].forEach((r) => state.followUpIndex.set(r.ID, r));
-  log(`Loaded ${state.placeRows.length} place/shop rows and ${state.travelRows.length} travel/realm rows.`);
-}
-
-function parseMixedSampleRows(rows) {
-  const placeRows = rows.filter((r) => /meetingplace|shop/i.test(r.Category || ""));
-  const travelRows = rows
-    .filter((r) => /travelevent|realmtrait/i.test(r.Category || ""))
-    .map((r) => ({
-      ID: r.ID, Category: r.Category, Label: r.Label,
-      TriggerRange: r.DistrictRange,
-      MechanicalEffect: r.DistrictType,
-      FictionText: r.D6Roll,
-      Tags: r.TypesPOI,
-      FollowUps: r.MechanicalEffect,
-      Persistence: r.Tags || "no"
-    }));
-  return { placeRows, travelRows };
-}
-
-function districtMatch(place, idx) {
-  const r = parseRange(place.DistrictRange);
-  return !!r && idx >= r.min && idx <= r.max;
-}
-
-
-function rollD100(rng) { return rollDice("d100", rng); }
-
-function pickFromRangeTable(roll, table, fallback = "Unknown") {
-  const hit = table.find((entry) => roll >= entry.min && roll <= entry.max);
-  return hit ? hit.value : fallback;
-}
-
-const NPC_RACE_TABLE = {
-  rarity: [
-    { min: 1, max: 50, value: "Common" },
-    { min: 51, max: 80, value: "Uncommon" },
-    { min: 81, max: 100, value: "Rare" },
-  ],
-  common: [
-    { min: 1, max: 30, value: "Human" },
-    { min: 31, max: 50, value: "Elf" },
-    { min: 51, max: 70, value: "Dwarf" },
-    { min: 71, max: 80, value: "Half-Orc" },
-    { min: 81, max: 90, value: "Halfling" },
-    { min: 91, max: 100, value: "Dragonborn" },
-  ],
-  uncommon: [
-    { min: 1, max: 20, value: "Gnome" },
-    { min: 21, max: 40, value: "Tiefling" },
-    { min: 41, max: 60, value: "Half-Elf" },
-    { min: 61, max: 65, value: "Fairy Folk" },
-    { min: 66, max: 75, value: "Goblin" },
-    { min: 76, max: 90, value: "Tabaxi" },
-    { min: 91, max: 100, value: "Triton" },
-  ],
-  rare: [
-    { min: 1, max: 20, value: "Tortle" },
-    { min: 21, max: 40, value: "Warforged" },
-    { min: 41, max: 60, value: "Centaur" },
-    { min: 61, max: 80, value: "Minotaur" },
-    { min: 81, max: 100, value: "Changeling" },
-  ],
+const renderQuickLinks = (links) => {
+  const container = document.getElementById("quickLinks");
+  container.innerHTML = links
+    .map(
+      (link) => `
+        <article class="card">
+          <h3>${link.title}</h3>
+          <p>${link.description}</p>
+          <a href="${link.href}" target="_blank" rel="noopener noreferrer">Open</a>
+        </article>`
+    )
+    .join("");
 };
 
-const NPC_CLASS_TABLE = [
-  { min: 1, max: 10, value: "Fighter" },
-  { min: 11, max: 20, value: "Ranger" },
-  { min: 21, max: 30, value: "Rogue" },
-  { min: 31, max: 40, value: "Wizard" },
-  { min: 41, max: 50, value: "Cleric" },
-  { min: 51, max: 55, value: "Barbarian" },
-  { min: 56, max: 60, value: "Bard" },
-  { min: 61, max: 70, value: "Monk" },
-  { min: 71, max: 80, value: "Druid" },
-  { min: 81, max: 85, value: "Warlock" },
-  { min: 86, max: 90, value: "Sorcerer" },
-  { min: 91, max: 95, value: "Artificer" },
-  { min: 96, max: 100, value: "Gunslinger" },
-];
+const renderUpdates = (updates) => {
+  const container = document.getElementById("updatesList");
+  container.innerHTML = updates
+    .map(
+      (item) => `
+        <article class="update-item">
+          <h3>${item.title}</h3>
+          <p class="update-meta">${formatDate(item.date)} • ${item.owner}</p>
+          <p>${item.summary}</p>
+          <a href="${item.href}" target="_blank" rel="noopener noreferrer">Read update</a>
+        </article>`
+    )
+    .join("");
+};
 
-const NPC_MOTIVATION_TABLE = [
-  { min: 1, max: 9, value: "Wealth" },
-  { min: 10, max: 18, value: "Fame" },
-  { min: 19, max: 27, value: "Glory" },
-  { min: 28, max: 38, value: "Adventure" },
-  { min: 39, max: 46, value: "Truth" },
-  { min: 47, max: 54, value: "Knowledge" },
-  { min: 55, max: 60, value: "Revenge" },
-  { min: 61, max: 65, value: "Romance" },
-  { min: 66, max: 75, value: "Power" },
-  { min: 76, max: 84, value: "Freedom" },
-  { min: 85, max: 92, value: "Order" },
-  { min: 93, max: 100, value: "Escape" },
-];
-
-function generateNpcRace(rng) {
-  const rarityRoll = rollD100(rng);
-  const rarity = pickFromRangeTable(rarityRoll, NPC_RACE_TABLE.rarity, "Common");
-  const raceRoll = rollD100(rng);
-  const racePool = rarity.toLowerCase() === "common" ? NPC_RACE_TABLE.common
-    : (rarity.toLowerCase() === "uncommon" ? NPC_RACE_TABLE.uncommon : NPC_RACE_TABLE.rare);
-  const race = pickFromRangeTable(raceRoll, racePool, "Human");
-  return { rarity, rarityRoll, raceRoll, race };
-}
-
-function attitude(roll) {
-  const table = {
-    1: ["Hostile", "Demands payment before cooperation."], 2: ["Wary", "Needs proof before helping."],
-    3: ["Neutral", "Shares only basic info."], 4: ["Open", "Will trade a favor for a favor."],
-    5: ["Helpful", "Offers useful lead or resource."], 6: ["Friendly", "Offers direct help and advocacy."]
-  };
-  return { label: table[roll][0], effect: table[roll][1] };
-}
-
-function makeNPC(dId, place, rng) {
-  const names = ["Ari", "Thorne", "Mara", "Brigg", "Sel", "Jun", "Kest", "Rook"];
-  const quirks = ["speaks in proverbs", "never removes gloves", "collects broken keys", "keeps coded notes"];
-
-  const raceMeta = generateNpcRace(rng);
-  const classRoll = rollD100(rng);
-  const npcClass = pickFromRangeTable(classRoll, NPC_CLASS_TABLE, "Fighter");
-  const motivationRoll = rollD100(rng);
-  const motivation = pickFromRangeTable(motivationRoll, NPC_MOTIVATION_TABLE, "Adventure");
-
-  const attitudeRoll = rollDice("d6", rng);
-  return {
-    id: `NPC-${dId}-${rng.int(100, 999)}`,
-    name: rng.pick(names),
-    role: `${raceMeta.race} ${npcClass}`,
-    race: raceMeta.race,
-    raceRarity: raceMeta.rarity,
-    raceRolls: { rarityRoll: raceMeta.rarityRoll, raceRoll: raceMeta.raceRoll },
-    class: npcClass,
-    classRoll,
-    motivation,
-    motivationRoll,
-    attitudeRoll,
-    attitude: attitude(attitudeRoll),
-    goal: `${motivation.toLowerCase()}-driven objective near ${place.Label}`,
-    quirk: rng.pick(quirks),
-    contactTag: rng.pick(place.tags.length ? place.tags : ["local"])
-  };
-}
-
-function makeHook(place, npc, rng) {
-  const tag = rng.pick(place.tags.length ? place.tags : ["frontier"]);
-  const objective = rng.pick([
-    `Investigate escalating trouble around ${place.Label}`,
-    `Escort a team through the ${place.Label} district`,
-    `Retrieve evidence hidden near ${place.Label}`
-  ]);
-  const complication = rng.pick([
-    `${tag} hazards worsen every dusk`,
-    `a rival faction shadows ${npc.name}`,
-    `a local pact tied to ${place.Label} is collapsing`
-  ]);
-  const rewardHint = rng.pick(["favor with local powers", "access to restricted records", "payment plus a relic lead"]);
-  const urgency = Math.min(5, Math.ceil(rollDice("d6", rng) / 1.2));
-  return { objective, complication, rewardHint, urgency };
-}
-
-function enqueueFollowUps(entity, queue, rng) {
-  listField(entity.FollowUps).forEach((f) => queue.push({ name: f, source: entity.ID, roll: rollDice("d6", rng) }));
-}
-function resolveFollowUps(queue) {
-  while (queue.length) {
-    const item = queue.shift();
-    const found = [...state.followUpIndex.values()].find((r) => nTok(r.ID) === item.name || nTok(r.Label) === item.name);
-    if (found) log(`Resolved follow-up "${item.name}" from ${item.source} -> ${found.ID}.`);
-    else log(`Skipped follow-up "${item.name}" from ${item.source}: missing table row.`);
-  }
-}
-
-function buildRegion(seed, size) {
-  const rng = createRng(seed);
-  const queue = [];
-  const districts = [];
-
-  for (let i = 1; i <= size; i++) {
-    const matches = state.placeRows.filter((p) => districtMatch(p, i));
-    const place = matches.length ? rng.pick(matches) : rng.pick(state.placeRows);
-    if (!matches.length) log(`District ${i}: no DistrictRange match, fallback random place used.`);
-
-    const placeTags = listField(place.Tags);
-    const poiBase = listField(place.TypesPOI);
-    const poiCount = rng.int(1, 3);
-    const pois = Array.from({ length: poiCount }, (_, pIdx) => ({
-      id: `POI-${i}-${pIdx + 1}`,
-      type: poiBase.length ? rng.pick(poiBase) : "unknown",
-      summary: `${place.Label} point ${pIdx + 1}`,
-      tags: placeTags
-    }));
-
-    const npc = makeNPC(i, { ...place, tags: placeTags }, rng);
-    const questHook = makeHook({ ...place, tags: placeTags }, npc, rng);
-    const persistent = state.persistentOverrides[place.ID] ?? (nTok(place.Persistence) === "yes");
-
-    districts.push({
-      districtId: i,
-      place: { ...place, tags: placeTags, persistent },
-      pois,
-      npcs: [npc],
-      questHook,
-      note: state.notes[`district-${i}`] || ""
-    });
-
-    enqueueFollowUps(place, queue, rng);
-  }
-
-  const travel = state.travelRows.length ? rng.pick(state.travelRows) : null;
-  if (travel) enqueueFollowUps(travel, queue, rng);
-  resolveFollowUps(queue);
-
-  return {
-    seed,
-    settings: { regionSize: size },
-    travelHint: travel ? {
-      ...travel,
-      tags: listField(travel.Tags),
-      suggestions: districts.filter((d) => d.place.tags.some((t) => listField(travel.Tags).includes(t))).map((d) => ({ districtId: d.districtId, placeId: d.place.ID, label: d.place.Label }))
-    } : null,
-    districts
-  };
-}
-
-function renderLogs() { els.logList.innerHTML = state.logs.map((x) => `<li>${x}</li>`).join(""); }
-
-function renderMap() {
-  els.mapCanvas.innerHTML = "";
-  if (!state.region) return;
-
-  state.region.districts.forEach((d) => {
-    const b = document.createElement("button");
-    b.className = "tile";
-    if (d.districtId === state.selectedDistrictId) b.classList.add("selected");
-    if (d.place.persistent) b.classList.add("persistent");
-
-    const tagHit = state.selectedTags.size && [...state.selectedTags].some((t) => d.place.tags.includes(t) || d.pois.some((p) => p.tags.includes(t) || p.type.includes(t)) || d.npcs.some((n) => n.contactTag === t));
-    if (tagHit) b.classList.add("highlight");
-
-    b.innerHTML = `<span class="idx">District ${d.districtId}</span>${d.place.Label}${d.place.persistent ? ' <span class="persistent-badge">★</span>' : ''}`;
-    b.addEventListener("click", () => { state.selectedDistrictId = d.districtId; renderMap(); renderDetail(); });
-    els.mapCanvas.appendChild(b);
+const formatDate = (isoDate) =>
+  new Date(`${isoDate}T00:00:00Z`).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC"
   });
-}
 
-function renderDetail() {
-  const d = state.region?.districts.find((x) => x.districtId === state.selectedDistrictId);
-  if (!d) { els.detailContent.innerHTML = "<p>Select a district to view details.</p>"; return; }
-
-  const visiblePois = d.pois.filter((p) => !state.selectedTags.size || [...state.selectedTags].some((t) => p.tags.includes(t) || p.type.includes(t)));
-  const hint = state.region.travelHint
-    ? `<p class="suggestion">Travel/Realm hint <strong>${state.region.travelHint.Label}</strong>: matching districts ${state.region.travelHint.suggestions.map((s) => s.districtId).join(", ") || "none"}.</p>`
-    : "";
-
-  els.detailContent.innerHTML = `
-    <div class="card">
-      <h3>${d.place.Label} ${d.place.persistent ? '<span class="persistent-badge">★ persistent</span>' : ''}</h3>
-      <p>${d.place.MechanicalEffect}</p>
-      <p><strong>Tags:</strong> ${d.place.tags.join(", ") || "none"}</p>
-      ${hint}
-    </div>
-    <div class="card"><h4>POIs (${visiblePois.length}/${d.pois.length})</h4><ul>${visiblePois.map((p) => `<li class="poi-item">${p.type} — ${p.summary}</li>`).join("")}</ul></div>
-    <div class="card"><h4>NPC Contact</h4>${d.npcs.map((n) => `<p><strong>${n.name}</strong> (${n.role}) | d6 ${n.attitudeRoll} ${n.attitude.label}: ${n.attitude.effect}<br/>Goal: ${n.goal}. Quirk: ${n.quirk}. Tag: ${n.contactTag}<br/>Race: ${n.race} (${n.raceRarity}, rolls ${n.raceRolls.rarityRoll}/${n.raceRolls.raceRoll}) | Class: ${n.class} (d100 ${n.classRoll}) | Motivation: ${n.motivation} (d100 ${n.motivationRoll})</p>`).join("")}</div>
-    <div class="card"><h4>Quest Hook</h4><p>${d.questHook.objective}; complication: ${d.questHook.complication}; reward: ${d.questHook.rewardHint}. <strong>Urgency:</strong> ${d.questHook.urgency}/5.</p></div>
-    <div class="card">
-      <div class="button-row"><button id="followUpBtn">Roll Follow-up</button><button id="persistentBtn">Mark Persistent</button></div>
-      <label for="noteInput">Add Note</label>
-      <textarea id="noteInput" rows="3" placeholder="Session note">${d.note || ""}</textarea>
-    </div>
-  `;
-
-  document.getElementById("followUpBtn").addEventListener("click", () => {
-    const rng = createRng(`${state.region.seed}-followup-${d.districtId}-${state.logs.length}`);
-    const q = []; enqueueFollowUps(d.place, q, rng); resolveFollowUps(q);
-  });
-  document.getElementById("persistentBtn").addEventListener("click", () => {
-    d.place.persistent = !d.place.persistent;
-    state.persistentOverrides[d.place.ID] = d.place.persistent;
-    persistLocal(); renderMap(); renderDetail();
-  });
-  document.getElementById("noteInput").addEventListener("input", (e) => {
-    d.note = e.target.value; state.notes[`district-${d.districtId}`] = d.note; persistLocal();
-  });
-}
-
-function renderTagFilters() {
-  const tags = new Set();
-  state.region?.districts.forEach((d) => {
-    d.place.tags.forEach((t) => tags.add(t));
-    d.pois.forEach((p) => p.tags.forEach((t) => tags.add(t)));
-    d.npcs.forEach((n) => tags.add(n.contactTag));
-  });
-  els.tagFilters.innerHTML = "";
-  [...tags].sort().forEach((tag) => {
-    const b = document.createElement("button");
-    b.className = `tag-chip${state.selectedTags.has(tag) ? " active" : ""}`;
-    b.textContent = tag;
-    b.addEventListener("click", () => {
-      if (state.selectedTags.has(tag)) state.selectedTags.delete(tag); else state.selectedTags.add(tag);
-      renderTagFilters(); renderMap(); renderDetail();
-    });
-    els.tagFilters.appendChild(b);
-  });
-}
-
-function persistLocal() {
-  localStorage.setItem("rpg-region-notes", JSON.stringify(state.notes));
-  localStorage.setItem("rpg-region-persistent", JSON.stringify(state.persistentOverrides));
-}
-function loadLocal() {
-  state.notes = JSON.parse(localStorage.getItem("rpg-region-notes") || "{}");
-  state.persistentOverrides = JSON.parse(localStorage.getItem("rpg-region-persistent") || "{}");
-}
-
-function exportRegion() {
-  if (!state.region) return;
-  els.exportText.value = JSON.stringify(state.region, null, 2);
-  els.exportModal.showModal();
-}
-
-async function readCSVFromInput(inputEl) {
-  if (!inputEl.files?.[0]) return null;
-  const txt = await inputEl.files[0].text();
-  return parseCSV(txt);
-}
-
-els.loadSampleBtn.addEventListener("click", async () => {
-  try {
-    const sampleText = await (await fetch("sample-data.csv")).text();
-    const parsed = parseCSV(sampleText);
-    requireColumns(parsed.headers, PLACE_COLUMNS, "Sample");
-    const mixed = parseMixedSampleRows(parsed.data);
-    setRows(mixed.placeRows, mixed.travelRows);
-  } catch (e) { log(`Sample load error: ${e.message}`); }
+render().catch((error) => {
+  console.error("Failed to load site content", error);
 });
-
-els.generateBtn.addEventListener("click", async () => {
-  try {
-    const placeParsed = await readCSVFromInput(els.placeCsvFile);
-    const travelParsed = await readCSVFromInput(els.travelCsvFile);
-
-    if (placeParsed) {
-      requireColumns(placeParsed.headers, PLACE_COLUMNS, "Places/Shop");
-      const placeRows = placeParsed.data.filter((r) => /meetingplace|shop/i.test(r.Category || ""));
-      let travelRows = state.travelRows;
-
-      if (travelParsed) {
-        requireColumns(travelParsed.headers, TRAVEL_COLUMNS, "Travel/Realm");
-        travelRows = travelParsed.data.filter((r) => /travelevent|realmtrait/i.test(r.Category || ""));
-      } else {
-        const mixed = parseMixedSampleRows(placeParsed.data);
-        travelRows = mixed.travelRows;
-      }
-      setRows(placeRows, travelRows);
-    }
-
-    if (!state.placeRows.length) throw new Error("Load sample data or import a Places/Shop CSV first.");
-
-    state.logs = [];
-    const seed = els.seedInput.value.trim() || "default-seed";
-    const size = Math.min(8, Math.max(1, Number(els.sizeInput.value || 6)));
-    state.region = buildRegion(seed, size);
-    state.selectedDistrictId = 1;
-    renderTagFilters(); renderMap(); renderDetail();
-    log(`Generated region with seed="${seed}" and size=${size}.`);
-  } catch (e) {
-    log(`Generation error: ${e.message}`);
-  }
-});
-
-els.randomSeedBtn.addEventListener("click", () => { els.seedInput.value = `seed-${Math.random().toString(36).slice(2, 10)}`; });
-els.exportBtn.addEventListener("click", exportRegion);
-els.copyExportBtn.addEventListener("click", async () => { await navigator.clipboard.writeText(els.exportText.value); log("Copied exported JSON to clipboard."); });
-els.downloadExportBtn.addEventListener("click", () => {
-  const blob = new Blob([els.exportText.value], { type: "application/json" });
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = `region-${state.region.seed}.json`;
-  a.click();
-  URL.revokeObjectURL(a.href);
-});
-
-loadLocal();
-log("Ready. Load sample data or import CSV files to begin.");

--- a/data/site-content.json
+++ b/data/site-content.json
@@ -1,0 +1,64 @@
+{
+  "hero": {
+    "summary": "XWA keeps X-Wing thriving through organized play, community resources, and transparent communication.",
+    "nextEvent": "Worlds 2026 registration opens January 11, 2026 at 12:00 PM Central (UTC-6).",
+    "actions": [
+      {
+        "label": "Join Discord",
+        "href": "https://discord.gg/x-wing",
+        "primary": true
+      },
+      {
+        "label": "View Organized Play",
+        "href": "https://www.xwing.life/organized-play"
+      }
+    ]
+  },
+  "nav": [
+    { "label": "News", "href": "https://www.xwing.life/news" },
+    { "label": "Organized Play", "href": "https://www.xwing.life/organized-play" },
+    { "label": "Resources", "href": "https://www.xwing.life/resources" },
+    { "label": "About", "href": "https://www.xwing.life/about-xwa" }
+  ],
+  "quickLinks": [
+    {
+      "title": "OP Resources",
+      "description": "Tournament documents, event kits, and policies for organizers.",
+      "href": "https://www.xwing.life/organized-play/op-resources"
+    },
+    {
+      "title": "OP Forms",
+      "description": "Submit event requests, reports, and feedback to the OP team.",
+      "href": "https://www.xwing.life/organized-play/op-forms"
+    },
+    {
+      "title": "Points Documents",
+      "description": "Official points updates and release history.",
+      "href": "https://www.xwing.life/resources/xwa-points-documents"
+    },
+    {
+      "title": "Player Map",
+      "description": "Find and connect with local X-Wing communities.",
+      "href": "https://www.xwing.life/resources/player-map"
+    }
+  ],
+  "updates": [
+    {
+      "title": "Worlds 2026 Sneak Peek",
+      "date": "2026-01-11",
+      "owner": "Organized Play Team",
+      "summary": "Event registration goes live at noon Central on the Adepticon website.",
+      "href": "https://www.xwing.life/news"
+    },
+    {
+      "title": "Brand Book 1.4",
+      "date": "2025-12-01",
+      "owner": "PR Team",
+      "summary": "Updated guidance for logo use, palette, and visual tone across community channels.",
+      "href": "https://www.xwing.life/resources/xwa-brand-book"
+    }
+  ],
+  "footer": {
+    "text": "Need a content update? Edit data/site-content.json and commit—no code changes required for standard updates."
+  }
+}

--- a/index.html
+++ b/index.html
@@ -3,76 +3,75 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>RPG Campaign Region Generator</title>
+  <title>X-Wing Alliance</title>
+  <meta name="description" content="X-Wing Alliance (XWA) is the community home for Star Wars X-Wing organized play, resources, and news." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Orbitron:wght@500;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="topbar">
-    <h1>RPG Region & POI Generator</h1>
-    <p>Deterministic campaign generator for districts, POIs, NPCs, quest hooks, and follow-ups.</p>
+  <a class="skip-link" href="#main-content">Skip to content</a>
+
+  <header class="site-header">
+    <div class="header-inner container">
+      <div class="brand-block" aria-label="X-Wing Alliance brand area">
+        <p class="eyebrow">Volunteer-run • Community-first</p>
+        <h1>X-Wing Alliance</h1>
+        <p class="tagline">The central hub for organized play, resources, and community support for Star Wars™ X-Wing.</p>
+      </div>
+      <nav aria-label="Primary">
+        <ul id="primaryNav" class="primary-nav"></ul>
+      </nav>
+    </div>
   </header>
 
-  <main class="layout">
-    <section class="panel map-panel" aria-label="Map canvas">
-      <h2>Map Canvas</h2>
-      <p class="help">Click a district tile to inspect details.</p>
-      <div id="mapCanvas" class="map-canvas" role="grid" aria-label="District map"></div>
+  <main id="main-content">
+    <section class="hero container" aria-labelledby="hero-heading">
+      <div class="hero-copy">
+        <p class="hero-label">Live now</p>
+        <h2 id="hero-heading">Clear updates for players, organizers, and creators.</h2>
+        <p id="heroSummary"></p>
+        <div class="hero-actions" id="heroActions"></div>
+      </div>
+      <aside class="hero-panel" aria-labelledby="next-event-heading">
+        <h3 id="next-event-heading">Next key milestone</h3>
+        <p id="nextEventText"></p>
+      </aside>
     </section>
 
-    <section class="panel detail-panel" aria-live="polite" aria-label="Detail panel">
-      <h2>Detail Panel</h2>
-      <div id="detailContent" class="detail-content">
-        <p>Select a district to view Place, POIs, NPC contact, and quest hook.</p>
-      </div>
+    <section class="container section" aria-labelledby="quick-links-heading">
+      <h2 id="quick-links-heading">Quick Links</h2>
+      <div id="quickLinks" class="card-grid"></div>
     </section>
 
-    <section class="panel controls-panel" aria-label="Controls and logs">
-      <h2>Controls & Logs</h2>
-
-      <label for="seedInput" title="Same seed + region size + CSV data = same output.">Seed</label>
-      <div class="inline-row">
-        <input id="seedInput" type="text" value="mistwatch-001" />
-        <button id="randomSeedBtn" title="Create a random seed value">Randomize</button>
+    <section class="container section" aria-labelledby="latest-heading">
+      <div class="section-heading-row">
+        <h2 id="latest-heading">Latest Communications</h2>
+        <p class="section-subtitle">Post updates in one JSON file so volunteers can publish quickly.</p>
       </div>
+      <div id="updatesList" class="stack"></div>
+    </section>
 
-      <label for="sizeInput" title="How many districts to create">Region Size (1–8)</label>
-      <input id="sizeInput" type="number" min="1" max="8" value="6" />
-
-      <h3>CSV Import</h3>
-      <label for="placeCsvFile" title="Places/Shops schema file">Places/Shop CSV</label>
-      <input id="placeCsvFile" type="file" accept=".csv,text/csv" />
-
-      <label for="travelCsvFile" title="Travel/Realm schema file">Travel/Realm CSV</label>
-      <input id="travelCsvFile" type="file" accept=".csv,text/csv" />
-
-      <button id="loadSampleBtn" title="Load bundled sample-data.csv">Load Sample Data</button>
-      <button id="generateBtn" title="Generate deterministic region">Generate Region</button>
-
-      <h3>Tag Filter</h3>
-      <p class="help">Click tags to highlight matching Places/POIs/NPCs and narrow POIs.</p>
-      <div id="tagFilters" class="tag-filters"></div>
-
-      <div class="button-row">
-        <button id="exportBtn" title="Export full region JSON">Export Region</button>
+    <section class="container section" aria-labelledby="brand-heading">
+      <h2 id="brand-heading">Brand Consistency</h2>
+      <div class="brand-guidance">
+        <p>
+          This rebuild follows the XWA brand structure with a dedicated palette and reusable components.
+          For logos and future marketing graphics, reference the official XWA Brand Book.
+        </p>
+        <a class="text-link" href="https://www.xwing.life/resources/xwa-brand-book" target="_blank" rel="noopener noreferrer">Open XWA Brand Book</a>
       </div>
-
-      <h3>Generator Log</h3>
-      <ol id="logList" class="log-list"></ol>
     </section>
   </main>
 
-  <dialog id="exportModal">
-    <form method="dialog" class="modal-content">
-      <h3>Exported Region JSON</h3>
-      <textarea id="exportText" rows="14"></textarea>
-      <div class="button-row">
-        <button id="copyExportBtn" type="button">Copy to Clipboard</button>
-        <button id="downloadExportBtn" type="button">Download JSON</button>
-        <button type="submit">Close</button>
-      </div>
-    </form>
-  </dialog>
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p id="footerText"></p>
+      <p class="legal">X-Wing Alliance is a volunteer community group and is not affiliated with Lucasfilm or Asmodee.</p>
+    </div>
+  </footer>
 
-  <script src="app.js"></script>
+  <script src="app.js" defer></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,114 +1,238 @@
 :root {
-  --bg: #0f1420;
-  --panel: #1a2333;
-  --panel-2: #202c40;
-  --text: #eaf1ff;
-  --accent: #7dd3fc;
-  --muted: #9fb3cc;
-  --persistent: #f59e0b;
-  --highlight: #34d399;
-  --danger: #fb7185;
+  --xwa-navy: #002846;
+  --xwa-blue: #0046aa;
+  --xwa-gold: #aa8200;
+  --xwa-red: #821414;
+  --xwa-black: #231f20;
+  --xwa-paper: #f4f2ec;
+  --xwa-white: #ffffff;
+
+  --container: min(1100px, 92vw);
+  --radius: 14px;
+  --shadow: 0 12px 32px rgba(0, 0, 0, 0.26);
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-  background: var(--bg);
-  color: var(--text);
+  font-family: "Barlow", "Segoe UI", sans-serif;
+  color: var(--xwa-black);
+  background: radial-gradient(circle at top, #0b3c67, var(--xwa-navy) 52%, #00182a 100%);
+  line-height: 1.5;
 }
 
-.topbar {
-  padding: 1rem;
-  background: #111827;
-  border-bottom: 1px solid #334155;
-}
-.topbar h1 { margin: 0 0 0.3rem; }
-.topbar p { margin: 0; color: var(--muted); }
-
-.layout {
-  display: grid;
-  grid-template-columns: 1fr 1fr 0.9fr;
-  gap: 0.9rem;
-  padding: 0.9rem;
-}
-.panel {
-  background: var(--panel);
-  border: 1px solid #334155;
-  border-radius: 10px;
-  padding: 0.8rem;
-  min-height: 70vh;
+h1,
+h2,
+h3 {
+  font-family: "Orbitron", "Barlow", sans-serif;
+  letter-spacing: 0.02em;
+  margin: 0;
 }
 
-.map-canvas {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.5rem;
+.container {
+  width: var(--container);
+  margin-inline: auto;
 }
-.tile {
-  border: 1px solid #475569;
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  z-index: 200;
+  padding: 0.55rem 0.7rem;
   border-radius: 8px;
-  background: var(--panel-2);
-  color: var(--text);
-  text-align: left;
-  padding: 0.5rem;
-  min-height: 90px;
-  cursor: pointer;
+  background: var(--xwa-paper);
+  color: var(--xwa-black);
 }
-.tile.selected { outline: 2px solid var(--accent); }
-.tile.persistent { border-color: var(--persistent); }
-.tile.highlight { box-shadow: 0 0 0 2px var(--highlight) inset; }
-.tile .idx { color: var(--accent); font-weight: bold; display: block; }
 
-.help { color: var(--muted); font-size: 0.9rem; }
-.inline-row, .button-row { display: flex; gap: 0.5rem; }
-input, button, textarea {
-  width: 100%;
-  background: #0b1220;
-  color: var(--text);
-  border: 1px solid #475569;
-  border-radius: 6px;
-  padding: 0.45rem;
+.site-header {
+  border-bottom: 2px solid var(--xwa-gold);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.15));
 }
-button { cursor: pointer; }
 
-.tag-filters {
+.header-inner {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  align-items: end;
+  padding: 2rem 0 1.6rem;
+}
+
+.eyebrow,
+.tagline,
+.hero-label,
+.section-subtitle,
+.legal {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.brand-block h1 {
+  color: var(--xwa-white);
+  font-size: clamp(2rem, 5vw, 2.85rem);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+  color: var(--xwa-gold);
+}
+
+.tagline {
+  max-width: 58ch;
+}
+
+.primary-nav {
+  list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0;
+}
+
+.primary-nav a {
+  display: inline-block;
+  text-decoration: none;
+  color: var(--xwa-white);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-weight: 600;
+}
+
+main {
+  padding: 2rem 0 3rem;
+}
+
+.hero,
+.section {
+  background: var(--xwa-paper);
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: 1.25rem;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.hero-label {
+  color: var(--xwa-red);
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  margin-bottom: 0.35rem;
+}
+
+.hero-copy h2 {
   margin-bottom: 0.6rem;
 }
-.tag-chip {
-  border: 1px solid #64748b;
-  border-radius: 999px;
-  padding: 0.15rem 0.55rem;
-  background: #0f172a;
-  font-size: 0.82rem;
+
+.hero-actions {
+  display: flex;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
 }
-.tag-chip.active { border-color: var(--highlight); color: var(--highlight); }
+
+.button {
+  text-decoration: none;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 0.58rem 1rem;
+}
+
+.button-primary {
+  background: var(--xwa-blue);
+  color: var(--xwa-white);
+}
+
+.button-secondary {
+  border: 1px solid var(--xwa-blue);
+  color: var(--xwa-blue);
+}
+
+.hero-panel {
+  border-radius: 12px;
+  background: #e9e4d8;
+  border-top: 5px solid var(--xwa-gold);
+  padding: 1rem;
+}
+
+.section {
+  padding: clamp(1rem, 3vw, 1.5rem);
+  margin-top: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 0.8rem;
+}
 
 .card {
-  background: #111827;
-  border: 1px solid #334155;
-  border-radius: 8px;
-  padding: 0.55rem;
-  margin-bottom: 0.45rem;
-}
-.poi-item.hidden-by-filter { display: none; }
-.persistent-badge { color: var(--persistent); font-weight: bold; }
-.suggestion { color: var(--highlight); }
-.error { color: var(--danger); }
-.log-list { font-size: 0.88rem; padding-left: 1.2rem; }
-
-dialog {
-  border: 1px solid #334155;
+  padding: 0.9rem;
   border-radius: 10px;
-  width: min(900px, 95vw);
-  background: #0f172a;
-  color: var(--text);
+  border-left: 5px solid var(--xwa-blue);
+  background: #fffcf7;
 }
 
-@media (max-width: 980px) {
-  .layout { grid-template-columns: 1fr; }
-  .panel { min-height: auto; }
+.card h3 {
+  font-size: 1.02rem;
+  margin-bottom: 0.25rem;
+}
+
+.card a,
+.text-link {
+  color: var(--xwa-blue);
+  font-weight: 700;
+}
+
+.stack {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.update-item {
+  border-left: 5px solid var(--xwa-red);
+  background: #fffdf8;
+  border-radius: 8px;
+  padding: 0.8rem;
+}
+
+.update-meta {
+  margin: 0;
+  color: #555;
+  font-size: 0.93rem;
+}
+
+.site-footer {
+  color: var(--xwa-white);
+  padding: 1.4rem 0 2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.footer-inner {
+  display: grid;
+  gap: 0.25rem;
+}
+
+@media (max-width: 860px) {
+  .header-inner,
+  .hero {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace the old single-purpose RPG generator landing page with a maintainable community-facing homepage focused on clear communications for players, organizers, and creators.  
- Make content updates simple for volunteer maintainers by removing most content from code and centralizing it in a data file.  
- Enforce the project brand tokens (palette/typography) and provide a consistent set of components for future pages and marketing assets.  

### Description
- Replaced the previous generator UI with a new `index.html` that implements a branded landing page including header/nav, hero (summary + CTAs), quick links grid, latest communications list, brand guidance section, and legal footer.  
- Introduced a small content renderer in `app.js` that fetches `data/site-content.json` and renders `nav`, `hero`, `quickLinks`, and `updates` at runtime so non-developers can update copy without editing HTML/CSS/JS.  
- Rewrote `styles.css` to expose brand tokens (navy/blue/gold/red), provide typography via Google fonts, and implement accessible/responsive components and layout (skip link, container, cards, hero, etc.).  
- Added `data/site-content.json` with example site content and updated `README.md` with maintenance and local preview instructions (`python3 -m http.server 8080`).  

### Testing
- Ran `node --check app.js` to verify `app.js` has no basic syntax errors; the check succeeded.  
- Validated the JSON file with `python3 -m json.tool data/site-content.json` which succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb2b68a3ac8332b7510558fe2db44a)