### PR TITLE
Introduce Candlelight Delve solo-GM app: procedural generators, persistence, and UI/theme revamp

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,91 +1,204 @@
-const contentPath = "data/site-content.json";
+const STORAGE_KEY = "candlelight-delve-state-v2";
 
-const renderSite = async () => {
-  const response = await fetch(contentPath);
-  const content = await response.json();
-
-  renderWordmark(content.brand?.wordmarkPath);
-  renderNav(content.nav || []);
-  renderHero(content.hero || {});
-  renderAudience(content.audiences || []);
-  renderUpdates(content.updates || []);
-
-  document.getElementById("boilerplate").textContent = content.about?.boilerplate || "";
-  document.getElementById("footerMaintenance").textContent = content.footer?.maintenance || "";
-  document.getElementById("legalLine").textContent = content.footer?.legal || "";
+const TABLES = {
+  roomSizes: ["Cramped niche", "Broad hall", "Collapsed vault", "Sunken gallery", "Split-level rotunda", "Long crypt chamber", "Pillar-filled sanctuary"],
+  roomShapes: ["oval", "rectangular", "hexagonal", "irregular cavern", "circular with side alcoves"],
+  exits: ["1 hidden exit", "2 archways", "3 uneven tunnels", "a stair descending further", "a flooded breach and a narrow door"],
+  terrainFeatures: ["broken idol and candle wax", "chasm crossed by cracked planks", "root-tangled pillars", "knee-deep black water", "bones arranged as warning marks"],
+  sensoryDetails: ["air tastes of copper and wet stone", "faint choir hum behind the walls", "dripping echoes count like a clock", "flickering light with no source", "smell of old incense and mildew"],
+  dangerRatings: ["Still", "Wary", "Threatening", "Perilous", "Dire"],
+  happenings: ["Two unseen groups recently crossed paths here", "A ritual was interrupted moments before your arrival", "Something scavenges in the dark, avoiding direct contact", "The room itself shifts and erases tracks", "A survivor hides nearby, too frightened to call out"],
+  envStory: ["old graffiti maps a route that no longer exists", "fresh claw marks score over ancient carvings", "charred packs and snapped tools lie abandoned", "the noble crest on the wall is deliberately defaced", "chalk tally marks show someone counting down"],
+  tensions: ["time pressure from dwindling light", "risk of alerting a greater presence", "mistrust between potential allies", "unstable footing during any conflict", "an omen that suggests betrayal ahead"],
+  conflicts: ["parley with desperate scavengers", "avoid a territorial guardian", "disable a trap under duress", "choose between stealth and speed", "secure a route before a rival faction does"],
+  discoveries: ["a half-burned expedition journal", "a sealed bronze coffer with unknown sigil", "an old prayer that doubles as a passphrase", "a route to a lower level marked in blood", "evidence that your active threat serves someone else"],
+  hazards: [
+    "Pressure plate linked to a slamming stone door",
+    "Concealed dart launcher in carved masonry",
+    "Unstable ledge crumbling into a lower shaft",
+    "Runic ward that flashes and scorches intruders",
+    "Quicksand-like subsidence in slick silt"
+  ],
+  cover: ["half-collapsed pews", "heavy stone sarcophagus lids", "pillar shadows", "waist-high rubble", "broken statuary"],
+  lootHints: ["a tarnished holy symbol", "wax-sealed satchel", "fungus-wrapped lockbox", "coin trail ending at a crack", "map fragment stitched into cloth"]
 };
 
-const renderWordmark = (path) => {
-  const img = document.getElementById("brandWordmark");
-  img.src = path || "";
-  img.onerror = () => {
-    img.replaceWith(buildFallbackTitle());
-  };
+const oracleOutcomes = ["No, and…", "No", "No, but…", "Yes, but…", "Yes", "Yes, and…"];
+
+const state = {
+  party: [],
+  dungeon: { depth: "", dangerMeter: "", lightResources: "", activeThreat: "", factionPressure: "" },
+  outputs: {
+    room: "No chamber sketched yet.",
+    situation: "No situation recorded yet.",
+    oracle: "The oracle waits in silence.",
+    roomVisual: null
+  },
+  log: []
 };
 
-const buildFallbackTitle = () => {
-  const fallback = document.createElement("span");
-  fallback.className = "wordmark-fallback";
-  fallback.textContent = "X-WING ALLIANCE";
-  return fallback;
-};
+const randomOf = (arr) => arr[Math.floor(Math.random() * arr.length)];
+const timestamp = () => new Date().toLocaleString();
 
-const renderNav = (items) => {
-  const nav = document.getElementById("primaryNav");
-  nav.innerHTML = items
-    .map((item) => `<li><a href="${item.href}" target="_blank" rel="noopener noreferrer">${item.label}</a></li>`)
-    .join("");
-};
+function hydrateState() {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (!saved) {
+    state.party = [buildCharacter(), buildCharacter(), buildCharacter()];
+    return;
+  }
+  try { Object.assign(state, JSON.parse(saved)); }
+  catch { state.party = [buildCharacter(), buildCharacter(), buildCharacter()]; }
+  if (!state.party?.length) state.party = [buildCharacter(), buildCharacter(), buildCharacter()];
+}
 
-const renderHero = (hero) => {
-  document.getElementById("heroEyebrow").textContent = hero.eyebrow || "";
-  document.getElementById("hero-heading").textContent = hero.heading || "";
-  document.getElementById("heroSummary").textContent = hero.summary || "";
-  document.getElementById("nextPriority").textContent = hero.priority || "";
+function persistState() { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }
+function buildCharacter() { return { name: "", class: "", level: "1", hp: "", maxHp: "", notes: "" }; }
+function addLog(type, text) { state.log.unshift({ type, text, at: timestamp() }); persistState(); renderLog(); }
 
-  document.getElementById("heroActions").innerHTML = (hero.actions || [])
-    .map((action) => {
-      const roleClass = action.primary ? "primary" : "secondary";
-      return `<a class="button ${roleClass}" href="${action.href}" target="_blank" rel="noopener noreferrer">${action.label}</a>`;
-    })
-    .join("");
-};
-
-const renderAudience = (cards) => {
-  document.getElementById("audienceCards").innerHTML = cards
-    .map(
-      (card) => `
-      <article class="card">
-        <h3>${card.title}</h3>
-        <p>${card.summary}</p>
-        <a href="${card.href}" target="_blank" rel="noopener noreferrer">${card.cta}</a>
-      </article>`
-    )
-    .join("");
-};
-
-const renderUpdates = (updates) => {
-  document.getElementById("updatesList").innerHTML = updates
-    .map(
-      (item) => `
-      <article class="update-item">
-        <h3>${item.title}</h3>
-        <p class="meta">${formatDate(item.date)} • ${item.owner}</p>
-        <p>${item.summary}</p>
-        <a href="${item.href}" target="_blank" rel="noopener noreferrer">Read update</a>
-      </article>`
-    )
-    .join("");
-};
-
-const formatDate = (isoDate) =>
-  new Date(`${isoDate}T00:00:00Z`).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    timeZone: "UTC"
+function renderParty() {
+  const list = document.getElementById("partyList");
+  list.innerHTML = "";
+  state.party.forEach((character, index) => {
+    const card = document.createElement("article");
+    card.className = "character-card";
+    card.innerHTML = `<div class="character-grid">
+      <label>Name <input data-field="name" data-index="${index}" value="${character.name}" /></label>
+      <label>Class <input data-field="class" data-index="${index}" value="${character.class}" /></label>
+      <label>Level <input data-field="level" data-index="${index}" value="${character.level}" /></label>
+      <label>HP <input data-field="hp" data-index="${index}" value="${character.hp}" /></label>
+      <label>Max HP <input data-field="maxHp" data-index="${index}" value="${character.maxHp}" /></label>
+      <label>Status Notes <input data-field="notes" data-index="${index}" value="${character.notes}" /></label>
+    </div>`;
+    list.append(card);
   });
+}
 
-renderSite().catch((error) => {
-  console.error("Failed to render site content", error);
-});
+function syncDungeonState() {
+  ["depth", "dangerMeter", "lightResources", "activeThreat", "factionPressure"].forEach((key) => { state.dungeon[key] = document.getElementById(key).value; });
+  persistState();
+}
+
+function renderDungeonState() { Object.entries(state.dungeon).forEach(([key, value]) => { document.getElementById(key).value = value; }); }
+
+function renderOutputs() {
+  document.getElementById("roomOutput").textContent = state.outputs.room;
+  document.getElementById("situationOutput").textContent = state.outputs.situation;
+  document.getElementById("oracleAnswer").textContent = state.outputs.oracle;
+  renderRoomVisualization();
+}
+
+function renderLog() {
+  const log = document.getElementById("campaignLog");
+  if (!state.log.length) { log.innerHTML = "<em>The journal is empty.</em>"; return; }
+  log.innerHTML = state.log.map((entry) => `<div class="log-entry"><strong>[${entry.type}]</strong> <small>${entry.at}</small><p>${entry.text}</p></div>`).join("");
+}
+
+function buildRoomVisual() {
+  return {
+    shape: randomOf(TABLES.roomShapes),
+    exits: Array.from({ length: Math.floor(Math.random() * 3) + 1 }, () => ({ side: randomOf(["north", "east", "south", "west"]), kind: randomOf(["door", "arch", "stairs", "breach"]) })),
+    hazards: [randomOf(TABLES.hazards), randomOf(TABLES.hazards)],
+    cover: [randomOf(TABLES.cover), randomOf(TABLES.cover)],
+    loot: randomOf(TABLES.lootHints),
+    terrain: randomOf(TABLES.terrainFeatures)
+  };
+}
+
+function generateRoom() {
+  const visual = buildRoomVisual();
+  const text = `${randomOf(TABLES.roomSizes)} ${visual.shape} with ${randomOf(TABLES.exits)}. Feature: ${visual.terrain}. Sensory detail: ${randomOf(TABLES.sensoryDetails)}. Danger: ${randomOf(TABLES.dangerRatings)}. Hazards: ${visual.hazards[0]}; ${visual.hazards[1]}. Cover: ${visual.cover[0]}.`;
+  state.outputs.room = text;
+  state.outputs.roomVisual = visual;
+  persistState();
+  renderOutputs();
+  addLog("Room", `${text} Loot clue: ${visual.loot}.`);
+}
+
+function generateSituation() {
+  const text = `${randomOf(TABLES.happenings)}; ${randomOf(TABLES.envStory)}. Tension: ${randomOf(TABLES.tensions)}. Possible conflict: ${randomOf(TABLES.conflicts)}. Discovery: ${randomOf(TABLES.discoveries)}.`;
+  state.outputs.situation = text;
+  persistState();
+  renderOutputs();
+  addLog("Situation", text);
+}
+
+function askOracle() {
+  const question = document.getElementById("oracleQuestion").value.trim();
+  if (!question) return;
+  const result = `${randomOf(oracleOutcomes)} ${question}`;
+  state.outputs.oracle = result;
+  persistState();
+  renderOutputs();
+  addLog("Oracle", result);
+  document.getElementById("oracleQuestion").value = "";
+}
+
+function renderRoomVisualization() {
+  const target = document.getElementById("roomSketch");
+  const details = document.getElementById("roomDetails");
+  const visual = state.outputs.roomVisual;
+  if (!visual) {
+    target.innerHTML = "<p class='placeholder'>Generate a room to sketch its map and tactical notes.</p>";
+    details.textContent = "No room details to annotate.";
+    return;
+  }
+  const shapeSvg = {
+    oval: "<ellipse cx='220' cy='130' rx='160' ry='95' />",
+    rectangular: "<rect x='55' y='40' width='330' height='180' rx='10' />",
+    hexagonal: "<polygon points='125,35 315,35 390,130 315,225 125,225 50,130' />",
+    "irregular cavern": "<path d='M72,72 C120,24 280,22 342,68 C396,112 389,191 326,218 C250,249 146,238 94,200 C35,157 26,106 72,72 Z' />",
+    "circular with side alcoves": "<path d='M220,40 a90,90 0 1,0 0.1,0 Z M130,125 a24,24 0 1,0 0.1,0 Z M310,125 a24,24 0 1,0 0.1,0 Z' />"
+  };
+  const exitMarks = visual.exits.map((e) => {
+    const map = { north: [220, 38], east: [385, 130], south: [220, 222], west: [55, 130] }[e.side];
+    return `<g><circle cx='${map[0]}' cy='${map[1]}' r='7'></circle><text x='${map[0] + 10}' y='${map[1] + 4}'>${e.kind}</text></g>`;
+  }).join("");
+
+  target.innerHTML = `<svg viewBox='0 0 440 260' class='room-svg' aria-label='Generated dungeon room sketch'>
+    <g class='room-outline'>${shapeSvg[visual.shape] || shapeSvg.rectangular}</g>
+    <g class='room-exits'>${exitMarks}</g>
+    <g class='room-notes'>
+      <text x='64' y='246'>Terrain: ${visual.terrain}</text>
+      <text x='64' y='20'>Loot clue: ${visual.loot}</text>
+    </g>
+  </svg>`;
+
+  details.innerHTML = `<strong>Hazards</strong>: ${visual.hazards.join("; ")}<br><strong>Cover</strong>: ${visual.cover.join("; ")}<br><strong>Exits</strong>: ${visual.exits.map((e) => `${e.side} ${e.kind}`).join(", ")}`;
+}
+
+function addManualNote() {
+  const noteInput = document.getElementById("manualNote");
+  const note = noteInput.value.trim();
+  if (!note) return;
+  addLog("Note", note);
+  noteInput.value = "";
+}
+
+function wireEvents() {
+  document.getElementById("addCharacterBtn").addEventListener("click", () => {
+    if (state.party.length >= 4) return;
+    state.party.push(buildCharacter()); persistState(); renderParty();
+  });
+  document.getElementById("partyList").addEventListener("input", (event) => {
+    const t = event.target; const i = Number(t.dataset.index); const f = t.dataset.field;
+    if (Number.isNaN(i) || !f) return; state.party[i][f] = t.value; persistState();
+  });
+  ["depth", "dangerMeter", "lightResources", "activeThreat", "factionPressure"].forEach((id) => document.getElementById(id).addEventListener("input", syncDungeonState));
+  document.getElementById("generateRoomBtn").addEventListener("click", generateRoom);
+  document.getElementById("generateSituationBtn").addEventListener("click", generateSituation);
+  document.getElementById("askOracleBtn").addEventListener("click", askOracle);
+  document.getElementById("addNoteBtn").addEventListener("click", addManualNote);
+  document.getElementById("clearLogBtn").addEventListener("click", () => { state.log = []; persistState(); renderLog(); });
+
+  // Future extension hooks:
+  // - Faction relationship engine and faction clocks.
+  // - Dungeon theme packs and biome-aware room tables.
+  // - Procedural quest hooks and milestone tracking.
+  // - Treasure and relic generation tables.
+  // - NPC motivations, names, and rumor generators.
+  // - Overland/travel systems tied to resource pressure.
+  // - Campaign clocks that trigger major world shifts.
+}
+
+function init() { hydrateState(); renderParty(); renderDungeonState(); renderOutputs(); renderLog(); wireEvents(); }
+init();

--- a/index.html
+++ b/index.html
@@ -3,65 +3,87 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>X-Wing Alliance</title>
-  <meta name="description" content="X-Wing Alliance official community hub for players, tournament organizers, and creators." />
+  <title>Candlelight Delve — Solo Dungeon Journal</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Condensed:wght@400;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <a class="skip-link" href="#main-content">Skip to content</a>
+  <div class="grain"></div>
+  <main class="page">
+    <header class="hero panel">
+      <p class="eyebrow">Dungeon Companion</p>
+      <h1>Candlelight Delve</h1>
+      <p class="lead">A browser-based solo GM assistant for a 3–4 character party, styled like a field journal from a forgotten age.</p>
+    </header>
 
-  <header class="site-header">
-    <div class="container header-inner">
-      <a class="logo-link" href="/" aria-label="X-Wing Alliance home">
-        <img id="brandWordmark" class="brand-wordmark" alt="X-Wing Alliance" />
-      </a>
-      <nav aria-label="Primary">
-        <ul id="primaryNav" class="primary-nav"></ul>
-      </nav>
-    </div>
-  </header>
-
-  <main id="main-content">
-    <section class="container hero" aria-labelledby="hero-heading">
-      <div>
-        <p class="eyebrow" id="heroEyebrow"></p>
-        <h1 id="hero-heading"></h1>
-        <p id="heroSummary" class="lead"></p>
-        <div id="heroActions" class="button-row"></div>
+    <section class="panel" aria-labelledby="party-heading">
+      <div class="panel-head">
+        <h2 id="party-heading">Party Panel</h2>
+        <button id="addCharacterBtn" class="ink-btn" type="button">Add Character</button>
       </div>
-      <aside class="hero-note" aria-labelledby="hero-note-heading">
-        <h2 id="hero-note-heading">Latest priority</h2>
-        <p id="nextPriority"></p>
-      </aside>
+      <p class="hint">Maintain three or four delvers in your company.</p>
+      <div id="partyList" class="party-list"></div>
     </section>
 
-    <section class="container section" aria-labelledby="audience-heading">
-      <h2 id="audience-heading">Start Here</h2>
-      <p class="section-intro">Audience-first navigation for the most common X-Wing Alliance tasks.</p>
-      <div id="audienceCards" class="card-grid"></div>
+    <section class="panel" aria-labelledby="state-heading">
+      <h2 id="state-heading">Dungeon State</h2>
+      <div class="state-grid">
+        <label>Dungeon Depth <input id="depth" type="text" placeholder="e.g. 3rd Stratum" /></label>
+        <label>Danger Meter <input id="dangerMeter" type="text" placeholder="e.g. Rising" /></label>
+        <label>Light / Resources <input id="lightResources" type="text" placeholder="e.g. 4 torches, low rations" /></label>
+        <label>Active Threat <input id="activeThreat" type="text" placeholder="e.g. Echoing hunter" /></label>
+        <label>Faction Pressure <input id="factionPressure" type="text" placeholder="e.g. Cult scouts closing in" /></label>
+      </div>
+      <article class="room-visual-panel">
+        <h3>Room Visualization</h3>
+        <div id="roomSketch" class="room-sketch"></div>
+        <p id="roomDetails" class="room-details"></p>
+      </article>
+
     </section>
 
-    <section class="container section" aria-labelledby="updates-heading">
-      <h2 id="updates-heading">Official Communications</h2>
-      <p class="section-intro">Post date-stamped updates here so every channel has one source of truth.</p>
-      <div id="updatesList" class="stack"></div>
+    <section class="panel" aria-labelledby="gen-heading">
+      <h2 id="gen-heading">Procedural Generators</h2>
+      <div class="generator-grid">
+        <article>
+          <div class="panel-head">
+            <h3>Room Generator</h3>
+            <button id="generateRoomBtn" class="ink-btn" type="button">Generate Room</button>
+          </div>
+          <div id="roomOutput" class="output-box">No chamber sketched yet.</div>
+        </article>
+        <article>
+          <div class="panel-head">
+            <h3>Situation Generator</h3>
+            <button id="generateSituationBtn" class="ink-btn" type="button">Generate Situation</button>
+          </div>
+          <div id="situationOutput" class="output-box">No situation recorded yet.</div>
+        </article>
+      </div>
     </section>
 
-    <section class="container section" aria-labelledby="about-heading">
-      <h2 id="about-heading">About X-Wing Alliance</h2>
-      <p id="boilerplate"></p>
+    <section class="panel" aria-labelledby="oracle-heading">
+      <h2 id="oracle-heading">Oracle</h2>
+      <label for="oracleQuestion">Question for fate:</label>
+      <div class="oracle-row">
+        <input id="oracleQuestion" type="text" placeholder="Will the stairwell hold our weight?" />
+        <button id="askOracleBtn" class="ink-btn" type="button">Ask</button>
+      </div>
+      <p id="oracleAnswer" class="oracle-answer">The oracle waits in silence.</p>
+    </section>
+
+    <section class="panel" aria-labelledby="log-heading">
+      <h2 id="log-heading">Campaign Log</h2>
+      <div class="note-row">
+        <input id="manualNote" type="text" placeholder="Add player note..." />
+        <button id="addNoteBtn" class="ink-btn" type="button">Add Note</button>
+        <button id="clearLogBtn" class="ink-btn danger" type="button">Clear Log</button>
+      </div>
+      <div id="campaignLog" class="campaign-log"></div>
     </section>
   </main>
-
-  <footer class="site-footer">
-    <div class="container footer-inner">
-      <p id="footerMaintenance"></p>
-      <p id="legalLine" class="legal"></p>
-    </div>
-  </footer>
 
   <script src="app.js" defer></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -1,228 +1,183 @@
 :root {
-  --xwa-red: #c80000;
-  --xwa-black: #000000;
-  --xwa-white: #ffffff;
-
-  --xwa-blue: #002846;
-  --xwa-green: #006400;
-  --xwa-orange: #dc6432;
-  --xwa-gold: #aa8200;
-  --xwa-royal: #0046aa;
-
-  --surface: #efefef;
-  --surface-2: #f9f9f9;
-  --text: #101010;
-
-  --radius: 12px;
-  --container: min(1100px, 92vw);
-}
-
-/* Brand-book font stack support. Add licensed files at assets/fonts when available. */
-@font-face {
-  font-family: "Kimberley";
-  src: local("Kimberley"), url("assets/fonts/kimberley.woff2") format("woff2");
-  font-display: swap;
-}
-
-@font-face {
-  font-family: "Eurostile";
-  src: local("Eurostile"), url("assets/fonts/eurostile.woff2") format("woff2");
-  font-display: swap;
+  --parchment: #dfc79a;
+  --parchment-dark: #c8ab78;
+  --ink: #2a1f14;
+  --ink-soft: #4e3b29;
+  --accent: #7f5a33;
+  --danger: #6d2f25;
+  --shadow: rgba(34, 24, 16, 0.28);
 }
 
 * { box-sizing: border-box; }
 
 body {
   margin: 0;
-  font-family: "Roboto", "Roboto Condensed", "Segoe UI", sans-serif;
-  background: linear-gradient(180deg, var(--xwa-blue) 0%, #00111e 100%);
-  color: var(--text);
-  line-height: 1.5;
+  color: var(--ink);
+  font-family: "Crimson Text", Georgia, serif;
+  background:
+    radial-gradient(circle at 18% 12%, #f2dfb7 0%, transparent 35%),
+    radial-gradient(circle at 80% 20%, #e7c892 0%, transparent 32%),
+    linear-gradient(170deg, #d6b782 0%, #b38f5f 100%);
+  min-height: 100vh;
 }
 
-h1,
-h2,
-h3 {
-  font-family: "Kimberley", "Eurostile", "Roboto Condensed", sans-serif;
-  text-transform: uppercase;
-  margin: 0;
+.grain {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(rgba(50, 33, 17, 0.12) 0.4px, transparent 0.4px);
+  background-size: 3px 3px;
+  opacity: 0.18;
 }
 
-.container {
-  width: var(--container);
-  margin-inline: auto;
-}
-
-.skip-link {
-  position: absolute;
-  left: -9999px;
-}
-
-.skip-link:focus {
-  left: 1rem;
-  top: 1rem;
-  z-index: 500;
-  background: var(--xwa-white);
-  color: var(--xwa-black);
-  padding: 0.4rem 0.65rem;
-}
-
-.site-header {
-  border-bottom: 3px solid var(--xwa-gold);
-  background: rgba(0, 0, 0, 0.22);
-}
-
-.header-inner {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.8rem;
-  padding: 1rem 0;
-}
-
-.logo-link { display: inline-flex; }
-
-.brand-wordmark {
-  max-width: 260px;
-  min-height: 48px;
-  object-fit: contain;
-}
-
-.primary-nav {
-  list-style: none;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin: 0;
-  padding: 0;
-}
-
-.primary-nav a {
-  color: var(--xwa-white);
-  text-decoration: none;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  border-radius: 999px;
-  padding: 0.35rem 0.8rem;
-  font-weight: 700;
-}
-
-main {
-  padding: 1.2rem 0 2.5rem;
-}
-
-.hero,
-.section {
-  background: var(--surface);
-  border: 1px solid #d6d6d6;
-  border-radius: var(--radius);
-  padding: 1rem;
-}
-
-.hero {
+.page {
+  position: relative;
+  z-index: 1;
+  width: min(1080px, 94vw);
+  margin: 1.2rem auto 2rem;
   display: grid;
-  grid-template-columns: 1fr 280px;
   gap: 1rem;
 }
 
-.eyebrow {
-  margin: 0 0 0.2rem;
-  font-family: "Eurostile", "Roboto Condensed", sans-serif;
-  font-weight: 700;
-  color: var(--xwa-red);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.lead { margin: 0.6rem 0 0; max-width: 65ch; }
-
-.button-row {
-  margin-top: 0.9rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-}
-
-.button {
-  text-decoration: none;
-  font-weight: 700;
+.panel {
+  background: linear-gradient(175deg, rgba(250, 236, 205, 0.92), rgba(224, 199, 154, 0.95));
+  border: 2px solid var(--ink-soft);
   border-radius: 8px;
-  padding: 0.5rem 0.9rem;
+  padding: 1rem;
+  box-shadow: 0 10px 18px -12px var(--shadow), inset 0 0 0 1px rgba(114, 78, 43, 0.35);
 }
 
-.button.primary { background: var(--xwa-red); color: var(--xwa-white); }
-.button.secondary { border: 1px solid var(--xwa-blue); color: var(--xwa-blue); }
-
-.hero-note {
-  background: var(--surface-2);
-  border-left: 4px solid var(--xwa-gold);
-  border-radius: 8px;
-  padding: 0.75rem;
-}
-
-.section { margin-top: 1rem; }
-.section-intro { margin: 0.4rem 0 0.8rem; }
-
-.card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 0.65rem;
-}
-
-.card {
-  background: var(--surface-2);
-  border-left: 4px solid var(--xwa-royal);
-  border-radius: 8px;
-  padding: 0.8rem;
-}
-
-.card p { margin: 0.35rem 0 0.6rem; }
-.card a,
-.update-item a { color: var(--xwa-royal); font-weight: 700; }
-
-.stack {
-  display: grid;
-  gap: 0.65rem;
-}
-
-.update-item {
-  background: var(--surface-2);
-  border-left: 4px solid var(--xwa-red);
-  border-radius: 8px;
-  padding: 0.8rem;
-}
-
-.meta {
-  margin: 0;
-  color: #545454;
-  font-size: 0.93rem;
-}
-
-.site-footer {
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-  color: var(--xwa-white);
-}
-
-.footer-inner {
-  padding: 1rem 0 1.4rem;
-  display: grid;
-  gap: 0.3rem;
-}
-
-.legal {
-  margin: 0;
-  font-size: 0.92rem;
-  opacity: 0.9;
-}
-
-@media (max-width: 860px) {
-  .hero { grid-template-columns: 1fr; }
-}
-
-.wordmark-fallback {
-  font-family: "Kimberley", "Eurostile", "Roboto Condensed", sans-serif;
-  color: var(--xwa-white);
-  font-size: 1.5rem;
-  font-weight: 700;
+.hero h1,
+.panel h2,
+.panel h3 {
+  font-family: "Cinzel", "Times New Roman", serif;
   letter-spacing: 0.04em;
+  margin: 0;
 }
+
+.panel h2 { margin-bottom: 0.45rem; }
+.panel h3 { font-size: 1.05rem; }
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+}
+
+.lead { margin: 0.45rem 0 0; max-width: 75ch; }
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.hint { margin: 0 0 0.7rem; font-style: italic; }
+
+.ink-btn {
+  border: 1px solid #5b422d;
+  background: linear-gradient(180deg, #8c6a43, #6f5234);
+  color: #f2e4c6;
+  font-family: "Cinzel", serif;
+  font-size: 0.86rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: transform 120ms ease, filter 120ms ease;
+}
+
+.ink-btn:hover { filter: brightness(1.07); transform: translateY(-1px); }
+.ink-btn:active { transform: translateY(0); }
+
+.ink-btn.danger { background: linear-gradient(180deg, #7b392e, #61271f); }
+
+.party-list { display: grid; gap: 0.7rem; }
+
+.character-card {
+  border: 1px dashed rgba(68, 48, 32, 0.8);
+  padding: 0.7rem;
+  background: rgba(255, 247, 228, 0.55);
+}
+
+.character-grid,
+.state-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem;
+}
+
+label { display: grid; gap: 0.2rem; font-weight: 600; }
+input {
+  background: rgba(255, 251, 240, 0.7);
+  border: 1px solid #76573b;
+  color: var(--ink);
+  border-radius: 4px;
+  padding: 0.4rem;
+  font-family: "Crimson Text", serif;
+}
+
+.generator-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.8rem;
+}
+
+.output-box,
+.oracle-answer,
+.campaign-log {
+  background: rgba(253, 245, 222, 0.66);
+  border: 1px solid rgba(86, 62, 38, 0.65);
+  padding: 0.65rem;
+  margin-top: 0.5rem;
+  min-height: 54px;
+}
+
+.oracle-row,
+.note-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+}
+
+.note-row { grid-template-columns: 1fr auto auto; }
+
+.campaign-log {
+  max-height: 280px;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.log-entry {
+  border-bottom: 1px dotted rgba(74, 50, 31, 0.55);
+  padding-bottom: 0.35rem;
+}
+
+.log-entry p { margin: 0.2rem 0 0; }
+
+@media (max-width: 680px) {
+  .note-row,
+  .oracle-row { grid-template-columns: 1fr; }
+}
+
+.room-visual-panel {
+  margin-top: 0.8rem;
+  border-top: 1px solid rgba(80, 54, 31, 0.5);
+  padding-top: 0.6rem;
+}
+
+.room-sketch {
+  margin-top: 0.45rem;
+  border: 1px solid rgba(73, 50, 29, 0.7);
+  background: rgba(252, 241, 213, 0.7);
+  min-height: 220px;
+}
+
+.room-svg { width: 100%; height: auto; }
+.room-outline * { fill: rgba(196, 166, 120, 0.3); stroke: #3b2a1b; stroke-width: 3; }
+.room-exits circle { fill: #7d5a33; stroke: #2a1f14; stroke-width: 1; }
+.room-exits text, .room-notes text { font-family: "Crimson Text", serif; font-size: 12px; fill: #2b1e11; }
+.room-details { margin: 0.55rem 0 0; }
+.placeholder { padding: 0.8rem; margin: 0; font-style: italic; }


### PR DESCRIPTION
### Motivation
- Replace the previous content-driven shell with an interactive, stateful solo GM assistant focused on procedural dungeon generation and journaling.
- Provide persistent session state so a small party and dungeon context can be maintained between browser sessions.
- Offer quick procedural tools (room, situation, oracle) and a lightweight campaign log to speed up solo play.
- Refresh the visual presentation to match the new theme and improve usability for the intended use-case.

### Description
- Rewrote `app.js` to remove the old site-content fetch and instead add a `state` object, `TABLES` of procedural content, randomization helpers, and localStorage persistence using `STORAGE_KEY`.
- Implemented party management, dungeon state inputs, procedural generators (`generateRoom`, `generateSituation`, `askOracle`), an append-only log, and a room visualization renderer that outputs an inline SVG and tactical details.
- Added UI wiring in `wireEvents()` to handle party editing, dungeon state syncing, generation actions, log management, and note entry, and initialized the app with `init()` and `hydrateState()`.
- Reworked `index.html` to the new Candlelight Delve layout and controls (party panel, dungeon state, generators, oracle, campaign log) and replaced fonts/title; replaced legacy header/footer markup.
- Replaced `styles.css` with a new parchment/ink theme, components for panels, buttons, forms, campaign log, and SVG room styling to match the new visual identity.

### Testing
- No automated test suite is configured for this change and no automated tests were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10e121032483328e1d42342c802a81)